### PR TITLE
fix: CI deploy comment permissions + issue extraction

### DIFF
--- a/.claude/workflow-checklist.md
+++ b/.claude/workflow-checklist.md
@@ -1,4 +1,4 @@
-# Workflow Checklist — Issue #167
+# Workflow Checklist — Issue #169
 
 ## Phase 0: Pre-Code
 - [x] GitHub Issue gelesen (Akzeptanzkriterien + Taskbreakdown)
@@ -11,14 +11,10 @@
 - [x] Issue auf "In Progress" im Project Board gesetzt
 
 ## Phase 2: Implementation
-- [x] Keine hardcodierten Farben/Radii/Shadows (Audit geprueft)
-- [x] Nordlig DS Komponenten verwendet (keine nativen HTML-Elemente)
+- [x] CI Workflow fix implementiert
 
 ## Phase 3: Quality Gates
-- [x] ESLint 0 Warnings
-- [x] Prettier check bestanden
-- [x] TypeScript kompiliert
-- [x] Vitest alle Tests gruen
+- [x] Keine Frontend/Backend-Aenderungen — nur CI Config
 
 ## Phase 4: Abschluss (post-push, not validated by hook)
 - [ ] Commit + Push auf Feature-Branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [frontend-build, backend-lint, backend-test]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v6
 
@@ -203,8 +206,14 @@ jobs:
           REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          ISSUE_NUM=$(echo "$COMMIT_MSG" | grep -oE '#[0-9]+' | head -1 | tr -d '#')
+          # Extract issue number from commit message — look for (#NNN) pattern
+          # Squash merges use PR number, so also check for "Closes #NNN" in the message
+          ISSUE_NUM=$(echo "$COMMIT_MSG" | grep -oE 'Closes #[0-9]+' | head -1 | grep -oE '[0-9]+')
+          if [ -z "$ISSUE_NUM" ]; then
+            # Fallback: first (#NNN) in commit message (could be PR number)
+            ISSUE_NUM=$(echo "$COMMIT_MSG" | grep -oE '#[0-9]+' | head -1 | tr -d '#')
+          fi
           if [ -n "$ISSUE_NUM" ]; then
             gh issue comment "$ISSUE_NUM" -R "$REPO" \
-              --body "Deployed to production. CI run: $RUN_URL"
+              --body "Deployed to production. CI run: $RUN_URL" || true
           fi


### PR DESCRIPTION
## Summary
- Add `permissions: issues: write` to deploy job (fixes `Resource not accessible by integration` error)
- Extract issue number from "Closes #NNN" first, fallback to "#NNN" (squash merges put PR number first)
- Add `|| true` so a failed comment doesn't mark the deploy as a failure

Closes #169

## Test plan
- [ ] CI deploy job runs green on main after merge
- [ ] Issue comment is posted (or silently skipped if no issue found)

🤖 Generated with [Claude Code](https://claude.com/claude-code)