### PR TITLE
fix: Kraftsession-Übungen nachträglich bearbeitbar (#186)

### DIFF
--- a/backend/app/api/v1/strength.py
+++ b/backend/app/api/v1/strength.py
@@ -177,6 +177,67 @@ async def create_strength_session(
     }
 
 
+@router.patch("/{session_id}/exercises")
+async def update_strength_exercises(
+    session_id: int,
+    exercises_json: str = Form(..., description="JSON-Array der Übungen"),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Aktualisiert die Übungen einer bestehenden Krafttraining-Session."""
+    from pydantic import ValidationError
+
+    # Session laden
+    result = await db.execute(select(WorkoutModel).where(WorkoutModel.id == session_id))
+    workout = result.scalar_one_or_none()
+    if not workout:
+        raise HTTPException(status_code=404, detail="Session nicht gefunden.")
+    if workout.workout_type != "strength":
+        raise HTTPException(status_code=400, detail="Nur Kraftsessions können bearbeitet werden.")
+
+    # Exercises validieren
+    try:
+        exercises = ExerciseListAdapter.validate_json(exercises_json)
+    except ValidationError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+    if len(exercises) == 0:
+        raise HTTPException(status_code=422, detail="Mindestens eine Übung erforderlich.")
+
+    exercises_data = [
+        {
+            "name": ex.name,
+            "category": ex.category.value,
+            "sets": [
+                {"reps": s.reps, "weight_kg": s.weight_kg, "status": s.status.value}
+                for s in ex.sets
+            ],
+        }
+        for ex in exercises
+    ]
+
+    # Update exercises + recalculate metrics
+    workout.exercises_json = json.dumps(exercises_data)  # type: ignore[assignment]
+    metrics = calculate_strength_metrics(exercises_data)
+
+    # Sync exercises to library
+    from app.services.exercise_sync import sync_exercises_from_session
+
+    model_date = workout.date
+    if isinstance(model_date, datetime):
+        session_date = model_date
+    else:
+        session_date = datetime.combine(date.today(), datetime.min.time())
+    await sync_exercises_from_session(db, exercises_data, session_date=session_date)
+
+    await db.commit()
+
+    return {
+        "success": True,
+        "session_id": session_id,
+        "exercises": exercises_data,
+        "metrics": metrics,
+    }
+
+
 @router.get("/last-complete")
 async def get_last_complete_session(
     db: AsyncSession = Depends(get_db),

--- a/frontend/src/api/strength.ts
+++ b/frontend/src/api/strength.ts
@@ -105,6 +105,36 @@ export async function getLastCompleteStrengthSession(): Promise<LastCompleteSess
   return response.data;
 }
 
+export interface UpdateExercisesResponse {
+  success: boolean;
+  session_id: number;
+  exercises: Array<{
+    name: string;
+    category: string;
+    sets: Array<{ reps: number; weight_kg: number; status: string }>;
+  }>;
+  metrics: {
+    total_exercises: number;
+    total_sets: number;
+    total_tonnage_kg: number;
+    completed_sets: number;
+  };
+}
+
+export async function updateStrengthExercises(
+  sessionId: number,
+  exercises: ExerciseInput[],
+): Promise<UpdateExercisesResponse> {
+  const formData = new FormData();
+  formData.append('exercises_json', JSON.stringify(exercises));
+  const response = await apiClient.patch<UpdateExercisesResponse>(
+    `/api/v1/sessions/strength/${sessionId}/exercises`,
+    formData,
+    { headers: { 'Content-Type': 'multipart/form-data' } },
+  );
+  return response.data;
+}
+
 export async function getLastExerciseSets(exerciseName: string): Promise<LastExerciseResponse> {
   const response = await apiClient.get<LastExerciseResponse>(
     '/api/v1/sessions/strength/last-exercises',

--- a/frontend/src/components/StrengthExercisesEditor.tsx
+++ b/frontend/src/components/StrengthExercisesEditor.tsx
@@ -1,0 +1,376 @@
+/**
+ * Inline-Editor für Übungen einer gespeicherten Kraftsession.
+ * Wird in SessionDetail angezeigt, wenn der User auf "Übungen bearbeiten" klickt.
+ */
+import { useState, useCallback } from 'react';
+import { Button, Input, Select, Badge, Spinner, useToast } from '@nordlig/components';
+import { Plus, Trash2, Save, X, Check, AlertTriangle, Ban } from 'lucide-react';
+import { updateStrengthExercises } from '@/api/strength';
+import type { ExerciseCategory, SetStatus } from '@/api/strength';
+
+// --- Types ---
+
+interface SetForm {
+  id: string;
+  reps: number;
+  weight_kg: number;
+  status: SetStatus;
+}
+
+interface ExerciseForm {
+  id: string;
+  name: string;
+  category: ExerciseCategory;
+  sets: SetForm[];
+}
+
+interface ExerciseData {
+  name: string;
+  category: string;
+  sets: Array<{ reps: number; weight_kg: number; status: string }>;
+}
+
+interface StrengthExercisesEditorProps {
+  sessionId: number;
+  exercises: ExerciseData[];
+  onSave: (exercises: ExerciseData[]) => void;
+  onCancel: () => void;
+}
+
+// --- Helpers ---
+
+const CATEGORY_OPTIONS: { value: string; label: string }[] = [
+  { value: 'push', label: 'Push' },
+  { value: 'pull', label: 'Pull' },
+  { value: 'legs', label: 'Beine' },
+  { value: 'core', label: 'Core' },
+  { value: 'cardio', label: 'Cardio' },
+  { value: 'drills', label: 'Lauf-ABC' },
+];
+
+const STATUS_ICONS: Record<string, typeof Check> = {
+  completed: Check,
+  reduced: AlertTriangle,
+  skipped: Ban,
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  completed: 'Fertig',
+  reduced: 'Reduziert',
+  skipped: 'Ausgelassen',
+};
+
+let nextId = 0;
+function genId(): string {
+  return `edit-${++nextId}-${Date.now()}`;
+}
+
+function toForms(exercises: ExerciseData[]): ExerciseForm[] {
+  return exercises.map((ex) => ({
+    id: genId(),
+    name: ex.name,
+    category: ex.category as ExerciseCategory,
+    sets: ex.sets.map((s) => ({
+      id: genId(),
+      reps: s.reps,
+      weight_kg: s.weight_kg,
+      status: (s.status || 'completed') as SetStatus,
+    })),
+  }));
+}
+
+// --- Component ---
+
+export function StrengthExercisesEditor({
+  sessionId,
+  exercises: initialExercises,
+  onSave,
+  onCancel,
+}: StrengthExercisesEditorProps) {
+  const { toast } = useToast();
+  const [exercises, setExercises] = useState<ExerciseForm[]>(() => toForms(initialExercises));
+  const [saving, setSaving] = useState(false);
+
+  const updateExercise = useCallback((exId: string, patch: Partial<ExerciseForm>) => {
+    setExercises((prev) => prev.map((ex) => (ex.id === exId ? { ...ex, ...patch } : ex)));
+  }, []);
+
+  const updateSet = useCallback((exId: string, setId: string, patch: Partial<SetForm>) => {
+    setExercises((prev) =>
+      prev.map((ex) =>
+        ex.id === exId
+          ? {
+              ...ex,
+              sets: ex.sets.map((s) => (s.id === setId ? { ...s, ...patch } : s)),
+            }
+          : ex,
+      ),
+    );
+  }, []);
+
+  const addSet = useCallback((exId: string) => {
+    setExercises((prev) =>
+      prev.map((ex) => {
+        if (ex.id !== exId) return ex;
+        const lastSet = ex.sets[ex.sets.length - 1];
+        return {
+          ...ex,
+          sets: [
+            ...ex.sets,
+            {
+              id: genId(),
+              reps: lastSet?.reps ?? 10,
+              weight_kg: lastSet?.weight_kg ?? 0,
+              status: 'completed' as SetStatus,
+            },
+          ],
+        };
+      }),
+    );
+  }, []);
+
+  const removeSet = useCallback((exId: string, setId: string) => {
+    setExercises((prev) =>
+      prev.map((ex) => {
+        if (ex.id !== exId) return ex;
+        if (ex.sets.length <= 1) return ex; // mindestens 1 Satz
+        return { ...ex, sets: ex.sets.filter((s) => s.id !== setId) };
+      }),
+    );
+  }, []);
+
+  const addExercise = useCallback(() => {
+    setExercises((prev) => [
+      ...prev,
+      {
+        id: genId(),
+        name: '',
+        category: 'push' as ExerciseCategory,
+        sets: [{ id: genId(), reps: 10, weight_kg: 0, status: 'completed' as SetStatus }],
+      },
+    ]);
+  }, []);
+
+  const removeExercise = useCallback((exId: string) => {
+    setExercises((prev) => {
+      if (prev.length <= 1) return prev; // mindestens 1 Übung
+      return prev.filter((ex) => ex.id !== exId);
+    });
+  }, []);
+
+  const cycleStatus = useCallback((exId: string, setId: string) => {
+    const order: SetStatus[] = ['completed', 'reduced', 'skipped'];
+    setExercises((prev) =>
+      prev.map((ex) =>
+        ex.id === exId
+          ? {
+              ...ex,
+              sets: ex.sets.map((s) => {
+                if (s.id !== setId) return s;
+                const idx = order.indexOf(s.status);
+                return { ...s, status: order[(idx + 1) % order.length] };
+              }),
+            }
+          : ex,
+      ),
+    );
+  }, []);
+
+  const handleSave = async () => {
+    // Validierung
+    const valid = exercises.every((ex) => ex.name.trim().length > 0 && ex.sets.length > 0);
+    if (!valid) {
+      toast({
+        title: 'Jede Übung braucht einen Namen und mindestens einen Satz.',
+        variant: 'error',
+      });
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const apiExercises = exercises.map((ex) => ({
+        name: ex.name.trim(),
+        category: ex.category,
+        sets: ex.sets.map((s) => ({
+          reps: s.reps,
+          weight_kg: s.weight_kg,
+          status: s.status,
+        })),
+      }));
+
+      const result = await updateStrengthExercises(sessionId, apiExercises);
+      onSave(result.exercises);
+      toast({ title: 'Übungen gespeichert', variant: 'success' });
+    } catch {
+      toast({ title: 'Speichern fehlgeschlagen', variant: 'error' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {exercises.map((ex, exIdx) => {
+        const StatusIcon = STATUS_ICONS[ex.category] ?? Check;
+        void StatusIcon; // unused, just for clarity
+        return (
+          <div
+            key={ex.id}
+            className="rounded-[var(--radius-component-md)] border border-[var(--color-border-default)] p-3 space-y-3"
+          >
+            {/* Übung Header */}
+            <div className="flex items-center gap-2">
+              <span className="text-xs font-medium text-[var(--color-text-muted)] shrink-0">
+                {exIdx + 1}.
+              </span>
+              <Input
+                value={ex.name}
+                onChange={(e) => updateExercise(ex.id, { name: e.target.value })}
+                placeholder="Übungsname"
+                className="flex-1"
+              />
+              <Select
+                options={CATEGORY_OPTIONS}
+                value={ex.category}
+                onChange={(val) =>
+                  updateExercise(ex.id, {
+                    category: (val as ExerciseCategory) || 'push',
+                  })
+                }
+                className="w-28 shrink-0"
+              />
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => removeExercise(ex.id)}
+                disabled={exercises.length <= 1}
+                aria-label="Übung entfernen"
+              >
+                <Trash2 className="w-4 h-4" />
+              </Button>
+            </div>
+
+            {/* Sets */}
+            <div className="space-y-1.5">
+              {ex.sets.map((s, sIdx) => {
+                const SIcon = STATUS_ICONS[s.status] ?? Check;
+                return (
+                  <div key={s.id} className="flex items-center gap-2">
+                    <span className="text-xs text-[var(--color-text-muted)] w-5 text-right shrink-0">
+                      {sIdx + 1}
+                    </span>
+                    <Input
+                      type="number"
+                      min={0}
+                      max={999}
+                      value={s.reps}
+                      onChange={(e) =>
+                        updateSet(ex.id, s.id, {
+                          reps: Math.max(0, parseInt(e.target.value) || 0),
+                        })
+                      }
+                      className="w-16"
+                      aria-label={`Satz ${sIdx + 1} Wiederholungen`}
+                    />
+                    <span className="text-xs text-[var(--color-text-muted)]">×</span>
+                    <Input
+                      type="number"
+                      min={0}
+                      max={999}
+                      step={0.5}
+                      value={s.weight_kg}
+                      onChange={(e) =>
+                        updateSet(ex.id, s.id, {
+                          weight_kg: Math.max(0, parseFloat(e.target.value) || 0),
+                        })
+                      }
+                      className="w-20"
+                      aria-label={`Satz ${sIdx + 1} Gewicht`}
+                    />
+                    <span className="text-xs text-[var(--color-text-muted)]">kg</span>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => cycleStatus(ex.id, s.id)}
+                      className="shrink-0"
+                      aria-label={`Status: ${STATUS_LABELS[s.status]}`}
+                    >
+                      <Badge
+                        variant={
+                          s.status === 'completed'
+                            ? 'success'
+                            : s.status === 'reduced'
+                              ? 'warning'
+                              : 'info'
+                        }
+                        size="xs"
+                      >
+                        <SIcon className="w-3 h-3" />
+                      </Badge>
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => removeSet(ex.id, s.id)}
+                      disabled={ex.sets.length <= 1}
+                      aria-label="Satz entfernen"
+                      className="shrink-0"
+                    >
+                      <Trash2 className="w-3.5 h-3.5" />
+                    </Button>
+                  </div>
+                );
+              })}
+              <Button variant="ghost" size="sm" onClick={() => addSet(ex.id)} className="mt-1">
+                <Plus className="w-3.5 h-3.5 mr-1" />
+                Satz
+              </Button>
+            </div>
+          </div>
+        );
+      })}
+
+      {/* Übung hinzufügen */}
+      <Button variant="secondary" size="sm" onClick={addExercise} className="w-full">
+        <Plus className="w-4 h-4 mr-1.5" />
+        Übung hinzufügen
+      </Button>
+
+      {/* Aktionen */}
+      <div className="flex items-center gap-2 pt-2 border-t border-[var(--color-border-default)]">
+        <Button variant="primary" size="sm" onClick={handleSave} disabled={saving}>
+          {saving ? (
+            <Spinner size="sm" />
+          ) : (
+            <>
+              <Save className="w-4 h-4 mr-1.5" />
+              Speichern
+            </>
+          )}
+        </Button>
+        <Button variant="ghost" size="sm" onClick={onCancel} disabled={saving}>
+          <X className="w-4 h-4 mr-1.5" />
+          Abbrechen
+        </Button>
+      </div>
+
+      {/* Tonnage-Vorschau */}
+      {(() => {
+        let tonnage = 0;
+        for (const ex of exercises) {
+          for (const s of ex.sets) {
+            if (s.status !== 'skipped') tonnage += s.reps * s.weight_kg;
+          }
+        }
+        if (tonnage <= 0) return null;
+        return (
+          <div className="text-xs text-[var(--color-text-muted)]">
+            Tonnage:{' '}
+            {tonnage >= 1000 ? `${(tonnage / 1000).toFixed(1)} t` : `${Math.round(tonnage)} kg`}
+          </div>
+        );
+      })()}
+    </div>
+  );
+}

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -115,6 +115,7 @@ import { format, parseISO } from 'date-fns';
 import { de } from 'date-fns/locale';
 import { createTemplateFromSession } from '@/api/session-templates';
 import { GlossaryHint } from '@/components/GlossaryHint';
+import { StrengthExercisesEditor } from '@/components/StrengthExercisesEditor';
 import { SEGMENT_TYPES } from '@/constants/taxonomy';
 import { generateInsights } from '@/utils/insights';
 import type { InsightType } from '@/utils/insights';
@@ -218,6 +219,9 @@ export function SessionDetailPage() {
 
   // RPE editing
   const [localRpe, setLocalRpe] = useState<number | null>(null);
+
+  // Strength exercises editing
+  const [editingExercises, setEditingExercises] = useState(false);
 
   // Recalculate zones dialog
   const [showRecalcDialog, setShowRecalcDialog] = useState(false);
@@ -1097,86 +1101,110 @@ export function SessionDetailPage() {
       {session.exercises && session.exercises.length > 0 && (
         <section aria-label="Übungen">
           <Card elevation="raised">
-            <CardHeader>
+            <CardHeader className="flex items-center justify-between">
               <h2 className="text-sm font-semibold text-[var(--color-text-base)]">
                 Übungen ({session.exercises.length})
               </h2>
+              {!editingExercises && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setEditingExercises(true)}
+                  aria-label="Übungen bearbeiten"
+                >
+                  <Pencil className="w-4 h-4" />
+                </Button>
+              )}
             </CardHeader>
             <CardBody className="space-y-4">
-              {session.exercises.map(
-                (
-                  ex: {
-                    name: string;
-                    category: string;
-                    sets: Array<{ reps: number; weight_kg: number; status: string }>;
-                  },
-                  exIdx: number,
-                ) => {
-                  const categoryLabels: Record<string, string> = {
-                    push: 'Push',
-                    pull: 'Pull',
-                    legs: 'Beine',
-                    core: 'Core',
-                    cardio: 'Cardio',
-                  };
-                  return (
-                    <div key={exIdx} className="space-y-2">
-                      <div className="flex items-center gap-2">
-                        <span className="text-sm font-medium text-[var(--color-text-base)]">
-                          {ex.name}
-                        </span>
-                        <Badge variant={categoryBadgeVariant[ex.category] ?? 'neutral'} size="xs">
-                          {categoryLabels[ex.category] ?? ex.category}
-                        </Badge>
-                      </div>
-                      <div className="overflow-x-auto -mx-[var(--spacing-card-padding-normal)]">
-                        <Table>
-                          <TableHeader>
-                            <TableRow>
-                              <TableHead className="w-10 sticky left-0 z-10 bg-[var(--color-table-header-bg)]">
-                                #
-                              </TableHead>
-                              <TableHead>Wdh.</TableHead>
-                              <TableHead>Gewicht</TableHead>
-                              <TableHead>Status</TableHead>
-                            </TableRow>
-                          </TableHeader>
-                          <TableBody>
-                            {ex.sets.map((s, sIdx) => {
-                              const statusLabels: Record<string, string> = {
-                                completed: 'Fertig',
-                                reduced: 'Reduziert',
-                                skipped: 'Ausgelassen',
-                              };
-                              const statusVariant: Record<string, 'success' | 'warning' | 'info'> =
-                                {
+              {editingExercises ? (
+                <StrengthExercisesEditor
+                  sessionId={sessionId}
+                  exercises={session.exercises}
+                  onSave={(updatedExercises) => {
+                    setSession((prev) => (prev ? { ...prev, exercises: updatedExercises } : prev));
+                    setEditingExercises(false);
+                  }}
+                  onCancel={() => setEditingExercises(false)}
+                />
+              ) : (
+                session.exercises.map(
+                  (
+                    ex: {
+                      name: string;
+                      category: string;
+                      sets: Array<{ reps: number; weight_kg: number; status: string }>;
+                    },
+                    exIdx: number,
+                  ) => {
+                    const categoryLabels: Record<string, string> = {
+                      push: 'Push',
+                      pull: 'Pull',
+                      legs: 'Beine',
+                      core: 'Core',
+                      cardio: 'Cardio',
+                    };
+                    return (
+                      <div key={exIdx} className="space-y-2">
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-medium text-[var(--color-text-base)]">
+                            {ex.name}
+                          </span>
+                          <Badge variant={categoryBadgeVariant[ex.category] ?? 'neutral'} size="xs">
+                            {categoryLabels[ex.category] ?? ex.category}
+                          </Badge>
+                        </div>
+                        <div className="overflow-x-auto -mx-[var(--spacing-card-padding-normal)]">
+                          <Table>
+                            <TableHeader>
+                              <TableRow>
+                                <TableHead className="w-10 sticky left-0 z-10 bg-[var(--color-table-header-bg)]">
+                                  #
+                                </TableHead>
+                                <TableHead>Wdh.</TableHead>
+                                <TableHead>Gewicht</TableHead>
+                                <TableHead>Status</TableHead>
+                              </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                              {ex.sets.map((s, sIdx) => {
+                                const statusLabels: Record<string, string> = {
+                                  completed: 'Fertig',
+                                  reduced: 'Reduziert',
+                                  skipped: 'Ausgelassen',
+                                };
+                                const statusVariant: Record<
+                                  string,
+                                  'success' | 'warning' | 'info'
+                                > = {
                                   completed: 'success',
                                   reduced: 'warning',
                                   skipped: 'info',
                                 };
-                              return (
-                                <TableRow key={sIdx}>
-                                  <TableCell className="text-[var(--color-text-muted)]">
-                                    {sIdx + 1}
-                                  </TableCell>
-                                  <TableCell>{s.reps}</TableCell>
-                                  <TableCell>
-                                    {s.weight_kg > 0 ? `${s.weight_kg} kg` : '-'}
-                                  </TableCell>
-                                  <TableCell>
-                                    <Badge variant={statusVariant[s.status] ?? 'info'} size="xs">
-                                      {statusLabels[s.status] ?? s.status}
-                                    </Badge>
-                                  </TableCell>
-                                </TableRow>
-                              );
-                            })}
-                          </TableBody>
-                        </Table>
+                                return (
+                                  <TableRow key={sIdx}>
+                                    <TableCell className="text-[var(--color-text-muted)]">
+                                      {sIdx + 1}
+                                    </TableCell>
+                                    <TableCell>{s.reps}</TableCell>
+                                    <TableCell>
+                                      {s.weight_kg > 0 ? `${s.weight_kg} kg` : '-'}
+                                    </TableCell>
+                                    <TableCell>
+                                      <Badge variant={statusVariant[s.status] ?? 'info'} size="xs">
+                                        {statusLabels[s.status] ?? s.status}
+                                      </Badge>
+                                    </TableCell>
+                                  </TableRow>
+                                );
+                              })}
+                            </TableBody>
+                          </Table>
+                        </div>
                       </div>
-                    </div>
-                  );
-                },
+                    );
+                  },
+                )
               )}
             </CardBody>
           </Card>


### PR DESCRIPTION
## Summary
- Backend: Neuer PATCH-Endpoint `/{session_id}/exercises` zum Aktualisieren der Übungen einer gespeicherten Kraftsession
- Frontend: Neuer `StrengthExercisesEditor`-Inline-Editor in der SessionDetail-Ansicht (Übungsname, Kategorie, Sätze, Gewicht, Wiederholungen, Status)
- Tonnage wird nach dem Speichern automatisch neu berechnet, Exercise Library wird synchronisiert

## Test plan
- [x] Quality Gates bestanden (ESLint, TSC, Prettier, Ruff, Mypy)
- [x] 148 Frontend-Tests + 469 Backend-Tests grün
- [x] Manuell verifiziert via Preview: Übungen bearbeiten → Reps ändern → Speichern → Tonnage-Update korrekt
- [ ] CI-Pipeline grün

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)