### PR TITLE
fix: Duplizierte Konstanten konsolidieren (#211)

### DIFF
--- a/.claude/design-review.md
+++ b/.claude/design-review.md
@@ -1,14 +1,16 @@
-# Design Review — Issue #199
+# Design Review — Issue #211
 
-> Mobile-First Set-Row Layout + Labels für Übungsformular
+> Duplizierte Konstanten konsolidieren
 
 ## 1. Nordlig DS Compliance
 
 - [x] Keine hardcodierten Farben (bg-white, bg-gray-*, text-red-* etc.)
 - [x] Keine hardcodierten Radii (rounded-sm/md/lg/xl/2xl)
-- [x] Keine hardcodierten Shadows (shadow-sm/md/lg) — `shadow-[var(--shadow-md)]` verwendet DS-Token (ds-ok)
-- [x] Keine nativen HTML-Elemente — Autocomplete-Suggestions verwenden `<button type="button">` als List-Items (akzeptabel)
+- [x] Keine hardcodierten Shadows (shadow-sm/md/lg) — `shadow-[var(--shadow-*)]` sind Token-basiert (ds-ok)
+- [x] Keine nativen HTML-Elemente (button, input, select, textarea)
 - [x] Nur Level-3/4 Tokens verwendet (keine L1/L2)
+
+Keine neuen UI-Elemente — nur Konstanten-Konsolidierung (Imports statt Duplikate).
 
 ## 2. Mobile-First Check (375px)
 
@@ -16,32 +18,30 @@
 screenshot: .claude/screenshots/mobile-375-exercise-edit.png
 
 **Befunde:**
-- Layout bricht nicht — Set-Rows wrappen auf Mobile korrekt (3-Spalten + Status/Delete in Zeile 2)
-- Kein horizontaler Overflow
-- Text ist lesbar (min. 14px)
-- NumberInput-Werte (Reps, Weight) auf Mobile sichtbar und bedienbar
-- Labels "Übungsname" und "Kategorie" sichtbar auf beiden Seiten
+- Keine visuellen Änderungen (reine Refactoring-Arbeit)
+- Layout und Darstellung identisch
 
 ## 3. Touch Targets
 
 - [x] Alle interaktiven Elemente >= 44x44px
-- [x] Buttons haben ausreichend Padding — NumberInput +/- Buttons 44px Touch-Target
+- [x] Buttons haben ausreichend Padding
 - [x] Links/Icons haben genug Abstand zueinander
+
+Keine UI-Änderungen — Touch Targets unverändert.
 
 ## 4. Weissraum & Spacing
 
-- [x] Container-Padding 24-32px (p-4 auf Card-Body-Level)
-- [x] Sektionen-Abstand 32-64px (space-y-6 = 24px)
+- [x] Container-Padding 24-32px
+- [x] Sektionen-Abstand 32-64px
 - [x] Weißraum-Anteil visuell ~30-40%
 - [x] Keine Card-on-Card Schatten
+
+Keine UI-Änderungen — Spacing unverändert.
 
 ## 5. Gesamtbewertung
 
 **Verdict:** PASS
 
 **Anmerkungen:**
-- Formular-Hintergründe: --color-input-bg (#fff) statt --color-bg-base (#e2e8f0)
-- Set-Row-Grid responsive: Mobile 3-Spalten mit Wrapping, Desktop 5-Spalten einzeilig
-- Labels für Übungsname und Kategorie ergänzt
-- hideTonnageSummary im Editor aktiviert
-- Button "Letztes Training übernehmen" wrapping-sicher
+Issue #211 ist ein reines Refactoring (Konstanten-Konsolidierung). Keine visuellen Änderungen.
+CATEGORY_LABELS in WeeklyPlan.tsx von Englisch (Legs, Drills) auf Deutsch (Beine, Lauf-ABC) korrigiert.

--- a/.claude/workflow-checklist.md
+++ b/.claude/workflow-checklist.md
@@ -1,29 +1,35 @@
-# Workflow Checklist — Issue #159
+# Workflow Checklist — Issue #211
 
 ## Phase 0: Pre-Code
 - [x] GitHub Issue gelesen (Akzeptanzkriterien + Taskbreakdown)
 - [x] PROJEKT_REGELN.md gelesen
-- [x] DESIGN_REVIEW.md gelesen (bei UI-Aenderungen)
-- [x] DOMAIN_MODEL.md gelesen (bei Datenmodell-Aenderungen)
+- [x] DESIGN_REVIEW.md gelesen (bei UI-Änderungen)
+- [x] CLEAN_CODE.md gelesen
 
 ## Phase 1: Branch & Board
-- [x] Feature-Branch erstellt (kein main!)
+- [x] Feature-Branch erstellt (feature/211-consolidate-constants)
 - [x] Issue auf "In Progress" im Project Board gesetzt
 
 ## Phase 2: Implementation
-- [x] Vite manualChunks konfiguriert (vendor-react + vendor-ui Split)
-- [x] rollup-plugin-visualizer als devDependency installiert
+- [x] constants/plan.ts erstellt (DAY_LABELS, RUN_TYPE_LABELS, SESSION_TYPE_OPTIONS)
+- [x] constants/training.ts erweitert (CATEGORY_LABELS)
+- [x] DayCard.tsx — lokale DAY_LABELS, RUN_TYPE_LABELS, SESSION_TYPE_OPTIONS entfernt → Import
+- [x] MoveSessionDialog.tsx — lokale DAY_LABELS entfernt → Import
+- [x] PhaseWeeklyTemplateEditor.tsx — lokale DAY_LABELS, SESSION_TYPE_OPTIONS entfernt → Import
+- [x] TemplatePickerDialog.tsx — lokale RUN_TYPE_LABELS entfernt → Import
+- [x] WeeklyPlan.tsx — lokale RUN_TYPE_LABELS + CATEGORY_LABELS (EN→DE) entfernt → Import
+- [x] StrengthProgression.tsx — lokale CATEGORY_LABELS entfernt → Import
+- [x] exercise-helpers.ts — lokale CATEGORY_LABELS → Re-Export aus constants/training.ts
+- [x] plan-helpers.ts — lokale DAY_LABELS → Re-Export aus constants/plan.ts
 
 ## Phase 3: Quality Gates
+- [x] TSC --noEmit bestanden
 - [x] ESLint 0 Warnings
-- [x] Prettier check bestanden
-- [x] TypeScript kompiliert
-- [x] Vitest alle Tests gruen (148 tests)
-- [x] Keine UI-Aenderungen — kein Design Review noetig
+- [x] Vitest 145 Tests bestanden
 
 ## Phase 4: Abschluss (post-push, not validated by hook)
 - [ ] Commit + Push auf Feature-Branch
-- [ ] CI gruen
+- [ ] CI grün
 - [ ] GitHub Issue kommentiert
 - [ ] GitHub Issue geschlossen
 - [ ] Project Board Status auf "Done"

--- a/frontend/src/components/DayCard.tsx
+++ b/frontend/src/components/DayCard.tsx
@@ -53,6 +53,7 @@ import type {
 import type { Segment } from '@/api/segment';
 import { createEmptySegment } from '@/api/segment';
 import { getPresetSegments, hasSegmentData } from '@/config/segmentPresets';
+import { DAY_LABELS, RUN_TYPE_LABELS, SESSION_TYPE_OPTIONS } from '@/constants/plan';
 import { lapTypeLabels } from '@/constants/training';
 import { getSessionTemplate, type TemplateExercise } from '@/api/session-templates';
 import { formatTonnage } from '@/hooks/useTonnageCalc';
@@ -63,20 +64,6 @@ import { StrengthExerciseEditor } from './StrengthExerciseEditor';
 import { TemplatePickerDialog } from './TemplatePickerDialog';
 
 // --- Constants ---
-
-const DAY_LABELS = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'];
-
-const RUN_TYPE_LABELS: Record<string, string> = {
-  recovery: 'Regeneration',
-  easy: 'Lockerer Lauf',
-  long_run: 'Langer Lauf',
-  progression: 'Steigerungslauf',
-  tempo: 'Tempolauf',
-  intervals: 'Intervalle',
-  repetitions: 'Repetitions',
-  fartlek: 'Fahrtspiel',
-  race: 'Wettkampf',
-};
 
 const RUN_TYPE_OPTIONS = [
   { value: 'recovery', label: 'Regeneration' },
@@ -95,11 +82,6 @@ const INITIAL_TYPE_OPTIONS = [
   { value: 'running', label: 'Laufen' },
   { value: 'strength', label: 'Kraft' },
   { value: 'rest', label: 'Ruhetag' },
-];
-
-const SESSION_TYPE_OPTIONS = [
-  { value: 'running', label: 'Laufen' },
-  { value: 'strength', label: 'Kraft' },
 ];
 
 const MAX_SESSIONS = 3;

--- a/frontend/src/components/MoveSessionDialog.tsx
+++ b/frontend/src/components/MoveSessionDialog.tsx
@@ -1,6 +1,5 @@
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@nordlig/components';
-
-const DAY_LABELS = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'];
+import { DAY_LABELS } from '@/constants/plan';
 
 interface MoveSessionDialogProps {
   open: boolean;

--- a/frontend/src/components/PhaseWeeklyTemplateEditor.tsx
+++ b/frontend/src/components/PhaseWeeklyTemplateEditor.tsx
@@ -37,11 +37,10 @@ import type { TemplateExercise } from '@/api/session-templates';
 import { getSessionTemplate } from '@/api/session-templates';
 import type { SessionTemplateSummary } from '@/api/session-templates';
 import { getPresetSegments, hasSegmentData } from '@/config/segmentPresets';
+import { DAY_LABELS, SESSION_TYPE_OPTIONS } from '@/constants/plan';
 import { RunDetailsEditor } from './RunDetailsEditor';
 import { StrengthExerciseEditor } from './StrengthExerciseEditor';
 import { TemplatePickerDialog } from './TemplatePickerDialog';
-
-const DAY_LABELS = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'];
 
 type DayType =
   | 'rest'
@@ -76,11 +75,6 @@ const RUN_TYPE_OPTIONS: { value: RunType; label: string }[] = [
   { value: 'repetitions', label: 'Repetitions' },
   { value: 'fartlek', label: 'Fartlek' },
   { value: 'race', label: 'Wettkampf' },
-];
-
-const SESSION_TYPE_OPTIONS = [
-  { value: 'running', label: 'Laufen' },
-  { value: 'strength', label: 'Kraft' },
 ];
 
 const DAY_TYPE_OPTIONS = [

--- a/frontend/src/components/TemplatePickerDialog.tsx
+++ b/frontend/src/components/TemplatePickerDialog.tsx
@@ -1,19 +1,8 @@
 import { useEffect, useState } from 'react';
 import { Button, Dialog, DialogContent, DialogHeader, DialogTitle } from '@nordlig/components';
 import { Dumbbell, Footprints, Loader2 } from 'lucide-react';
+import { RUN_TYPE_LABELS } from '@/constants/plan';
 import { listSessionTemplates, type SessionTemplateSummary } from '@/api/session-templates';
-
-const RUN_TYPE_LABELS: Record<string, string> = {
-  recovery: 'Regeneration',
-  easy: 'Lockerer Lauf',
-  long_run: 'Langer Lauf',
-  progression: 'Steigerungslauf',
-  tempo: 'Tempolauf',
-  intervals: 'Intervalle',
-  repetitions: 'Repetitions',
-  fartlek: 'Fahrtspiel',
-  race: 'Wettkampf',
-};
 
 interface TemplatePickerDialogProps {
   open: boolean;

--- a/frontend/src/components/plan-helpers.ts
+++ b/frontend/src/components/plan-helpers.ts
@@ -44,7 +44,7 @@ export const STATUS_BADGE_VARIANTS: Record<PlanStatus, 'neutral' | 'info' | 'suc
     paused: 'warning',
   };
 
-export const DAY_LABELS = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'];
+export { DAY_LABELS } from '@/constants/plan';
 
 export function formatDateDE(d: Date | string | undefined | null): string {
   if (!d) return '—';

--- a/frontend/src/constants/plan.ts
+++ b/frontend/src/constants/plan.ts
@@ -1,0 +1,20 @@
+/** Plan-bezogene Konstanten — Single Source of Truth. */
+
+export const DAY_LABELS = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'] as const;
+
+export const RUN_TYPE_LABELS: Record<string, string> = {
+  recovery: 'Regeneration',
+  easy: 'Lockerer Lauf',
+  long_run: 'Langer Lauf',
+  progression: 'Steigerungslauf',
+  tempo: 'Tempolauf',
+  intervals: 'Intervalle',
+  repetitions: 'Repetitions',
+  fartlek: 'Fahrtspiel',
+  race: 'Wettkampf',
+};
+
+export const SESSION_TYPE_OPTIONS: { value: string; label: string }[] = [
+  { value: 'running', label: 'Laufen' },
+  { value: 'strength', label: 'Kraft' },
+];

--- a/frontend/src/constants/training.ts
+++ b/frontend/src/constants/training.ts
@@ -32,6 +32,15 @@ export const trainingTypeOptions = Object.entries(trainingTypeLabels).map(([valu
   label,
 }));
 
+export const CATEGORY_LABELS: Record<string, string> = {
+  push: 'Push',
+  pull: 'Pull',
+  legs: 'Beine',
+  core: 'Core',
+  cardio: 'Cardio',
+  drills: 'Lauf-ABC',
+};
+
 export const categoryBadgeVariant: Record<string, BadgeVariant> = {
   push: 'accent-bold',
   pull: 'primary',

--- a/frontend/src/pages/StrengthProgression.tsx
+++ b/frontend/src/pages/StrengthProgression.tsx
@@ -29,7 +29,7 @@ import {
   getPersonalRecords,
   getTonnageTrend,
 } from '@/api/progression';
-import { categoryBadgeVariant } from '@/constants/training';
+import { CATEGORY_LABELS, categoryBadgeVariant } from '@/constants/training';
 import type {
   ExerciseListItem,
   ExerciseHistoryResponse,
@@ -45,15 +45,6 @@ const TIME_RANGE_LABELS: Record<TimeRange, string> = {
   '28': '4 Wochen',
   '90': '3 Monate',
   '180': '6 Monate',
-};
-
-const CATEGORY_LABELS: Record<string, string> = {
-  push: 'Push',
-  pull: 'Pull',
-  legs: 'Beine',
-  core: 'Core',
-  cardio: 'Cardio',
-  drills: 'Lauf-ABC',
 };
 
 const PR_TYPE_LABELS: Record<string, string> = {

--- a/frontend/src/pages/WeeklyPlan.tsx
+++ b/frontend/src/pages/WeeklyPlan.tsx
@@ -54,20 +54,13 @@ import {
 } from '@/api/weekly-plan';
 import type { WeeklyPlanEntry, ComplianceResponse } from '@/api/weekly-plan';
 import { formatTonnage } from '@/hooks/useTonnageCalc';
+import { RUN_TYPE_LABELS } from '@/constants/plan';
+import { CATEGORY_LABELS } from '@/constants/training';
 import { DayCard } from '@/components/DayCard';
 import { SyncToPlanBar } from '@/components/SyncToPlanBar';
 import { SaveWeeklyPlanDialog } from '@/components/SaveWeeklyPlanDialog';
 
 // --- Helpers ---
-
-const CATEGORY_LABELS: Record<string, string> = {
-  push: 'Push',
-  pull: 'Pull',
-  legs: 'Legs',
-  core: 'Core',
-  cardio: 'Cardio',
-  drills: 'Drills',
-};
 
 function categoryLabel(key: string): string {
   return CATEGORY_LABELS[key] ?? key;
@@ -102,18 +95,6 @@ function formatDateRange(weekStart: string): string {
   }
   return `${startDay}. ${startMonth} – ${endDay}. ${endMonth}`;
 }
-
-const RUN_TYPE_LABELS: Record<string, string> = {
-  recovery: 'Regeneration',
-  easy: 'Lockerer Lauf',
-  long_run: 'Langer Lauf',
-  progression: 'Steigerungslauf',
-  tempo: 'Tempolauf',
-  intervals: 'Intervalle',
-  repetitions: 'Repetitions',
-  fartlek: 'Fahrtspiel',
-  race: 'Wettkampf',
-};
 
 // --- Component ---
 

--- a/frontend/src/utils/exercise-helpers.ts
+++ b/frontend/src/utils/exercise-helpers.ts
@@ -3,6 +3,7 @@
  * `SessionTemplateEditor` (full-page) and `StrengthExerciseEditor` (inline).
  */
 import type { ExerciseCategory, ExerciseType, TemplateExercise } from '@/api/session-templates';
+export { CATEGORY_LABELS } from '@/constants/training';
 
 // --- Internal form state ---
 
@@ -28,15 +29,6 @@ export const CATEGORY_OPTIONS: { value: ExerciseCategory; label: string }[] = [
   { value: 'cardio', label: 'Cardio' },
   { value: 'drills', label: 'Lauf-ABC' },
 ];
-
-export const CATEGORY_LABELS: Record<string, string> = {
-  push: 'Push',
-  pull: 'Pull',
-  legs: 'Beine',
-  core: 'Core',
-  cardio: 'Cardio',
-  drills: 'Lauf-ABC',
-};
 
 export const EXERCISE_TYPE_OPTIONS: { value: ExerciseType; label: string }[] = [
   { value: 'kraft', label: 'Kraft' },


### PR DESCRIPTION
## Summary
- `constants/plan.ts` erstellt: `DAY_LABELS`, `RUN_TYPE_LABELS`, `SESSION_TYPE_OPTIONS`
- `constants/training.ts` erweitert: `CATEGORY_LABELS` (deutsch, konsistent)
- 12 Duplikate in 8 Dateien durch Imports ersetzt
- WeeklyPlan `CATEGORY_LABELS`: EN→DE korrigiert (Legs→Beine, Drills→Lauf-ABC)

## Test plan
- [x] TSC --noEmit bestanden
- [x] ESLint 0 Warnings
- [x] Vitest 145 Tests bestanden
- [ ] CI grün

Closes #211