### PR TITLE
feat: Post-Deploy E2E Smoke Tests + Deploy-Failure-Notification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   # Frontend Quality Gates
   frontend-lint:
@@ -185,12 +189,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [frontend-build, backend-lint, backend-test]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    permissions:
-      contents: read
-      issues: write
     steps:
-      - uses: actions/checkout@v6
-
       - name: Trigger Coolify deployment
         run: |
           curl -s -X POST "${{ secrets.COOLIFY_URL }}/api/v1/deploy" \
@@ -198,7 +197,65 @@ jobs:
             -H "Content-Type: application/json" \
             -d '{"uuid":"${{ secrets.COOLIFY_APP_UUID }}"}'
 
-      - name: Comment on linked issue
+  # Verify deployment is healthy before running E2E tests
+  deploy-verify:
+    name: Verify Deployment
+    runs-on: ubuntu-latest
+    needs: [deploy]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Warte auf Deployment und prüfe Health
+        id: health
+        env:
+          PROD_URL: http://training.89.167.78.223.sslip.io
+        run: |
+          echo "Polling $PROD_URL/health alle 15 Sekunden (max 5 Minuten)..."
+
+          HEALTHY=false
+          for i in $(seq 1 20); do
+            echo "Versuch $i/20..."
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$PROD_URL/health" --connect-timeout 5 --max-time 10 2>/dev/null || echo "000")
+
+            if [ "$HTTP_CODE" = "200" ]; then
+              BODY=$(curl -s "$PROD_URL/health" --connect-timeout 5 --max-time 10 2>/dev/null || echo "{}")
+              STATUS=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null || echo "")
+
+              if [ "$STATUS" = "ok" ]; then
+                echo "Health Check bestanden (Versuch $i)"
+                HEALTHY=true
+                break
+              else
+                echo "HTTP 200 aber Status nicht 'ok': $BODY"
+              fi
+            else
+              echo "HTTP $HTTP_CODE — noch nicht bereit"
+            fi
+
+            sleep 15
+          done
+
+          echo "healthy=$HEALTHY" >> $GITHUB_OUTPUT
+
+          if [ "$HEALTHY" = "false" ]; then
+            echo "::error::Deployment Health Check fehlgeschlagen nach 5 Minuten"
+            exit 1
+          fi
+
+      - name: Prüfe Frontend liefert HTML
+        env:
+          PROD_URL: http://training.89.167.78.223.sslip.io
+        run: |
+          CONTENT_TYPE=$(curl -s -o /dev/null -w "%{content_type}" "$PROD_URL/" --max-time 10)
+          if echo "$CONTENT_TYPE" | grep -q "text/html"; then
+            echo "Frontend liefert HTML aus"
+          else
+            echo "::error::Frontend liefert kein HTML: $CONTENT_TYPE"
+            exit 1
+          fi
+
+      - name: Kommentar auf verlinktes Issue
         if: success()
         continue-on-error: true
         env:
@@ -208,10 +265,153 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set +e
-          # Extract issue number: first (#NNN) in commit title line
           ISSUE_NUM=$(echo "$COMMIT_MSG" | head -1 | grep -oE '#[0-9]+' | head -1 | tr -d '#')
           set -e
           if [ -n "$ISSUE_NUM" ]; then
             gh issue comment "$ISSUE_NUM" -R "$REPO" \
-              --body "Deployed to production. CI run: $RUN_URL" || true
+              --body "Deployed und verifiziert. Health Check bestanden. CI Run: $RUN_URL" || true
+          fi
+
+      - name: Deployment Summary
+        if: always()
+        env:
+          HEALTH_RESULT: ${{ steps.health.outputs.healthy }}
+        run: |
+          echo "## Deployment Verification" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "$HEALTH_RESULT" = "true" ]; then
+            echo "| Status | Healthy |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| Status | FAILED |" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "URL: http://training.89.167.78.223.sslip.io" >> $GITHUB_STEP_SUMMARY
+
+  # E2E Smoke Tests against production
+  e2e-smoke:
+    name: E2E Smoke Tests
+    runs-on: ubuntu-latest
+    needs: [deploy-verify]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Install E2E dependencies
+        working-directory: e2e
+        run: npm install
+
+      - name: Install Playwright Chromium
+        working-directory: e2e
+        run: npx playwright install --with-deps chromium
+
+      - name: Smoke Tests ausführen
+        id: e2e
+        working-directory: e2e
+        env:
+          BASE_URL: http://training.89.167.78.223.sslip.io
+        run: npx playwright test
+
+      - name: Upload Test Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-smoke-report
+          path: e2e/playwright-report/
+          retention-days: 14
+
+      - name: E2E Summary
+        if: always()
+        env:
+          E2E_RESULT: ${{ steps.e2e.outcome }}
+        run: |
+          echo "## E2E Smoke Tests" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "$E2E_RESULT" = "success" ]; then
+            echo "| Status | Bestanden |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| Status | FAILED |" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "| Viewports | Mobile (375x812) + Desktop (1280x800) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Report | Siehe Artefakt 'e2e-smoke-report' |" >> $GITHUB_STEP_SUMMARY
+
+  # Failure notification — creates GitHub Issue on deploy/verify/e2e failure
+  deploy-notify:
+    name: Failure Notification
+    runs-on: ubuntu-latest
+    needs: [deploy, deploy-verify, e2e-smoke]
+    if: >-
+      always() &&
+      github.ref == 'refs/heads/main' &&
+      github.event_name == 'push' &&
+      (needs.deploy.result == 'failure' || needs.deploy-verify.result == 'failure' || needs.e2e-smoke.result == 'failure')
+    steps:
+      - name: Fehlerquelle bestimmen
+        id: failure
+        env:
+          DEPLOY_RESULT: ${{ needs.deploy.result }}
+          VERIFY_RESULT: ${{ needs.deploy-verify.result }}
+          E2E_RESULT: ${{ needs.e2e-smoke.result }}
+        run: |
+          if [ "$DEPLOY_RESULT" = "failure" ]; then
+            echo "title=[CI] Deploy fehlgeschlagen" >> $GITHUB_OUTPUT
+            echo "detail=Coolify Deployment API-Aufruf fehlgeschlagen." >> $GITHUB_OUTPUT
+          elif [ "$VERIFY_RESULT" = "failure" ]; then
+            echo "title=[CI] Deploy-Verifikation fehlgeschlagen" >> $GITHUB_OUTPUT
+            echo "detail=Health Check der Produktion nach Deploy nicht erfolgreich (5 Min Timeout)." >> $GITHUB_OUTPUT
+          elif [ "$E2E_RESULT" = "failure" ]; then
+            echo "title=[CI] E2E Smoke Tests fehlgeschlagen" >> $GITHUB_OUTPUT
+            echo "detail=Playwright Smoke Tests gegen Produktion fehlgeschlagen." >> $GITHUB_OUTPUT
+          fi
+
+      - name: Prüfe ob Issue bereits existiert
+        id: existing
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_TITLE: ${{ steps.failure.outputs.title }}
+        run: |
+          EXISTING=$(gh issue list -R "${{ github.repository }}" --state open --search "\"$ISSUE_TITLE\" in:title" --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
+          echo "issue_number=$EXISTING" >> $GITHUB_OUTPUT
+
+      - name: GitHub Issue erstellen oder kommentieren
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
+          ISSUE_TITLE: ${{ steps.failure.outputs.title }}
+          ISSUE_DETAIL: ${{ steps.failure.outputs.detail }}
+          EXISTING_ISSUE: ${{ steps.existing.outputs.issue_number }}
+        run: |
+          SHORT_SHA="${COMMIT_SHA:0:7}"
+
+          BODY="## CI Failure
+
+          ${ISSUE_DETAIL}
+
+          **Commit:** \`${SHORT_SHA}\`
+          **CI Run:** ${RUN_URL}
+          **Zeitpunkt:** $(date -u '+%Y-%m-%d %H:%M UTC')
+
+          ### Nächste Schritte
+          1. CI Run Log prüfen
+          2. Produktion manuell testen: http://training.89.167.78.223.sslip.io
+          3. Bei Bedarf: Coolify Dashboard prüfen (Port 8000)"
+
+          if [ -n "$EXISTING_ISSUE" ]; then
+            gh issue comment "$EXISTING_ISSUE" -R "$REPO" \
+              --body "Erneutes Auftreten:
+
+          ${BODY}"
+            echo "Kommentar auf bestehendes Issue #${EXISTING_ISSUE}"
+          else
+            gh issue create -R "$REPO" \
+              --title "$ISSUE_TITLE" \
+              --body "$BODY" \
+              --label "bug"
+            echo "Neues Failure-Issue erstellt"
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,11 @@ package-lock.json
 .coverage
 coverage/
 
+# E2E
+e2e/test-results/
+e2e/playwright-report/
+!e2e/package-lock.json
+
 # Claude Code workflow artifacts are NOT ignored — they get committed for PR visibility:
 # .claude/workflow-checklist.md  → workflow compliance proof
 # .claude/design-review.md      → design review report

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "training-analyzer-e2e",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "training-analyzer-e2e",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@playwright/test": "^1.50.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "training-analyzer-e2e",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "test": "playwright test",
+    "test:mobile": "playwright test --project=mobile",
+    "test:desktop": "playwright test --project=desktop"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.50.0"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from "@playwright/test";
+
+const PRODUCTION_URL =
+  process.env.BASE_URL || "http://training.89.167.78.223.sslip.io";
+
+export default defineConfig({
+  testDir: "./smoke",
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: true,
+  retries: 1,
+  reporter: [["html", { open: "never" }], ["list"]],
+  use: {
+    baseURL: PRODUCTION_URL,
+    screenshot: "only-on-failure",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "mobile",
+      use: {
+        viewport: { width: 375, height: 812 },
+        userAgent:
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+      },
+    },
+    {
+      name: "desktop",
+      use: {
+        viewport: { width: 1280, height: 800 },
+      },
+    },
+  ],
+});

--- a/e2e/smoke/dashboard.spec.ts
+++ b/e2e/smoke/dashboard.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Dashboard", () => {
+  test("lädt und zeigt Inhalt", async ({ page }) => {
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    // Kein Error-Boundary sichtbar
+    await expect(
+      page.getByText("Etwas ist schiefgelaufen"),
+    ).not.toBeVisible();
+
+    // Main-Content ist vorhanden und nicht leer
+    const main = page.locator("main");
+    await expect(main).toBeVisible();
+    await expect(main).not.toBeEmpty();
+  });
+
+  test("zeigt App-Branding", async ({ page }) => {
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    // Zwei Logos existieren: Sidebar (hidden auf Mobile) + TopBar (hidden auf Desktop)
+    // Prüfe, dass mindestens eines sichtbar ist
+    const logos = page.locator('img[alt="Training Analyzer"]');
+    const count = await logos.count();
+    expect(count).toBeGreaterThan(0);
+
+    let anyVisible = false;
+    for (let i = 0; i < count; i++) {
+      if (await logos.nth(i).isVisible()) {
+        anyVisible = true;
+        break;
+      }
+    }
+    expect(anyVisible).toBeTruthy();
+  });
+});

--- a/e2e/smoke/health.spec.ts
+++ b/e2e/smoke/health.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Health Check", () => {
+  test("backend /health returns ok", async ({ request }) => {
+    const response = await request.get("/health");
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("ok");
+  });
+
+  test("API /api/v1/health returns healthy", async ({ request }) => {
+    const response = await request.get("/api/v1/health");
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("healthy");
+  });
+
+  test("frontend serves HTML at /", async ({ request }) => {
+    const response = await request.get("/");
+    expect(response.status()).toBe(200);
+    const contentType = response.headers()["content-type"] || "";
+    expect(contentType).toContain("text/html");
+  });
+});

--- a/e2e/smoke/navigation.spec.ts
+++ b/e2e/smoke/navigation.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "@playwright/test";
+
+const pages = [
+  { path: "/dashboard", name: "Dashboard" },
+  { path: "/sessions", name: "Sessions" },
+  { path: "/analyse", name: "Analyse" },
+  { path: "/plan", name: "Plan" },
+  { path: "/profile", name: "Profil" },
+];
+
+test.describe("Navigation", () => {
+  for (const { path, name } of pages) {
+    test(`${name} (${path}) ist erreichbar`, async ({ page }) => {
+      await page.goto(path);
+      await page.waitForLoadState("networkidle");
+
+      // Richtige URL
+      await expect(page).toHaveURL(new RegExp(path));
+
+      // Kein Error-Boundary
+      await expect(
+        page.getByText("Etwas ist schiefgelaufen"),
+      ).not.toBeVisible();
+
+      // Seite hat Content
+      await expect(page.locator("main")).toBeVisible();
+    });
+  }
+
+  test("404-Seite bei unbekannter Route", async ({ page }) => {
+    await page.goto("/diese-seite-gibt-es-nicht");
+    await page.waitForLoadState("networkidle");
+
+    // Sollte eine 404-Anzeige haben (oder Redirect)
+    // Mindestens: kein weißer Screen
+    await expect(page.locator("body")).not.toBeEmpty();
+  });
+});

--- a/e2e/smoke/responsive.spec.ts
+++ b/e2e/smoke/responsive.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Responsive Layout", () => {
+  test("Mobile: BottomNav sichtbar", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name === "desktop", "Nur Mobile");
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    // BottomNav enthält die 5 Navigations-Links
+    const bottomNav = page.locator("nav").filter({
+      has: page.getByRole("link", { name: "Home" }),
+    });
+    await expect(bottomNav).toBeVisible();
+
+    // Alle 5 Nav-Items sichtbar
+    await expect(page.getByRole("link", { name: "Home" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Sessions" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Plan" })).toBeVisible();
+  });
+
+  test("Mobile: Sidebar versteckt", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name === "desktop", "Nur Mobile");
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    // Sidebar hat class "hidden lg:flex" — auf Mobile nicht sichtbar
+    // Prüfen über den Sidebar-spezifischen User-Chip "NC"
+    const sidebarUserChip = page.locator("nav").filter({
+      hasText: "Nils-Christian",
+    });
+    await expect(sidebarUserChip).not.toBeVisible();
+  });
+
+  test("Desktop: Sidebar sichtbar", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name === "mobile", "Nur Desktop");
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    // Sidebar mit "Training Analyzer" Branding und User-Chip
+    const sidebar = page.locator("nav").filter({
+      hasText: "Nils-Christian",
+    });
+    await expect(sidebar).toBeVisible();
+
+    // Sidebar Nav-Items sichtbar
+    await expect(
+      sidebar.getByRole("button", { name: /Dashboard/ }),
+    ).toBeVisible();
+    await expect(
+      sidebar.getByRole("button", { name: /Sessions/ }),
+    ).toBeVisible();
+  });
+
+  test("Desktop: BottomNav versteckt", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name === "mobile", "Nur Desktop");
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    // BottomNav hat class "lg:hidden" — auf Desktop nicht sichtbar
+    const bottomNav = page.locator("nav").filter({
+      has: page.getByRole("link", { name: "Home" }),
+    });
+    await expect(bottomNav).not.toBeVisible();
+  });
+});

--- a/e2e/smoke/sessions.spec.ts
+++ b/e2e/smoke/sessions.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Sessions", () => {
+  test("Sessions-Seite lädt", async ({ page }) => {
+    await page.goto("/sessions");
+    await page.waitForLoadState("networkidle");
+
+    // Kein Error-Boundary
+    await expect(
+      page.getByText("Etwas ist schiefgelaufen"),
+    ).not.toBeVisible();
+
+    // Main-Content ist vorhanden
+    const main = page.locator("main");
+    await expect(main).toBeVisible();
+    await expect(main).not.toBeEmpty();
+  });
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "resolveJsonModule": true
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Erweitert CI-Pipeline um **deploy-verify**, **e2e-smoke** und **deploy-notify** Jobs
- Playwright Smoke Tests gegen Produktion in **Mobile (375x812)** + **Desktop (1280x800)**
- Automatische **GitHub Issue-Erstellung** bei Deploy-/Verify-/E2E-Failure (mit Deduplizierung)
- Issue-Kommentar auf verlinktes Issue erst nach **verifiziertem** Deploy

## Pipeline-Flow

```
frontend-lint/test → frontend-build ─┐
                                      ├→ deploy → deploy-verify → e2e-smoke
backend-lint/test ────────────────────┘
                                             ↓ (bei failure)
                                        deploy-notify
```

## E2E Smoke Tests (28 Tests, ~15s)

| Spec | Tests |
|------|-------|
| `health` | Backend /health, API /api/v1/health, Frontend HTML |
| `dashboard` | Seite lädt, App-Branding sichtbar |
| `sessions` | Sessions-Seite lädt |
| `navigation` | Alle 5 Hauptseiten erreichbar, 404-Handling |
| `responsive` | Mobile: BottomNav sichtbar + Sidebar hidden, Desktop: umgekehrt |

Alle Tests sind **read-only** — kein Erstellen/Ändern/Löschen von Daten.

## Test plan

- [x] Lokal getestet: 28 passed, 4 skipped (viewport-spezifische Skips)
- [ ] CI-Pipeline auf PR grün (lint/test/build)
- [ ] Nach Merge: deploy-verify + e2e-smoke Jobs im CI sichtbar und grün
- [ ] Failure-Notification testen (temporär kaputten Test)

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)