### PR TITLE
fix: Übungen-UI vereinfachen — Input + Select statt Badges (#192)

### DIFF
--- a/frontend/src/components/StrengthExercisesEditor.tsx
+++ b/frontend/src/components/StrengthExercisesEditor.tsx
@@ -1,26 +1,14 @@
 /**
  * Inline-Editor für Übungen einer gespeicherten Kraftsession.
- * UI 1:1 identisch mit der Erfassungsseite (StrengthSession.tsx).
+ * UI identisch mit der Erfassungsseite (StrengthSession.tsx).
  * Wird in SessionDetail im globalen Bearbeiten-Modus angezeigt.
  * Die Eltern-Komponente ruft save() über den Ref auf.
  */
-import {
-  useState,
-  useCallback,
-  useImperativeHandle,
-  forwardRef,
-  useEffect,
-  useRef,
-  useMemo,
-} from 'react';
-import { Button, Card, CardBody, Input, NumberInput, Badge, useToast } from '@nordlig/components';
-import { Dumbbell, Plus, Trash2, Copy, ChevronDown, ChevronUp } from 'lucide-react';
-import { updateStrengthExercises, getLastExerciseSets } from '@/api/strength';
-import type { ExerciseCategory, SetStatus, ExerciseInput } from '@/api/strength';
-import { listExercises } from '@/api/exercises';
-import type { Exercise } from '@/api/exercises';
-import { categoryBadgeVariant } from '@/constants/training';
-import { useTonnageCalc, formatTonnage } from '@/hooks/useTonnageCalc';
+import { useState, useCallback, useImperativeHandle, forwardRef } from 'react';
+import { Button, Input, NumberInput, Select, useToast } from '@nordlig/components';
+import { Plus, Trash2 } from 'lucide-react';
+import { updateStrengthExercises } from '@/api/strength';
+import type { ExerciseCategory, SetStatus } from '@/api/strength';
 
 // --- Types ---
 
@@ -36,7 +24,6 @@ interface ExerciseForm {
   name: string;
   category: ExerciseCategory;
   sets: SetForm[];
-  collapsed: boolean;
 }
 
 export interface ExerciseData {
@@ -56,7 +43,7 @@ interface StrengthExercisesEditorProps {
 
 // --- Constants ---
 
-const CATEGORY_OPTIONS: { value: ExerciseCategory; label: string }[] = [
+const CATEGORY_SELECT_OPTIONS = [
   { value: 'push', label: 'Push' },
   { value: 'pull', label: 'Pull' },
   { value: 'legs', label: 'Beine' },
@@ -65,17 +52,11 @@ const CATEGORY_OPTIONS: { value: ExerciseCategory; label: string }[] = [
   { value: 'drills', label: 'Lauf-ABC' },
 ];
 
-const CATEGORY_LABELS: Record<string, string> = {
-  push: 'Push',
-  pull: 'Pull',
-  legs: 'Beine',
-  core: 'Core',
-  cardio: 'Cardio',
-  drills: 'Lauf-ABC',
-};
-
-// prettier-ignore
-const SUGGESTIONS_DROPDOWN_CLS = 'absolute z-10 mt-1 w-full rounded-[var(--radius-component-md)] bg-[var(--color-bg-elevated)] border border-[var(--color-border-default)] shadow-[var(--shadow-md)] max-h-48 overflow-y-auto'; // ds-ok
+const STATUS_SELECT_OPTIONS = [
+  { value: 'completed', label: 'Fertig' },
+  { value: 'reduced', label: 'Reduziert' },
+  { value: 'skipped', label: 'Übersprungen' },
+];
 
 // --- Helpers ---
 
@@ -93,7 +74,6 @@ function toForms(exercises: ExerciseData[]): ExerciseForm[] {
     id: genId(),
     name: ex.name,
     category: ex.category as ExerciseCategory,
-    collapsed: false,
     sets: ex.sets.map((s) => ({
       id: genId(),
       reps: s.reps,
@@ -101,17 +81,6 @@ function toForms(exercises: ExerciseData[]): ExerciseForm[] {
       status: (s.status || 'completed') as SetStatus,
     })),
   }));
-}
-
-/** Convert ExerciseForm[] to ExerciseInput[] for tonnage calc. */
-function toExerciseInputs(forms: ExerciseForm[]): ExerciseInput[] {
-  return forms
-    .filter((f) => f.name.trim())
-    .map((f) => ({
-      name: f.name,
-      category: f.category,
-      sets: f.sets.map((s) => ({ reps: s.reps, weight_kg: s.weight_kg, status: s.status })),
-    }));
 }
 
 // --- Component ---
@@ -122,32 +91,6 @@ export const StrengthExercisesEditor = forwardRef<
 >(function StrengthExercisesEditor({ sessionId, exercises: initialExercises }, ref) {
   const { toast } = useToast();
   const [exercises, setExercises] = useState<ExerciseForm[]>(() => toForms(initialExercises));
-
-  // Exercise library for suggestions
-  const [libraryExercises, setLibraryExercises] = useState<Exercise[]>([]);
-  const [showSuggestions, setShowSuggestions] = useState<string | null>(null);
-  const suggestionsRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    listExercises()
-      .then((res) => setLibraryExercises(res.exercises))
-      .catch(() => {});
-  }, []);
-
-  // Close suggestions on outside click
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      if (suggestionsRef.current && !suggestionsRef.current.contains(e.target as Node)) {
-        setShowSuggestions(null);
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
-
-  // Live tonnage
-  const exerciseInputs = useMemo(() => toExerciseInputs(exercises), [exercises]);
-  const tonnage = useTonnageCalc(exerciseInputs);
 
   // Expose save() to parent via ref
   useImperativeHandle(ref, () => ({
@@ -192,7 +135,6 @@ export const StrengthExercisesEditor = forwardRef<
               name: '',
               category: 'push' as ExerciseCategory,
               sets: [createDefaultSet()],
-              collapsed: false,
             },
           ]
         : filtered;
@@ -202,13 +144,7 @@ export const StrengthExercisesEditor = forwardRef<
   const addExercise = useCallback(() => {
     setExercises((prev) => [
       ...prev,
-      {
-        id: genId(),
-        name: '',
-        category: 'push' as ExerciseCategory,
-        sets: [createDefaultSet()],
-        collapsed: false,
-      },
+      { id: genId(), name: '', category: 'push' as ExerciseCategory, sets: [createDefaultSet()] },
     ]);
   }, []);
 
@@ -247,308 +183,128 @@ export const StrengthExercisesEditor = forwardRef<
     );
   }, []);
 
-  // --- Quick-Add: Load last session's sets ---
-
-  const loadLastSets = useCallback(
-    async (exId: string, exerciseName: string) => {
-      if (!exerciseName.trim()) return;
-      try {
-        const res = await getLastExerciseSets(exerciseName);
-        if (res.found && res.exercise) {
-          const loadedSets: SetForm[] = res.exercise.sets.map((s) => ({
-            id: genId(),
-            reps: s.reps,
-            weight_kg: s.weight_kg,
-            status: (s.status as SetStatus) || 'completed',
-          }));
-          updateExercise(exId, {
-            sets: loadedSets,
-            category: (res.exercise.category as ExerciseCategory) || 'push',
-          });
-        }
-      } catch {
-        // Silently fail
-      }
-    },
-    [updateExercise],
-  );
-
-  // --- Exercise name suggestions ---
-
-  const getFilteredSuggestions = useCallback(
-    (query: string): Exercise[] => {
-      if (!query.trim()) return libraryExercises.slice(0, 10);
-      const lower = query.toLowerCase();
-      return libraryExercises.filter((ex) => ex.name.toLowerCase().includes(lower)).slice(0, 8);
-    },
-    [libraryExercises],
-  );
-
-  const selectSuggestion = useCallback(
-    (exId: string, exercise: Exercise) => {
-      const categoryMap: Record<string, ExerciseCategory> = {
-        push: 'push',
-        pull: 'pull',
-        legs: 'legs',
-        core: 'core',
-        cardio: 'cardio',
-      };
-      updateExercise(exId, {
-        name: exercise.name,
-        category: categoryMap[exercise.category] ?? 'push',
-      });
-      setShowSuggestions(null);
-      loadLastSets(exId, exercise.name);
-    },
-    [updateExercise, loadLastSets],
-  );
-
   // --- Render ---
 
   return (
-    <div className="space-y-4">
-      {exercises.map((exercise, exIndex) => (
-        <Card key={exercise.id} elevation="raised" padding="spacious">
-          <CardBody>
-            <div className="space-y-4">
-              {/* Exercise Header */}
-              <div className="flex items-center justify-between gap-2">
-                <div className="flex items-center gap-2 min-w-0">
-                  <Dumbbell className="w-4 h-4 text-[var(--color-text-muted)] shrink-0" />
-                  <span className="text-xs font-medium text-[var(--color-text-muted)]">
-                    Übung {exIndex + 1}
-                  </span>
-                  {exercise.name && (
-                    <>
-                      <Badge
-                        variant={categoryBadgeVariant[exercise.category] ?? 'neutral'}
-                        size="xs"
-                      >
-                        {CATEGORY_LABELS[exercise.category] ?? exercise.category}
-                      </Badge>
-                      {(tonnage.perExercise.get(exIndex) ?? 0) > 0 && (
-                        <span className="text-xs text-[var(--color-text-muted)] tabular-nums">
-                          {formatTonnage(tonnage.perExercise.get(exIndex) ?? 0).value}
-                          {formatTonnage(tonnage.perExercise.get(exIndex) ?? 0).unit}
-                        </span>
-                      )}
-                    </>
-                  )}
-                </div>
-                <div className="flex items-center gap-1">
-                  {exercise.name && (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() =>
-                        updateExercise(exercise.id, { collapsed: !exercise.collapsed })
-                      }
-                      aria-label={exercise.collapsed ? 'Aufklappen' : 'Zuklappen'}
-                    >
-                      {exercise.collapsed ? (
-                        <ChevronDown className="w-4 h-4" />
-                      ) : (
-                        <ChevronUp className="w-4 h-4" />
-                      )}
-                    </Button>
-                  )}
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => removeExercise(exercise.id)}
-                    aria-label="Übung entfernen"
-                  >
-                    <Trash2 className="w-4 h-4 text-[var(--color-text-error)]" />
-                  </Button>
-                </div>
-              </div>
-
-              {/* Exercise Name (with suggestions) */}
-              {!exercise.collapsed && (
-                <>
-                  <div
-                    className="relative"
-                    ref={showSuggestions === exercise.id ? suggestionsRef : undefined}
-                  >
-                    <Input
-                      value={exercise.name}
-                      onChange={(e) => {
-                        updateExercise(exercise.id, { name: e.target.value });
-                        setShowSuggestions(exercise.id);
-                      }}
-                      onFocus={() => setShowSuggestions(exercise.id)}
-                      placeholder="Übungsname (z.B. Bankdrücken)"
-                      inputSize="md"
-                    />
-                    {showSuggestions === exercise.id && (
-                      <div className={SUGGESTIONS_DROPDOWN_CLS}>
-                        {getFilteredSuggestions(exercise.name).map((ex) => (
-                          <button
-                            key={ex.id}
-                            type="button"
-                            className="w-full text-left px-3 py-2.5 text-sm text-[var(--color-text-base)] hover:bg-[var(--color-bg-muted)] transition-colors duration-150 motion-reduce:transition-none flex items-center justify-between"
-                            onClick={() => selectSuggestion(exercise.id, ex)}
-                          >
-                            <span>{ex.name}</span>
-                            <Badge
-                              variant={categoryBadgeVariant[ex.category] ?? 'neutral'}
-                              size="xs"
-                            >
-                              {CATEGORY_LABELS[ex.category] ?? ex.category}
-                            </Badge>
-                          </button>
-                        ))}
-                        {getFilteredSuggestions(exercise.name).length === 0 && (
-                          <p className="px-3 py-2.5 text-xs text-[var(--color-text-muted)]">
-                            Keine Übung gefunden. Name wird neu angelegt.
-                          </p>
-                        )}
-                      </div>
-                    )}
-                  </div>
-
-                  {/* Category selector (only for exercises not in library) */}
-                  {exercise.name && !libraryExercises.some((l) => l.name === exercise.name) && (
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <span className="text-xs text-[var(--color-text-muted)]">Kategorie:</span>
-                      {CATEGORY_OPTIONS.map((cat) => (
-                        <button
-                          key={cat.value}
-                          type="button"
-                          onClick={() => updateExercise(exercise.id, { category: cat.value })}
-                          className={`px-2.5 py-1 text-xs rounded-[var(--radius-component-sm)] transition-colors duration-150 motion-reduce:transition-none ${
-                            exercise.category === cat.value
-                              ? 'bg-[var(--color-bg-primary-subtle)] text-[var(--color-primary-1-600)] font-medium'
-                              : 'bg-[var(--color-bg-surface)] text-[var(--color-text-muted)] hover:bg-[var(--color-bg-muted)]'
-                          }`}
-                        >
-                          {cat.label}
-                        </button>
-                      ))}
-                    </div>
-                  )}
-
-                  {/* Sets */}
-                  {exercise.name && (
-                    <div className="space-y-2">
-                      {/* Header row */}
-                      <div className="grid grid-cols-[auto_1fr_1fr_auto] gap-2 items-center px-1">
-                        <span className="text-xs text-[var(--color-text-muted)] w-6 text-center">
-                          #
-                        </span>
-                        <span className="text-xs text-[var(--color-text-muted)]">Reps</span>
-                        <span className="text-xs text-[var(--color-text-muted)]">Gewicht (kg)</span>
-                        <span className="w-8" />
-                      </div>
-
-                      {/* Set rows */}
-                      {exercise.sets.map((set, setIndex) => (
-                        <div
-                          key={set.id}
-                          className={`grid grid-cols-[auto_1fr_1fr_auto] gap-2 items-center rounded-[var(--radius-component-md)] px-1 py-1 ${
-                            set.status === 'skipped' ? 'opacity-50' : ''
-                          }`}
-                        >
-                          <button
-                            type="button"
-                            onClick={() => {
-                              const statusCycle: SetStatus[] = ['completed', 'reduced', 'skipped'];
-                              const currentIdx = statusCycle.indexOf(set.status);
-                              const nextStatus = statusCycle[(currentIdx + 1) % statusCycle.length];
-                              updateSet(exercise.id, set.id, { status: nextStatus });
-                            }}
-                            className={`w-6 h-6 rounded-full text-xs font-medium flex items-center justify-center transition-colors duration-150 motion-reduce:transition-none ${
-                              set.status === 'completed'
-                                ? 'bg-[var(--color-bg-success-subtle)] text-[var(--color-text-success)]'
-                                : set.status === 'reduced'
-                                  ? 'bg-[var(--color-bg-warning-subtle)] text-[var(--color-text-warning)]'
-                                  : 'bg-[var(--color-bg-surface)] text-[var(--color-text-disabled)]'
-                            }`}
-                            aria-label={`Satz ${setIndex + 1} Status: ${set.status}`}
-                            title="Tippen zum Ändern: Vollständig → Reduziert → Übersprungen"
-                          >
-                            {setIndex + 1}
-                          </button>
-                          <NumberInput
-                            value={set.reps}
-                            onChange={(val) => updateSet(exercise.id, set.id, { reps: val })}
-                            min={0}
-                            max={999}
-                            step={1}
-                            inputSize="sm"
-                            decrementLabel="Reps reduzieren"
-                            incrementLabel="Reps erhöhen"
-                          />
-                          <NumberInput
-                            value={set.weight_kg}
-                            onChange={(val) => updateSet(exercise.id, set.id, { weight_kg: val })}
-                            min={0}
-                            max={999}
-                            step={2.5}
-                            inputSize="sm"
-                            decrementLabel="Gewicht reduzieren"
-                            incrementLabel="Gewicht erhöhen"
-                          />
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => removeSet(exercise.id, set.id)}
-                            aria-label={`Satz ${setIndex + 1} entfernen`}
-                            className="!p-1"
-                          >
-                            <Trash2 className="w-3.5 h-3.5 text-[var(--color-text-muted)]" />
-                          </Button>
-                        </div>
-                      ))}
-
-                      {/* Add set + Quick-Add */}
-                      <div className="flex items-center gap-2 pt-1">
-                        <Button variant="ghost" size="sm" onClick={() => addSet(exercise.id)}>
-                          <Plus className="w-3.5 h-3.5 mr-1" />
-                          Satz
-                        </Button>
-                        {exercise.name.trim() && (
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => loadLastSets(exercise.id, exercise.name)}
-                          >
-                            <Copy className="w-3.5 h-3.5 mr-1" />
-                            Letzte Session
-                          </Button>
-                        )}
-                      </div>
-                    </div>
-                  )}
-                </>
-              )}
-
-              {/* Collapsed summary */}
-              {exercise.collapsed && exercise.name && (
-                <p className="text-sm text-[var(--color-text-muted)]">
-                  {exercise.sets.length} Sätze ·{' '}
-                  {exercise.sets
-                    .filter((s) => s.status !== 'skipped')
-                    .reduce((sum, s) => sum + s.reps, 0)}{' '}
-                  Reps ·{' '}
-                  {Math.round(
-                    exercise.sets
-                      .filter((s) => s.status !== 'skipped')
-                      .reduce((sum, s) => sum + s.reps * s.weight_kg, 0),
-                  )}{' '}
-                  kg Tonnage
-                </p>
-              )}
+    <div className="space-y-6">
+      {exercises.map((exercise) => (
+        <div
+          key={exercise.id}
+          className="rounded-[var(--radius-component-md)] border border-[var(--color-border-default)] p-4 space-y-4"
+        >
+          {/* Exercise name + category + delete */}
+          <div className="flex items-start gap-2 flex-wrap sm:flex-nowrap">
+            <div className="flex-1 min-w-0 basis-full sm:basis-auto">
+              <Input
+                value={exercise.name}
+                onChange={(e) => updateExercise(exercise.id, { name: e.target.value })}
+                placeholder="Übungsname"
+                inputSize="md"
+              />
             </div>
-          </CardBody>
-        </Card>
+            <div className="flex items-center gap-2">
+              <div className="w-32 sm:w-36 shrink-0">
+                <Select
+                  options={CATEGORY_SELECT_OPTIONS}
+                  value={exercise.category}
+                  onChange={(val) =>
+                    updateExercise(exercise.id, {
+                      category: (val as ExerciseCategory) || 'push',
+                    })
+                  }
+                  inputSize="md"
+                />
+              </div>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => removeExercise(exercise.id)}
+                aria-label="Übung entfernen"
+              >
+                <Trash2 className="w-4 h-4 text-[var(--color-text-muted)]" />
+              </Button>
+            </div>
+          </div>
+
+          {/* Sets header */}
+          <div className="grid grid-cols-[auto_1fr_1fr_1fr_auto] gap-2 items-center px-1">
+            <span className="text-xs text-[var(--color-text-muted)] w-6 text-center">#</span>
+            <span className="text-xs text-[var(--color-text-muted)]">Wdh.</span>
+            <span className="text-xs text-[var(--color-text-muted)]">kg</span>
+            <span className="text-xs text-[var(--color-text-muted)]">Status</span>
+            <span className="w-8" />
+          </div>
+
+          {/* Set rows */}
+          {exercise.sets.map((set, setIndex) => (
+            <div
+              key={set.id}
+              className={`grid grid-cols-[auto_1fr_1fr_1fr_auto] gap-2 items-center px-1 ${
+                set.status === 'skipped' ? 'opacity-50' : ''
+              }`}
+            >
+              <span className="text-sm text-[var(--color-text-muted)] w-6 text-center tabular-nums">
+                {setIndex + 1}
+              </span>
+              <NumberInput
+                value={set.reps}
+                onChange={(val) => updateSet(exercise.id, set.id, { reps: val })}
+                min={0}
+                max={999}
+                step={1}
+                inputSize="sm"
+                decrementLabel="Reps reduzieren"
+                incrementLabel="Reps erhöhen"
+              />
+              <NumberInput
+                value={set.weight_kg}
+                onChange={(val) => updateSet(exercise.id, set.id, { weight_kg: val })}
+                min={0}
+                max={999}
+                step={2.5}
+                inputSize="sm"
+                decrementLabel="Gewicht reduzieren"
+                incrementLabel="Gewicht erhöhen"
+              />
+              <Select
+                options={STATUS_SELECT_OPTIONS}
+                value={set.status}
+                onChange={(val) =>
+                  updateSet(exercise.id, set.id, {
+                    status: (val as SetStatus) || 'completed',
+                  })
+                }
+                inputSize="sm"
+              />
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => removeSet(exercise.id, set.id)}
+                aria-label={`Satz ${setIndex + 1} entfernen`}
+                className="!p-1"
+              >
+                <Trash2 className="w-4 h-4 text-[var(--color-text-muted)]" />
+              </Button>
+            </div>
+          ))}
+
+          {/* Add set */}
+          <div className="flex justify-center pt-1">
+            <Button variant="ghost" size="sm" onClick={() => addSet(exercise.id)}>
+              <Plus className="w-3.5 h-3.5 mr-1" />
+              Satz hinzufügen
+            </Button>
+          </div>
+        </div>
       ))}
 
       {/* Add exercise button */}
-      <Button variant="secondary" onClick={addExercise} className="w-full">
-        <Plus className="w-4 h-4 mr-2" />
-        Übung hinzufügen
-      </Button>
+      <div className="flex justify-center">
+        <Button variant="ghost" onClick={addExercise}>
+          <Plus className="w-4 h-4 mr-2" />
+          Übung hinzufügen
+        </Button>
+      </div>
     </div>
   );
 });

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -1102,11 +1102,18 @@ export function SessionDetailPage() {
       {session.exercises && session.exercises.length > 0 && (
         <section aria-label="Übungen">
           {isEditing ? (
-            <StrengthExercisesEditor
-              ref={exercisesEditorRef}
-              sessionId={sessionId}
-              exercises={session.exercises}
-            />
+            <Card elevation="raised" padding="spacious">
+              <CardBody>
+                <h2 className="text-base font-semibold text-[var(--color-text-base)] mb-4">
+                  Übungen ({session.exercises.length})
+                </h2>
+                <StrengthExercisesEditor
+                  ref={exercisesEditorRef}
+                  sessionId={sessionId}
+                  exercises={session.exercises}
+                />
+              </CardBody>
+            </Card>
           ) : (
             <Card elevation="raised">
               <CardHeader>

--- a/frontend/src/pages/StrengthSession.test.tsx
+++ b/frontend/src/pages/StrengthSession.test.tsx
@@ -6,12 +6,7 @@ import { StrengthSessionPage } from './StrengthSession';
 // Mock API modules
 vi.mock('@/api/strength', () => ({
   createStrengthSession: vi.fn(),
-  getLastExerciseSets: vi.fn(),
   getLastCompleteStrengthSession: vi.fn().mockResolvedValue({ found: false, session: null }),
-}));
-
-vi.mock('@/api/exercises', () => ({
-  listExercises: vi.fn(),
 }));
 
 vi.mock('@/api/session-templates', () => ({
@@ -31,11 +26,8 @@ vi.mock('react-router-dom', async () => {
 
 async function getMocks() {
   const strength = await import('@/api/strength');
-  const exercises = await import('@/api/exercises');
   return {
     createStrengthSession: vi.mocked(strength.createStrengthSession),
-    getLastExerciseSets: vi.mocked(strength.getLastExerciseSets),
-    listExercises: vi.mocked(exercises.listExercises),
   };
 }
 
@@ -44,230 +36,85 @@ describe('StrengthSessionPage', () => {
     vi.clearAllMocks();
   });
 
-  async function renderWithMocks() {
-    const mocks = await getMocks();
-    mocks.listExercises.mockResolvedValue({
-      exercises: [
-        {
-          id: 1,
-          name: 'Bankdrücken',
-          category: 'push',
-          is_favorite: false,
-          is_custom: false,
-          usage_count: 5,
-          last_used_at: null,
-          instructions: null,
-          primary_muscles: null,
-          secondary_muscles: null,
-          image_urls: null,
-          equipment: null,
-          level: null,
-          force: null,
-          mechanic: null,
-          exercise_db_id: null,
-        },
-        {
-          id: 2,
-          name: 'Kniebeugen',
-          category: 'legs',
-          is_favorite: false,
-          is_custom: false,
-          usage_count: 8,
-          last_used_at: null,
-          instructions: null,
-          primary_muscles: null,
-          secondary_muscles: null,
-          image_urls: null,
-          equipment: null,
-          level: null,
-          force: null,
-          mechanic: null,
-          exercise_db_id: null,
-        },
-        {
-          id: 3,
-          name: 'Klimmzüge',
-          category: 'pull',
-          is_favorite: false,
-          is_custom: false,
-          usage_count: 3,
-          last_used_at: null,
-          instructions: null,
-          primary_muscles: null,
-          secondary_muscles: null,
-          image_urls: null,
-          equipment: null,
-          level: null,
-          force: null,
-          mechanic: null,
-          exercise_db_id: null,
-        },
-      ],
-      total: 3,
-    });
-    return mocks;
-  }
-
-  it('renders the form with header and initial exercise', async () => {
-    await renderWithMocks();
+  it('renders the form with header and initial exercise', () => {
     render(<StrengthSessionPage />);
 
     expect(screen.getByText('Krafttraining erfassen')).toBeInTheDocument();
-    expect(screen.getByText('Übung 1')).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('Übungsname (z.B. Bankdrücken)')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Übungsname')).toBeInTheDocument();
     expect(screen.getByText('Training speichern')).toBeInTheDocument();
   });
 
-  it('renders date and duration inputs', async () => {
-    await renderWithMocks();
+  it('renders exercises container with count', () => {
+    render(<StrengthSessionPage />);
+
+    expect(screen.getByText(/Übungen \(/)).toBeInTheDocument();
+  });
+
+  it('renders date and duration inputs', () => {
     render(<StrengthSessionPage />);
 
     expect(screen.getByText('Datum')).toBeInTheDocument();
     expect(screen.getByText('Dauer (Minuten)')).toBeInTheDocument();
   });
 
-  it('renders RPE slider with default value', async () => {
-    await renderWithMocks();
+  it('renders RPE slider with default value', () => {
     render(<StrengthSessionPage />);
 
     expect(screen.getByText('Belastung (RPE)')).toBeInTheDocument();
     expect(screen.getByText(/5 — Mittel/)).toBeInTheDocument();
   });
 
-  it('renders notes textarea', async () => {
-    await renderWithMocks();
+  it('renders notes textarea', () => {
     render(<StrengthSessionPage />);
 
     expect(screen.getByPlaceholderText('Wie lief das Training?')).toBeInTheDocument();
     expect(screen.getByText('Notizen (optional)')).toBeInTheDocument();
   });
 
-  it('shows add exercise button', async () => {
-    await renderWithMocks();
+  it('shows add exercise button', () => {
     render(<StrengthSessionPage />);
 
     expect(screen.getByText('Übung hinzufügen')).toBeInTheDocument();
   });
 
-  it('submit button is disabled when no exercise name is entered', async () => {
-    await renderWithMocks();
+  it('submit button is disabled when no exercise name is entered', () => {
     render(<StrengthSessionPage />);
 
     const submitButton = screen.getByText('Training speichern').closest('button');
     expect(submitButton).toBeDisabled();
   });
 
-  it('shows exercise suggestions when focusing the name input', async () => {
-    const mocks = await renderWithMocks();
-    const user = userEvent.setup();
-    render(<StrengthSessionPage />);
-
-    // Wait for exercise library to load
-    await waitFor(() => {
-      expect(mocks.listExercises).toHaveBeenCalled();
-    });
-
-    const nameInput = screen.getByPlaceholderText('Übungsname (z.B. Bankdrücken)');
-    await user.click(nameInput);
-
-    await waitFor(() => {
-      expect(screen.getByText('Bankdrücken')).toBeInTheDocument();
-      expect(screen.getByText('Kniebeugen')).toBeInTheDocument();
-    });
-  });
-
-  it('filters suggestions when typing', async () => {
-    const mocks = await renderWithMocks();
-    const user = userEvent.setup();
-    render(<StrengthSessionPage />);
-
-    await waitFor(() => {
-      expect(mocks.listExercises).toHaveBeenCalled();
-    });
-
-    const nameInput = screen.getByPlaceholderText('Übungsname (z.B. Bankdrücken)');
-    await user.type(nameInput, 'Bank');
-
-    await waitFor(() => {
-      expect(screen.getByText('Bankdrücken')).toBeInTheDocument();
-      expect(screen.queryByText('Kniebeugen')).not.toBeInTheDocument();
-    });
-  });
-
-  it('selects a suggestion and shows category badge', async () => {
-    const mocks = await renderWithMocks();
-    mocks.getLastExerciseSets.mockResolvedValue({ found: false, exercise: null });
-    const user = userEvent.setup();
-    render(<StrengthSessionPage />);
-
-    await waitFor(() => {
-      expect(mocks.listExercises).toHaveBeenCalled();
-    });
-
-    const nameInput = screen.getByPlaceholderText('Übungsname (z.B. Bankdrücken)');
-    await user.click(nameInput);
-
-    await waitFor(() => {
-      expect(screen.getByText('Bankdrücken')).toBeInTheDocument();
-    });
-
-    // Click the suggestion (find the button in the suggestion list)
-    const suggestions = screen.getAllByText('Bankdrücken');
-    // Click the one that's a button (suggestion item)
-    const suggestionButton = suggestions.find(
-      (el) => el.closest('button')?.getAttribute('type') === 'button',
-    );
-    if (suggestionButton) {
-      await user.click(suggestionButton);
-    }
-
-    // Category badge should appear
-    await waitFor(() => {
-      expect(screen.getByText('Push')).toBeInTheDocument();
-    });
-  });
-
   it('adds a new exercise when clicking add button', async () => {
-    await renderWithMocks();
     const user = userEvent.setup();
     render(<StrengthSessionPage />);
+
+    // Initially 1 name input
+    expect(screen.getAllByPlaceholderText('Übungsname')).toHaveLength(1);
 
     await user.click(screen.getByText('Übung hinzufügen'));
 
-    expect(screen.getByText('Übung 1')).toBeInTheDocument();
-    expect(screen.getByText('Übung 2')).toBeInTheDocument();
+    // Now 2 name inputs
+    expect(screen.getAllByPlaceholderText('Übungsname')).toHaveLength(2);
   });
 
   it('removes an exercise', async () => {
-    await renderWithMocks();
     const user = userEvent.setup();
     render(<StrengthSessionPage />);
 
     // Add a second exercise
     await user.click(screen.getByText('Übung hinzufügen'));
-    expect(screen.getByText('Übung 2')).toBeInTheDocument();
+    expect(screen.getAllByPlaceholderText('Übungsname')).toHaveLength(2);
 
     // Remove the first one
     const removeButtons = screen.getAllByLabelText('Übung entfernen');
     await user.click(removeButtons[0]);
 
     // Should still have at least one exercise
-    expect(screen.getByText('Übung 1')).toBeInTheDocument();
-    expect(screen.queryByText('Übung 2')).not.toBeInTheDocument();
-  });
-
-  it('shows validation error when submitting without exercise name', async () => {
-    await renderWithMocks();
-    render(<StrengthSessionPage />);
-
-    // Submit button is disabled when all exercises have empty names
-    const submitButton = screen.getByText('Training speichern').closest('button');
-    expect(submitButton).toBeDisabled();
+    expect(screen.getAllByPlaceholderText('Übungsname')).toHaveLength(1);
   });
 
   it('submits successfully and navigates to session detail', async () => {
-    const mocks = await renderWithMocks();
-    mocks.getLastExerciseSets.mockResolvedValue({ found: false, exercise: null });
+    const mocks = await getMocks();
     mocks.createStrengthSession.mockResolvedValue({
       success: true,
       session_id: 42,
@@ -282,29 +129,9 @@ describe('StrengthSessionPage', () => {
     const user = userEvent.setup();
     render(<StrengthSessionPage />);
 
-    // Wait for library to load
-    await waitFor(() => {
-      expect(mocks.listExercises).toHaveBeenCalled();
-    });
-
-    // Select an exercise from suggestions
-    const nameInput = screen.getByPlaceholderText('Übungsname (z.B. Bankdrücken)');
-    await user.click(nameInput);
-    await waitFor(() => {
-      expect(screen.getByText('Kniebeugen')).toBeInTheDocument();
-    });
-    const suggestions = screen.getAllByText('Kniebeugen');
-    const suggestionButton = suggestions.find(
-      (el) => el.closest('button')?.getAttribute('type') === 'button',
-    );
-    if (suggestionButton) {
-      await user.click(suggestionButton);
-    }
-
-    // Wait for exercise to be selected and sets to appear
-    await waitFor(() => {
-      expect(screen.getByText('Beine')).toBeInTheDocument();
-    });
+    // Type exercise name
+    const nameInput = screen.getByPlaceholderText('Übungsname');
+    await user.type(nameInput, 'Bankdrücken');
 
     // Submit
     const submitButton = screen.getByText('Training speichern').closest('button');
@@ -315,29 +142,21 @@ describe('StrengthSessionPage', () => {
       expect(mocks.createStrengthSession).toHaveBeenCalledTimes(1);
     });
 
-    // Verify navigation
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('/sessions/42');
     });
   });
 
   it('shows error when submission fails', async () => {
-    const mocks = await renderWithMocks();
-    mocks.getLastExerciseSets.mockResolvedValue({ found: false, exercise: null });
+    const mocks = await getMocks();
     mocks.createStrengthSession.mockRejectedValue(new Error('Server-Fehler'));
 
     const user = userEvent.setup();
     render(<StrengthSessionPage />);
 
-    await waitFor(() => {
-      expect(mocks.listExercises).toHaveBeenCalled();
-    });
-
-    // Type exercise name directly (no suggestion)
-    const nameInput = screen.getByPlaceholderText('Übungsname (z.B. Bankdrücken)');
+    // Type exercise name
+    const nameInput = screen.getByPlaceholderText('Übungsname');
     await user.type(nameInput, 'Rudern');
-    // Close suggestions by clicking elsewhere
-    await user.click(screen.getByText('Krafttraining erfassen'));
 
     // Submit
     const submitButton = screen.getByText('Training speichern').closest('button');
@@ -348,51 +167,7 @@ describe('StrengthSessionPage', () => {
     });
   });
 
-  it('loads last session sets via Quick-Add', async () => {
-    const mocks = await renderWithMocks();
-    mocks.getLastExerciseSets.mockResolvedValue({
-      found: true,
-      exercise: {
-        exercise_name: 'Bankdrücken',
-        category: 'push',
-        sets: [
-          { reps: 8, weight_kg: 80, status: 'completed' },
-          { reps: 8, weight_kg: 80, status: 'completed' },
-          { reps: 6, weight_kg: 80, status: 'reduced' },
-        ],
-        session_date: '2026-02-28',
-      },
-    });
-
-    const user = userEvent.setup();
-    render(<StrengthSessionPage />);
-
-    await waitFor(() => {
-      expect(mocks.listExercises).toHaveBeenCalled();
-    });
-
-    // Select exercise from suggestions
-    const nameInput = screen.getByPlaceholderText('Übungsname (z.B. Bankdrücken)');
-    await user.click(nameInput);
-    await waitFor(() => {
-      expect(screen.getByText('Bankdrücken')).toBeInTheDocument();
-    });
-    const suggestions = screen.getAllByText('Bankdrücken');
-    const suggestionButton = suggestions.find(
-      (el) => el.closest('button')?.getAttribute('type') === 'button',
-    );
-    if (suggestionButton) {
-      await user.click(suggestionButton);
-    }
-
-    // Quick-Add should have been called automatically
-    await waitFor(() => {
-      expect(mocks.getLastExerciseSets).toHaveBeenCalledWith('Bankdrücken');
-    });
-  });
-
   it('navigates back when clicking back button', async () => {
-    await renderWithMocks();
     const user = userEvent.setup();
     render(<StrengthSessionPage />);
 
@@ -400,42 +175,18 @@ describe('StrengthSessionPage', () => {
     expect(mockNavigate).toHaveBeenCalledWith(-1);
   });
 
-  it('shows collapsed summary when exercise is collapsed', async () => {
-    const mocks = await renderWithMocks();
-    mocks.getLastExerciseSets.mockResolvedValue({ found: false, exercise: null });
-    const user = userEvent.setup();
+  it('shows set header labels', () => {
     render(<StrengthSessionPage />);
 
-    await waitFor(() => {
-      expect(mocks.listExercises).toHaveBeenCalled();
-    });
+    expect(screen.getByText('#')).toBeInTheDocument();
+    expect(screen.getByText('Wdh.')).toBeInTheDocument();
+    expect(screen.getByText('kg')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+  });
 
-    // Type exercise name
-    const nameInput = screen.getByPlaceholderText('Übungsname (z.B. Bankdrücken)');
-    await user.click(nameInput);
-    await waitFor(() => {
-      expect(screen.getByText('Bankdrücken')).toBeInTheDocument();
-    });
-    const suggestions = screen.getAllByText('Bankdrücken');
-    const suggestionButton = suggestions.find(
-      (el) => el.closest('button')?.getAttribute('type') === 'button',
-    );
-    if (suggestionButton) {
-      await user.click(suggestionButton);
-    }
+  it('shows add set button', () => {
+    render(<StrengthSessionPage />);
 
-    // Wait for sets to appear
-    await waitFor(() => {
-      expect(screen.getByText('Push')).toBeInTheDocument();
-    });
-
-    // Collapse the exercise
-    await user.click(screen.getByLabelText('Zuklappen'));
-
-    // Collapsed summary should show (e.g. "1 Sätze · 10 Reps · 0 kg Tonnage")
-    await waitFor(() => {
-      expect(screen.getByText(/Reps ·/)).toBeInTheDocument();
-      expect(screen.getByText(/kg Tonnage/)).toBeInTheDocument();
-    });
+    expect(screen.getByText('Satz hinzufügen')).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/StrengthSession.tsx
+++ b/frontend/src/pages/StrengthSession.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Button,
@@ -6,9 +6,9 @@ import {
   CardBody,
   Input,
   NumberInput,
+  Select,
   Label,
   Slider,
-  Badge,
   Spinner,
   Alert,
   AlertDescription,
@@ -16,12 +16,8 @@ import {
 import { DatePicker } from '@nordlig/components';
 import {
   ClipboardList,
-  Dumbbell,
   Plus,
   Trash2,
-  Copy,
-  ChevronDown,
-  ChevronUp,
   Save,
   ArrowLeft,
   RotateCcw,
@@ -35,13 +31,9 @@ import type {
   LastCompleteSession,
   SetStatus,
 } from '@/api/strength';
-import { categoryBadgeVariant } from '@/constants/training';
-import { listExercises } from '@/api/exercises';
-import type { Exercise } from '@/api/exercises';
-import { getLastExerciseSets } from '@/api/strength';
 import { listSessionTemplates, getSessionTemplate } from '@/api/session-templates';
 import type { SessionTemplateSummary } from '@/api/session-templates';
-import { useTonnageCalc, formatTonnage } from '@/hooks/useTonnageCalc';
+import { useTonnageCalc } from '@/hooks/useTonnageCalc';
 
 // --- Types ---
 
@@ -57,10 +49,9 @@ interface ExerciseForm {
   name: string;
   category: ExerciseCategory;
   sets: SetForm[];
-  collapsed: boolean;
 }
 
-const CATEGORY_OPTIONS: { value: ExerciseCategory; label: string }[] = [
+const CATEGORY_SELECT_OPTIONS = [
   { value: 'push', label: 'Push' },
   { value: 'pull', label: 'Pull' },
   { value: 'legs', label: 'Beine' },
@@ -69,14 +60,11 @@ const CATEGORY_OPTIONS: { value: ExerciseCategory; label: string }[] = [
   { value: 'drills', label: 'Lauf-ABC' },
 ];
 
-const CATEGORY_LABELS: Record<string, string> = {
-  push: 'Push',
-  pull: 'Pull',
-  legs: 'Beine',
-  core: 'Core',
-  cardio: 'Cardio',
-  drills: 'Lauf-ABC',
-};
+const STATUS_SELECT_OPTIONS = [
+  { value: 'completed', label: 'Fertig' },
+  { value: 'reduced', label: 'Reduziert' },
+  { value: 'skipped', label: 'Übersprungen' },
+];
 
 const RPE_LABELS: Record<number, string> = {
   1: 'Sehr leicht',
@@ -101,16 +89,10 @@ function createDefaultSet(): SetForm {
 }
 
 function createDefaultExercise(): ExerciseForm {
-  return {
-    id: genId(),
-    name: '',
-    category: 'push',
-    sets: [createDefaultSet()],
-    collapsed: false,
-  };
+  return { id: genId(), name: '', category: 'push', sets: [createDefaultSet()] };
 }
 
-/** Convert ExerciseForm[] (with id, collapsed) to ExerciseInput[] for tonnage calc + API. */
+/** Convert ExerciseForm[] to ExerciseInput[] for tonnage calc + API. */
 function toExerciseInputs(forms: ExerciseForm[]): ExerciseInput[] {
   return forms
     .filter((f) => f.name.trim())
@@ -142,15 +124,7 @@ export function StrengthSessionPage() {
   // Last session (for clone + tonnage delta)
   const [lastSession, setLastSession] = useState<LastCompleteSession | null>(null);
 
-  // Exercise library for suggestions
-  const [libraryExercises, setLibraryExercises] = useState<Exercise[]>([]);
-  const [showSuggestions, setShowSuggestions] = useState<string | null>(null);
-  const suggestionsRef = useRef<HTMLDivElement>(null);
-
   useEffect(() => {
-    listExercises()
-      .then((res) => setLibraryExercises(res.exercises))
-      .catch(() => {});
     listSessionTemplates('strength')
       .then((res) => setAvailableTemplates(res.templates))
       .catch(() => {});
@@ -166,17 +140,6 @@ export function StrengthSessionPage() {
   const tonnage = useTonnageCalc(exerciseInputs);
   const tonnageDelta =
     lastSession && tonnage.total > 0 ? tonnage.total - lastSession.total_tonnage_kg : null;
-
-  // Close suggestions on outside click
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      if (suggestionsRef.current && !suggestionsRef.current.contains(e.target as Node)) {
-        setShowSuggestions(null);
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
 
   // --- Exercise CRUD ---
 
@@ -234,32 +197,6 @@ export function StrengthSessionPage() {
     );
   }, []);
 
-  // --- Quick-Add: Load last session's sets ---
-
-  const loadLastSets = useCallback(
-    async (exerciseId: string, exerciseName: string) => {
-      if (!exerciseName.trim()) return;
-      try {
-        const res = await getLastExerciseSets(exerciseName);
-        if (res.found && res.exercise) {
-          const loadedSets: SetForm[] = res.exercise.sets.map((s) => ({
-            id: genId(),
-            reps: s.reps,
-            weight_kg: s.weight_kg,
-            status: (s.status as SetStatus) || 'completed',
-          }));
-          updateExercise(exerciseId, {
-            sets: loadedSets,
-            category: (res.exercise.category as ExerciseCategory) || 'push',
-          });
-        }
-      } catch {
-        // Silently fail
-      }
-    },
-    [updateExercise],
-  );
-
   // --- Load from plan ---
 
   const loadFromPlan = useCallback(async (planId: number) => {
@@ -276,7 +213,6 @@ export function StrengthSessionPage() {
           weight_kg: ex.weight_kg ?? 0,
           status: 'completed' as SetStatus,
         })),
-        collapsed: false,
       }));
       if (loadedExercises.length > 0) {
         setExercises(loadedExercises);
@@ -305,7 +241,6 @@ export function StrengthSessionPage() {
         weight_kg: s.weight_kg,
         status: 'completed' as SetStatus,
       })),
-      collapsed: false,
     }));
     if (cloned.length > 0) {
       setExercises(cloned);
@@ -314,37 +249,6 @@ export function StrengthSessionPage() {
       }
     }
   }, [lastSession, exercises]);
-
-  // --- Exercise name suggestions ---
-
-  const getFilteredSuggestions = useCallback(
-    (query: string): Exercise[] => {
-      if (!query.trim()) return libraryExercises.slice(0, 10);
-      const lower = query.toLowerCase();
-      return libraryExercises.filter((ex) => ex.name.toLowerCase().includes(lower)).slice(0, 8);
-    },
-    [libraryExercises],
-  );
-
-  const selectSuggestion = useCallback(
-    (exerciseId: string, exercise: Exercise) => {
-      const categoryMap: Record<string, ExerciseCategory> = {
-        push: 'push',
-        pull: 'pull',
-        legs: 'legs',
-        core: 'core',
-        cardio: 'cardio',
-      };
-      updateExercise(exerciseId, {
-        name: exercise.name,
-        category: categoryMap[exercise.category] ?? 'push',
-      });
-      setShowSuggestions(null);
-      // Auto-load last sets
-      loadLastSets(exerciseId, exercise.name);
-    },
-    [updateExercise, loadLastSets],
-  );
 
   // --- Submit ---
 
@@ -495,257 +399,134 @@ export function StrengthSessionPage() {
       )}
 
       {/* Exercises */}
-      <div className="space-y-4">
-        {exercises.map((exercise, exIndex) => (
-          <Card key={exercise.id} elevation="raised" padding="spacious">
-            <CardBody>
-              <div className="space-y-4">
-                {/* Exercise Header */}
-                <div className="flex items-center justify-between gap-2">
-                  <div className="flex items-center gap-2 min-w-0">
-                    <Dumbbell className="w-4 h-4 text-[var(--color-text-muted)] shrink-0" />
-                    <span className="text-xs font-medium text-[var(--color-text-muted)]">
-                      Übung {exIndex + 1}
-                    </span>
-                    {exercise.name && (
-                      <>
-                        <Badge
-                          variant={categoryBadgeVariant[exercise.category] ?? 'neutral'}
-                          size="xs"
-                        >
-                          {CATEGORY_LABELS[exercise.category] ?? exercise.category}
-                        </Badge>
-                        {(tonnage.perExercise.get(exIndex) ?? 0) > 0 && (
-                          <span className="text-xs text-[var(--color-text-muted)] tabular-nums">
-                            {formatTonnage(tonnage.perExercise.get(exIndex) ?? 0).value}
-                            {formatTonnage(tonnage.perExercise.get(exIndex) ?? 0).unit}
-                          </span>
-                        )}
-                      </>
-                    )}
+      <Card elevation="raised" padding="spacious">
+        <CardBody>
+          <h2 className="text-base font-semibold text-[var(--color-text-base)] mb-4">
+            Übungen ({exercises.filter((ex) => ex.name.trim()).length || exercises.length})
+          </h2>
+
+          <div className="space-y-6">
+            {exercises.map((exercise) => (
+              <div
+                key={exercise.id}
+                className="rounded-[var(--radius-component-md)] border border-[var(--color-border-default)] p-4 space-y-4"
+              >
+                {/* Exercise name + category + delete */}
+                <div className="flex items-start gap-2 flex-wrap sm:flex-nowrap">
+                  <div className="flex-1 min-w-0 basis-full sm:basis-auto">
+                    <Input
+                      value={exercise.name}
+                      onChange={(e) => updateExercise(exercise.id, { name: e.target.value })}
+                      placeholder="Übungsname"
+                      inputSize="md"
+                    />
                   </div>
-                  <div className="flex items-center gap-1">
-                    {exercise.name && (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() =>
-                          updateExercise(exercise.id, { collapsed: !exercise.collapsed })
+                  <div className="flex items-center gap-2">
+                    <div className="w-32 sm:w-36 shrink-0">
+                      <Select
+                        options={CATEGORY_SELECT_OPTIONS}
+                        value={exercise.category}
+                        onChange={(val) =>
+                          updateExercise(exercise.id, {
+                            category: (val as ExerciseCategory) || 'push',
+                          })
                         }
-                        aria-label={exercise.collapsed ? 'Aufklappen' : 'Zuklappen'}
-                      >
-                        {exercise.collapsed ? (
-                          <ChevronDown className="w-4 h-4" />
-                        ) : (
-                          <ChevronUp className="w-4 h-4" />
-                        )}
-                      </Button>
-                    )}
+                        inputSize="md"
+                      />
+                    </div>
                     <Button
                       variant="ghost"
                       size="sm"
                       onClick={() => removeExercise(exercise.id)}
                       aria-label="Übung entfernen"
                     >
-                      <Trash2 className="w-4 h-4 text-[var(--color-text-error)]" />
+                      <Trash2 className="w-4 h-4 text-[var(--color-text-muted)]" />
                     </Button>
                   </div>
                 </div>
 
-                {/* Exercise Name (with suggestions) */}
-                {!exercise.collapsed && (
-                  <>
-                    <div
-                      className="relative"
-                      ref={showSuggestions === exercise.id ? suggestionsRef : undefined}
+                {/* Sets header */}
+                <div className="grid grid-cols-[auto_1fr_1fr_1fr_auto] gap-2 items-center px-1">
+                  <span className="text-xs text-[var(--color-text-muted)] w-6 text-center">#</span>
+                  <span className="text-xs text-[var(--color-text-muted)]">Wdh.</span>
+                  <span className="text-xs text-[var(--color-text-muted)]">kg</span>
+                  <span className="text-xs text-[var(--color-text-muted)]">Status</span>
+                  <span className="w-8" />
+                </div>
+
+                {/* Set rows */}
+                {exercise.sets.map((set, setIndex) => (
+                  <div
+                    key={set.id}
+                    className={`grid grid-cols-[auto_1fr_1fr_1fr_auto] gap-2 items-center px-1 ${
+                      set.status === 'skipped' ? 'opacity-50' : ''
+                    }`}
+                  >
+                    <span className="text-sm text-[var(--color-text-muted)] w-6 text-center tabular-nums">
+                      {setIndex + 1}
+                    </span>
+                    <NumberInput
+                      value={set.reps}
+                      onChange={(val) => updateSet(exercise.id, set.id, { reps: val })}
+                      min={0}
+                      max={999}
+                      step={1}
+                      inputSize="sm"
+                      decrementLabel="Reps reduzieren"
+                      incrementLabel="Reps erhöhen"
+                    />
+                    <NumberInput
+                      value={set.weight_kg}
+                      onChange={(val) => updateSet(exercise.id, set.id, { weight_kg: val })}
+                      min={0}
+                      max={999}
+                      step={2.5}
+                      inputSize="sm"
+                      decrementLabel="Gewicht reduzieren"
+                      incrementLabel="Gewicht erhöhen"
+                    />
+                    <Select
+                      options={STATUS_SELECT_OPTIONS}
+                      value={set.status}
+                      onChange={(val) =>
+                        updateSet(exercise.id, set.id, {
+                          status: (val as SetStatus) || 'completed',
+                        })
+                      }
+                      inputSize="sm"
+                    />
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => removeSet(exercise.id, set.id)}
+                      aria-label={`Satz ${setIndex + 1} entfernen`}
+                      className="!p-1"
                     >
-                      <Input
-                        value={exercise.name}
-                        onChange={(e) => {
-                          updateExercise(exercise.id, { name: e.target.value });
-                          setShowSuggestions(exercise.id);
-                        }}
-                        onFocus={() => setShowSuggestions(exercise.id)}
-                        placeholder="Übungsname (z.B. Bankdrücken)"
-                        inputSize="md"
-                      />
-                      {showSuggestions === exercise.id && (
-                        <div className="absolute z-10 mt-1 w-full rounded-[var(--radius-component-md)] bg-[var(--color-bg-elevated)] border border-[var(--color-border-default)] shadow-[var(--shadow-md)] max-h-48 overflow-y-auto">
-                          {getFilteredSuggestions(exercise.name).map((ex) => (
-                            <button
-                              key={ex.id}
-                              type="button"
-                              className="w-full text-left px-3 py-2.5 text-sm text-[var(--color-text-base)] hover:bg-[var(--color-bg-muted)] transition-colors duration-150 motion-reduce:transition-none flex items-center justify-between"
-                              onClick={() => selectSuggestion(exercise.id, ex)}
-                            >
-                              <span>{ex.name}</span>
-                              <Badge
-                                variant={categoryBadgeVariant[ex.category] ?? 'neutral'}
-                                size="xs"
-                              >
-                                {CATEGORY_LABELS[ex.category] ?? ex.category}
-                              </Badge>
-                            </button>
-                          ))}
-                          {getFilteredSuggestions(exercise.name).length === 0 && (
-                            <p className="px-3 py-2.5 text-xs text-[var(--color-text-muted)]">
-                              Keine Übung gefunden. Name wird neu angelegt.
-                            </p>
-                          )}
-                        </div>
-                      )}
-                    </div>
+                      <Trash2 className="w-4 h-4 text-[var(--color-text-muted)]" />
+                    </Button>
+                  </div>
+                ))}
 
-                    {/* Category selector */}
-                    {exercise.name && !libraryExercises.some((l) => l.name === exercise.name) && (
-                      <div className="flex items-center gap-2 flex-wrap">
-                        <span className="text-xs text-[var(--color-text-muted)]">Kategorie:</span>
-                        {CATEGORY_OPTIONS.map((cat) => (
-                          <button
-                            key={cat.value}
-                            type="button"
-                            onClick={() => updateExercise(exercise.id, { category: cat.value })}
-                            className={`px-2.5 py-1 text-xs rounded-[var(--radius-component-sm)] transition-colors duration-150 motion-reduce:transition-none ${
-                              exercise.category === cat.value
-                                ? 'bg-[var(--color-bg-primary-subtle)] text-[var(--color-primary-1-600)] font-medium'
-                                : 'bg-[var(--color-bg-surface)] text-[var(--color-text-muted)] hover:bg-[var(--color-bg-muted)]'
-                            }`}
-                          >
-                            {cat.label}
-                          </button>
-                        ))}
-                      </div>
-                    )}
-
-                    {/* Sets */}
-                    {exercise.name && (
-                      <div className="space-y-2">
-                        {/* Header row */}
-                        <div className="grid grid-cols-[auto_1fr_1fr_auto] gap-2 items-center px-1">
-                          <span className="text-xs text-[var(--color-text-muted)] w-6 text-center">
-                            #
-                          </span>
-                          <span className="text-xs text-[var(--color-text-muted)]">Reps</span>
-                          <span className="text-xs text-[var(--color-text-muted)]">
-                            Gewicht (kg)
-                          </span>
-                          <span className="w-8" />
-                        </div>
-
-                        {/* Set rows */}
-                        {exercise.sets.map((set, setIndex) => (
-                          <div
-                            key={set.id}
-                            className={`grid grid-cols-[auto_1fr_1fr_auto] gap-2 items-center rounded-[var(--radius-component-md)] px-1 py-1 ${
-                              set.status === 'skipped' ? 'opacity-50' : ''
-                            }`}
-                          >
-                            <button
-                              type="button"
-                              onClick={() => {
-                                const statusCycle: SetStatus[] = [
-                                  'completed',
-                                  'reduced',
-                                  'skipped',
-                                ];
-                                const currentIdx = statusCycle.indexOf(set.status);
-                                const nextStatus =
-                                  statusCycle[(currentIdx + 1) % statusCycle.length];
-                                updateSet(exercise.id, set.id, { status: nextStatus });
-                              }}
-                              className={`w-6 h-6 rounded-full text-xs font-medium flex items-center justify-center transition-colors duration-150 motion-reduce:transition-none ${
-                                set.status === 'completed'
-                                  ? 'bg-[var(--color-bg-success-subtle)] text-[var(--color-text-success)]'
-                                  : set.status === 'reduced'
-                                    ? 'bg-[var(--color-bg-warning-subtle)] text-[var(--color-text-warning)]'
-                                    : 'bg-[var(--color-bg-surface)] text-[var(--color-text-disabled)]'
-                              }`}
-                              aria-label={`Satz ${setIndex + 1} Status: ${set.status}`}
-                              title="Tippen zum Ändern: Vollständig → Reduziert → Übersprungen"
-                            >
-                              {setIndex + 1}
-                            </button>
-                            <NumberInput
-                              value={set.reps}
-                              onChange={(val) => updateSet(exercise.id, set.id, { reps: val })}
-                              min={0}
-                              max={999}
-                              step={1}
-                              inputSize="sm"
-                              decrementLabel="Reps reduzieren"
-                              incrementLabel="Reps erhöhen"
-                            />
-                            <NumberInput
-                              value={set.weight_kg}
-                              onChange={(val) => updateSet(exercise.id, set.id, { weight_kg: val })}
-                              min={0}
-                              max={999}
-                              step={2.5}
-                              inputSize="sm"
-                              decrementLabel="Gewicht reduzieren"
-                              incrementLabel="Gewicht erhöhen"
-                            />
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => removeSet(exercise.id, set.id)}
-                              aria-label={`Satz ${setIndex + 1} entfernen`}
-                              className="!p-1"
-                            >
-                              <Trash2 className="w-3.5 h-3.5 text-[var(--color-text-muted)]" />
-                            </Button>
-                          </div>
-                        ))}
-
-                        {/* Add set + Quick-Add */}
-                        <div className="flex items-center gap-2 pt-1">
-                          <Button variant="ghost" size="sm" onClick={() => addSet(exercise.id)}>
-                            <Plus className="w-3.5 h-3.5 mr-1" />
-                            Satz
-                          </Button>
-                          {exercise.name.trim() && (
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => loadLastSets(exercise.id, exercise.name)}
-                            >
-                              <Copy className="w-3.5 h-3.5 mr-1" />
-                              Letzte Session
-                            </Button>
-                          )}
-                        </div>
-                      </div>
-                    )}
-                  </>
-                )}
-
-                {/* Collapsed summary */}
-                {exercise.collapsed && exercise.name && (
-                  <p className="text-sm text-[var(--color-text-muted)]">
-                    {exercise.sets.length} Sätze ·{' '}
-                    {exercise.sets
-                      .filter((s) => s.status !== 'skipped')
-                      .reduce((sum, s) => sum + s.reps, 0)}{' '}
-                    Reps ·{' '}
-                    {Math.round(
-                      exercise.sets
-                        .filter((s) => s.status !== 'skipped')
-                        .reduce((sum, s) => sum + s.reps * s.weight_kg, 0),
-                    )}{' '}
-                    kg Tonnage
-                  </p>
-                )}
+                {/* Add set */}
+                <div className="flex justify-center pt-1">
+                  <Button variant="ghost" size="sm" onClick={() => addSet(exercise.id)}>
+                    <Plus className="w-3.5 h-3.5 mr-1" />
+                    Satz hinzufügen
+                  </Button>
+                </div>
               </div>
-            </CardBody>
-          </Card>
-        ))}
+            ))}
 
-        {/* Add exercise button */}
-        <Button variant="secondary" onClick={addExercise} className="w-full">
-          <Plus className="w-4 h-4 mr-2" />
-          Übung hinzufügen
-        </Button>
-      </div>
+            {/* Add exercise button */}
+            <div className="flex justify-center">
+              <Button variant="ghost" onClick={addExercise}>
+                <Plus className="w-4 h-4 mr-2" />
+                Übung hinzufügen
+              </Button>
+            </div>
+          </div>
+        </CardBody>
+      </Card>
 
       {/* RPE + Notes */}
       <Card elevation="raised" padding="spacious">


### PR DESCRIPTION
## Summary
- Erstellen- und Bearbeiten-UI verwenden jetzt identisches, einfaches Layout
- Übungsname: Input + Select-Dropdown (Kategorie) + Trash-Button
- Sätze: NumberInput (Wdh.) + NumberInput (kg) + Select (Status) + Trash
- Entfernt: Exercise-Library-Suggestions, Category-Badges, farbige Status-Kreise, Tonnage pro Übung, Collapse/Expand, "Letzte Session"-Quick-Load
- Mobile-responsive: flex-wrap auf 375px
- 145 Tests grün, -705 LOC netto

## Test plan
- [x] ESLint 0 Warnings
- [x] Prettier check bestanden
- [x] TypeScript kompiliert
- [x] Vitest 145 Tests grün
- [x] Mobile-Screenshot bei 375px geprüft
- [x] Desktop-Screenshot geprüft
- [x] DS-Compliance-Audit bestanden

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)