### PR TITLE
docs: CLAUDE.md + CLEAN_CODE.md erweitern (#204)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@
 - [DESIGN_REVIEW.md](docs/DESIGN_REVIEW.md) — UX & Design Review Checkliste
 - [DOMAIN_MODEL.md](docs/DOMAIN_MODEL.md) — Domänenmodell (15 Entities, 200+ Felder)
 - [TRAINING_CONTEXT.md](docs/TRAINING_CONTEXT.md) — Trainingskontext (HM Sub-2h)
+- [CLEAN_CODE.md](docs/CLEAN_CODE.md) — Clean Code & SOLID Regeln
 
 ---
 
@@ -34,7 +35,8 @@ Vor der ersten Zeile Code:
 1. **PROJEKT_REGELN.md lesen** — Mobile-First, Nordlig DS, API-Design, Testing
 2. **DESIGN_REVIEW.md lesen** — 5 Säulen, 7 Kriterien, Nordlig-Heuristik
 3. **DOMAIN_MODEL.md lesen** — Entities und deren Beziehungen verstehen
-4. Bei UI-Änderungen: relevante Nordlig DS Komponenten in Storybook prüfen
+4. **CLEAN_CODE.md lesen** — Clean Code & SOLID Regeln, Grenzwerte
+5. Bei UI-Änderungen: relevante Nordlig DS Komponenten in Storybook prüfen
 
 ### Phase 1: Issue & Branch
 
@@ -63,6 +65,13 @@ Vor der ersten Zeile Code:
 **Für beide:**
 - Kleine, fokussierte Commits
 - Tests MÜSSEN vor dem Commit grün sein
+- **Clean Code Regeln einhalten (CLEAN_CODE.md):**
+  - Funktionen < 80 Zeilen (hart: < 150)
+  - Komponenten < 500 Zeilen
+  - Max 5 Parameter pro Funktion (sonst Parameter-Objekt)
+  - Cyclomatic Complexity < 10 (hart: < 15)
+  - Keine Code-Duplikation (DRY)
+  - Single Responsibility: Eine Klasse/Komponente = ein Grund sich zu ändern
 
 ### Phase 3: Quality Gates
 
@@ -186,6 +195,14 @@ gh api repos/NCS23/training-analyzer/issues -X POST \
 - ❌ Synchrone DB-Operationen → ✅ Async
 - ❌ Hardcodierte Konfiguration → ✅ Pydantic Settings / Environment
 
+### Clean Code (beide)
+- ❌ Funktion > 80 Zeilen → ✅ In Hilfsfunktionen aufbrechen
+- ❌ > 5 Parameter → ✅ Parameter-Objekt (DTO / Props Interface)
+- ❌ Duplizierter Code → ✅ Extrahieren und importieren
+- ❌ God-Component > 500 Zeilen → ✅ Custom Hooks + Sub-Components
+- ❌ 10+ useState in einer Komponente → ✅ useReducer oder Custom Hooks
+- ❌ Neues `# type: ignore` / `// eslint-disable` / `# noqa` ohne Begründung → ✅ Problem lösen
+
 ---
 
 ## Definition of Done
@@ -200,6 +217,9 @@ Ein Feature ist DONE wenn:
 - [ ] Mobile-First geprüft (375px iPhone SE)
 - [ ] Touch-Targets >= 44×44px
 - [ ] Nordlig DS Komponenten verwendet (keine eigenen Primitives)
+- [ ] Clean Code: Keine neue Funktion > 80 Zeilen, keine neue Komponente > 500 Zeilen
+- [ ] Clean Code: Keine neuen `# type: ignore`, `// eslint-disable`, `# noqa` ohne Begründung
+- [ ] Clean Code: Keine duplizierten Konstanten/Logik
 - [ ] CI-Pipeline grün
 - [ ] GitHub Issue kommentiert und geschlossen
 

--- a/docs/CLEAN_CODE.md
+++ b/docs/CLEAN_CODE.md
@@ -1,0 +1,270 @@
+# Clean Code & SOLID — Projektregeln
+
+> Referenz für alle Entwickler (Mensch und KI). Basierend auf Robert C. Martin.
+
+---
+
+## SOLID-Prinzipien
+
+### Single Responsibility (SRP)
+
+**Eine Klasse/Funktion/Komponente hat genau einen Grund, sich zu ändern.**
+
+Projektbeispiele:
+- `csv_parser.py` — nur CSV-Parsing, keine Validierung oder DB-Logik
+- `training_type_classifier.py` — nur Klassifizierung, kein Datenbankzugriff
+- Jede React-Komponente rendert eine Sache, Business-Logik in Custom Hooks
+
+Verstöße (werden in E16 behoben):
+- `SessionDetail.tsx` (1656 Zeilen) — Daten laden, rendern, editieren, Karte, Notes, Laps
+- `DayCard.tsx` (1344 Zeilen) — Card-Rendering + 2 Dialoge + Utilities
+
+### Open/Closed (OCP)
+
+**Offen für Erweiterung, geschlossen für Modifikation.**
+
+Projektbeispiele:
+- `TrainingParser` Interface — neuer Parser (FIT, TCX) ohne bestehenden Code zu ändern
+- AI Provider Strategy — Claude, OpenAI, Ollama über gemeinsames Interface
+- Segment-Type-System — neue Types über `taxonomy.py` ohne Classifier-Änderung
+
+### Liskov Substitution (LSP)
+
+**Subtypen müssen ihre Basistypen ersetzen können.**
+
+Projektbeispiele:
+- Alle `TrainingParser`-Implementierungen liefern dasselbe `ParsedWorkout`-Format
+- AI Provider liefern alle `AnalysisResult` unabhängig vom Backend
+
+### Interface Segregation (ISP)
+
+**Viele spezifische Interfaces statt eines großen.**
+
+Projektbeispiele:
+- API-Routers aufgeteilt: `sessions.py`, `training_plans.py`, `weekly_plan.py`
+- Frontend API-Layer: `sessionsApi.ts`, `plansApi.ts`, `goalsApi.ts`
+
+### Dependency Inversion (DIP)
+
+**Abhängigkeit von Abstraktionen, nicht von Implementierungen.**
+
+Projektbeispiele:
+- Endpoints hängen von `TrainingParser` ab, nicht von `CSVParser`
+- AI Service hängt von Provider-Interface ab, nicht von `AnthropicClient`
+- React Query als Abstraktion über HTTP-Calls
+
+---
+
+## Clean Code Grenzwerte
+
+| Metrik | Zielwert | Hartes Maximum | Durchgesetzt durch |
+|--------|----------|----------------|--------------------|
+| Funktionslänge | < 40 Zeilen | < 80 Zeilen | ESLint `max-lines-per-function`, Ruff `PLR0915` |
+| Komponenten-Länge | < 300 Zeilen | < 500 Zeilen | Code Review |
+| Cyclomatic Complexity | < 10 | < 15 | ESLint `complexity`, Ruff `C901` |
+| Parameter pro Funktion | < 4 | < 6 | ESLint `max-params`, Ruff `PLR0913` |
+| Verschachtelungstiefe | < 3 | < 4 | ESLint `max-depth` |
+| useState pro Komponente | < 5 | < 8 | Code Review |
+| Branches (if/elif/else) | < 8 | < 12 | Ruff `PLR0912` |
+| Return Statements | < 4 | < 6 | Ruff `PLR0911` |
+
+**Aktuell gelten die harten Maxima als warn-Level.** Nach Abschluss der E16-Stories (B1-B2, F1-F4) werden die Zielwerte als error-Level aktiviert.
+
+---
+
+## Clean Code Regeln
+
+### 1. Kleine Funktionen
+
+```python
+# Schlecht: 100+ Zeilen mit mehreren Verantwortlichkeiten
+def upload_csv(file, date, type, subtype, notes, rpe, overrides, type_override, planned_id, db):
+    # Validierung, Parsing, Mapping, DB-Speicherung — alles in einer Funktion
+    ...
+
+# Gut: Kleine Funktionen mit einer Aufgabe
+async def upload_csv(file: UploadFile, form: SessionUploadForm, db: AsyncSession):
+    content = await validate_upload_file(file, ".csv")
+    return await process_upload(content, csv_parser, form, db)
+```
+
+### 2. Aussagekräftige Namen
+
+```typescript
+// Schlecht
+const d = new Date();
+const arr = sessions.filter(s => s.t === "interval");
+function calc(a: number, b: number) { ... }
+
+// Gut
+const trainingDate = new Date();
+const intervalSessions = sessions.filter(s => s.type === "interval");
+function calculateWeeklyVolume(distanceKm: number, durationMin: number) { ... }
+```
+
+### 3. DRY — Don't Repeat Yourself
+
+```typescript
+// Schlecht: Konstanten in 3 Dateien dupliziert
+// DayCard.tsx
+const RUN_TYPE_LABELS = { easy: "Lockerer Lauf", ... };
+// TemplatePickerDialog.tsx
+const RUN_TYPE_LABELS = { easy: "Lockerer Lauf", ... };
+
+// Gut: Eine Quelle der Wahrheit
+// constants/plan.ts
+export const RUN_TYPE_LABELS = { easy: "Lockerer Lauf", ... } as const;
+```
+
+### 4. Keine Magic Values
+
+```python
+# Schlecht
+if heart_rate > 180:
+    return "too_high"
+if pace < 3.5:
+    return "sprint"
+
+# Gut
+MAX_HEART_RATE = 180
+SPRINT_PACE_THRESHOLD = 3.5
+
+if heart_rate > MAX_HEART_RATE:
+    return "too_high"
+if pace < SPRINT_PACE_THRESHOLD:
+    return "sprint"
+```
+
+### 5. God-Components aufbrechen
+
+```typescript
+// Schlecht: 1600 Zeilen, 24 useState, 4 useEffect
+function SessionDetail() {
+  const [session, setSession] = useState(null);
+  const [gpsData, setGpsData] = useState(null);
+  const [notes, setNotes] = useState("");
+  // ... 21 weitere useState
+
+  useEffect(() => { /* Daten laden */ }, []);
+  useEffect(() => { /* Notes auto-save */ }, [notes]);
+  // ... 2 weitere useEffect
+
+  return (/* 500 Zeilen JSX */);
+}
+
+// Gut: Custom Hooks + Sub-Components
+function SessionDetail() {
+  const { session, gpsData, isLoading } = useSessionData(id);
+  const { notes, updateNotes } = useSessionNotes(id);
+  const { editState, handlers } = useSessionEditing(session);
+
+  if (isLoading) return <LoadingSkeleton />;
+
+  return (
+    <SessionHeader session={session} />
+    <SessionMapSection gpsData={gpsData} />
+    <SessionLapsSection laps={session.laps} />
+    <SessionNotesSection notes={notes} onChange={updateNotes} />
+  );
+}
+```
+
+### 6. Parameter-Objekte statt langer Parameterlisten
+
+```python
+# Schlecht: 10 Parameter
+@router.post("/upload/csv")
+async def upload_csv(
+    csv_file: UploadFile,
+    training_date: date = Form(...),
+    training_type: str = Form(...),
+    training_subtype: str | None = Form(None),
+    notes: str | None = Form(None),
+    rpe: int | None = Form(None),
+    lap_overrides_json: str | None = Form(None),
+    training_type_override: str | None = Form(None),
+    planned_entry_id: int | None = Form(None),
+    db: AsyncSession = Depends(get_db),
+): ...
+
+# Gut: Parameter-Objekt
+@router.post("/upload/csv")
+async def upload_csv(
+    csv_file: UploadFile,
+    form: SessionUploadForm = Depends(),
+    db: AsyncSession = Depends(get_db),
+): ...
+```
+
+---
+
+## Self-Review Checkliste
+
+Vor jedem Commit prüfen:
+
+### Funktionen
+- [ ] Keine Funktion > 80 Zeilen?
+- [ ] Jede Funktion hat genau eine Aufgabe?
+- [ ] Max 5 Parameter (sonst Parameter-Objekt)?
+- [ ] Complexity < 10 (wenige if/elif/else)?
+- [ ] Aussagekräftige Funktionsnamen?
+
+### Komponenten (Frontend)
+- [ ] Keine Komponente > 500 Zeilen?
+- [ ] Max 8 useState (sonst useReducer/Custom Hook)?
+- [ ] Business-Logik in Custom Hooks, nicht in Komponenten?
+- [ ] Keine inline definierten Sub-Components > 30 Zeilen?
+
+### Duplikation
+- [ ] Keine kopierten Konstanten (DRY)?
+- [ ] Keine kopierten Logik-Blöcke?
+- [ ] Gemeinsame Patterns extrahiert?
+
+### Types & Unterdrückung
+- [ ] Keine neuen `# type: ignore` ohne Begründung?
+- [ ] Keine neuen `// eslint-disable` ohne Begründung?
+- [ ] Keine neuen `# noqa` ohne Begründung?
+
+---
+
+## Linter-Konfiguration
+
+### ESLint (Frontend)
+
+Aktive Clean Code Regeln in `frontend/eslint.config.js`:
+```js
+complexity: ["warn", { max: 15 }],           // Ziel: 10
+"max-depth": ["warn", { max: 4 }],           // Ziel: 3
+"max-params": ["warn", { max: 5 }],          // Ziel: 4
+"max-lines-per-function": ["warn", { max: 100 }],  // Ziel: 80
+```
+
+### Ruff (Backend)
+
+Aktive Clean Code Regeln in `backend/pyproject.toml`:
+```toml
+[tool.ruff.lint]
+select = ["C90", "PLR"]  # mccabe + pylint refactor
+
+[tool.ruff.lint.mccabe]
+max-complexity = 15       # Ziel: 10
+
+[tool.ruff.lint.pylint]
+max-args = 8              # Ziel: 6
+max-branches = 12         # Ziel: 10
+max-returns = 6           # Ziel: 4
+max-statements = 50       # Ziel: 40
+```
+
+---
+
+## Refactoring-Roadmap (Epic E16)
+
+| Phase | Stories | Beschreibung |
+|-------|---------|--------------|
+| 1 (Done) | W1, W2 | Linter-Regeln + Dokumentation |
+| 2 | F3, B4 | Konstanten konsolidieren, Parameter-Objekte |
+| 3 | B1, B2 | Backend Upload-Duplikation, Classifier |
+| 4 | F1, F2 | SessionDetail + DayCard aufbrechen |
+| 5 | B3, F4 | type:ignore beseitigen, restliche Komponenten |
+| 6 | — | Thresholds auf Zielwerte verschärfen |


### PR DESCRIPTION
## Summary
- Neue Datei `docs/CLEAN_CODE.md` mit SOLID-Prinzipien, Grenzwerten, Code-Beispielen und Self-Review Checkliste
- CLAUDE.md: Phase 0 (Pflichtlektüre), Phase 2 (Clean Code Regeln), Verbotene Muster, Definition of Done erweitert

## Akzeptanzkriterien (#204)
- [x] `docs/CLEAN_CODE.md` existiert mit SOLID-Erklärungen + Beispielen
- [x] CLAUDE.md Phase 0, Phase 2, DoD, Verbotene Muster aktualisiert
- [x] MEMORY.md Pre-Commit Checkliste erweitert um Clean Code Checks

## Test plan
- [x] Keine Code-Änderungen — nur Dokumentation
- [x] CI-Jobs bestehen (keine Code-Quality-Auswirkung)

🤖 Generated with [Claude Code](https://claude.com/claude-code)