### PR TITLE
fix: Frontend SPA Warmup vor E2E Smoke Tests (#184)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,47 @@ jobs:
             exit 1
           fi
 
+      - name: Frontend SPA Warmup
+        env:
+          PROD_URL: http://training.89.167.78.223.sslip.io
+        run: |
+          echo "Lade SPA-Routen vor um JS-Bundle-Caching sicherzustellen..."
+          FAILED=false
+
+          # Lade index.html und prüfe ob JS-Bundles referenziert werden
+          HTML=$(curl -s "$PROD_URL/" --max-time 15)
+          JS_ASSETS=$(echo "$HTML" | grep -oE 'src="/assets/[^"]+\.js"' | head -5)
+          if [ -z "$JS_ASSETS" ]; then
+            echo "::warning::Keine JS-Assets in index.html gefunden"
+          else
+            echo "JS-Assets gefunden:"
+            echo "$JS_ASSETS"
+
+            # Prüfe ob die JS-Bundles tatsächlich ladbar sind
+            for asset in $(echo "$HTML" | grep -oE '/assets/[^"]+\.js' | head -5); do
+              HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$PROD_URL$asset" --max-time 10 2>/dev/null || echo "000")
+              if [ "$HTTP_CODE" = "200" ]; then
+                echo "  ✓ $asset"
+              else
+                echo "  ✗ $asset (HTTP $HTTP_CODE)"
+                FAILED=true
+              fi
+            done
+          fi
+
+          if [ "$FAILED" = "true" ]; then
+            echo "::error::Nicht alle JS-Bundles erreichbar — Frontend noch nicht bereit"
+            exit 1
+          fi
+
+          # Warmup: Alle SPA-Routen einmal laden
+          for route in /dashboard /sessions /analyse /plan /profile; do
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$PROD_URL$route" --max-time 10 2>/dev/null || echo "000")
+            echo "Warmup $route → HTTP $HTTP_CODE"
+          done
+
+          echo "Frontend Warmup abgeschlossen"
+
       - name: Kommentar auf verlinktes Issue
         if: success()
         continue-on-error: true

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   timeout: 30_000,
   expect: { timeout: 10_000 },
   fullyParallel: true,
-  retries: 1,
+  retries: 2,
   reporter: [["html", { open: "never" }], ["list"]],
   use: {
     baseURL: PRODUCTION_URL,


### PR DESCRIPTION
## Summary
- Neuer **Frontend SPA Warmup** Step in `deploy-verify`: prüft ob JS-Bundles aus `index.html` tatsächlich per HTTP 200 erreichbar sind, dann Warmup aller SPA-Routen (`/dashboard`, `/sessions`, `/analyse`, `/plan`, `/profile`)
- Playwright Retries von 1 auf 2 erhöht als zusätzliches Safety-Net
- Behebt transienten E2E-Fehler wo `/profile` auf Mobile crashte weil JS-Assets nach Deploy noch nicht vollständig verfügbar waren

## Ursache
Der bisherige `deploy-verify` prüfte nur Backend-Health (`/health`) und ob Frontend HTML liefert (Content-Type). Nicht geprüft wurde, ob die gebauten JS-Bundles (mit Content-Hash im Dateinamen) tatsächlich vom Nginx ausgeliefert werden. Bei Container-Neustart gab es ein kurzes Fenster wo HTML neue Bundle-URLs referenzierte, die Dateien aber noch nicht serviert wurden → React ErrorBoundary.

## Test plan
- [ ] CI-Pipeline läuft durch (deploy-verify + E2E)
- [ ] Frontend SPA Warmup Step zeigt JS-Assets und HTTP-Status
- [ ] Keine Regression in bestehenden Tests

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)