### PR TITLE
fix: remove manualChunks causing production blank page

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,49 +9,6 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
-  build: {
-    rollupOptions: {
-      output: {
-        manualChunks(id) {
-          if (!id.includes('node_modules')) return;
-
-          // React core + routing (stable, cache-friendly)
-          if (
-            id.includes('/react/') ||
-            id.includes('/react-dom/') ||
-            id.includes('/react-router') ||
-            id.includes('/scheduler/')
-          ) {
-            return 'vendor-react';
-          }
-
-          // UI framework: Nordlig DS + Radix primitives + all transitive deps.
-          // @nordlig/components is a single-file ESM monolith that statically
-          // imports Radix UI, TipTap, recharts v3 etc. — tree-shaking cannot
-          // remove unused components because the bundle is pre-compiled.
-          // We group everything the UI framework pulls in together so it caches
-          // as one unit and updates only when the DS version changes.
-          if (
-            id.includes('/@nordlig/') ||
-            id.includes('/@radix-ui/') ||
-            id.includes('/@tiptap/') ||
-            id.includes('/prosemirror-') ||
-            id.includes('/clsx/') ||
-            id.includes('/tailwind-merge/') ||
-            id.includes('/class-variance-authority/') ||
-            id.includes('/cmdk/') ||
-            id.includes('/vaul/') ||
-            id.includes('/input-otp/') ||
-            id.includes('/react-resizable-panels/') ||
-            id.includes('/react-hook-form/') ||
-            id.includes('/@hookform/')
-          ) {
-            return 'vendor-ui';
-          }
-        },
-      },
-    },
-  },
   server: {
     port: 3000,
     host: true,


### PR DESCRIPTION
## Summary
- Removes `manualChunks` config from `vite.config.ts` that was introduced in PR #172
- The vendor chunk splitting created circular ESM imports between `vendor-react` and `vendor-ui` chunks
- This caused `React` to be `undefined` at load time → `TypeError: Cannot read properties of undefined (reading 'forwardRef')` → blank page in production

Closes #174

## Test plan
- [x] ESLint 0 warnings
- [x] TypeScript compiles
- [x] Vitest 148 tests pass
- [x] `npm run build` succeeds
- [ ] Production app renders after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)