### PR TITLE
refactor: Classifier auf Rule Registry Pattern (OCP) (#206)

### DIFF
--- a/backend/app/services/training_type_classifier.py
+++ b/backend/app/services/training_type_classifier.py
@@ -4,10 +4,13 @@ Erkennt automatisch den Trainingstyp basierend auf:
 - HR-Zonen-Verteilung (Karvonen 5-Zone oder 3-Zone Fallback)
 - Session-Dauer
 - Lap-Analyse (Anzahl, HR-Variabilitaet, Pace-Konsistenz)
+
+Architektur: Classification Rules als Registry (Open/Closed Principle).
+Neuer Trainingstyp = neue _check_*-Funktion + Eintrag in CLASSIFICATION_RULES.
 """
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Callable, Optional
 
 # --- Konfigurierbare Schwellenwerte ---
 
@@ -72,28 +75,50 @@ class ClassificationResult:
 
 @dataclass
 class SessionMetrics:
-    """Aggregierte Session-Metriken fuer die Klassifizierung."""
+    """Vorberechnete Session-Metriken — Input fuer alle Rule Checks."""
 
-    duration_sec: int
-    hr_avg: Optional[int]
-    hr_max: Optional[int]
-    distance_km: Optional[float]
+    duration_min: float
     laps: list[dict]
-    hr_zone_distribution: Optional[dict]
-    pace_values: list[float]  # min/km pro Lap
+    zone_pcts: dict[str, float]
+    pace_values: list[float]
+    lap_hr_stats: dict
+
+
+# Type alias fuer Rule-Funktionen
+RuleCheck = Callable[
+    [SessionMetrics, ClassifierThresholds],
+    tuple[str, int, list[str]],
+]
 
 
 # --- Classifier ---
 
 
+def _build_metrics(
+    duration_sec: int,
+    laps: list[dict],
+    hr_zone_distribution: dict | None,
+) -> SessionMetrics:
+    """Bereitet Session-Metriken fuer die Rule Checks vor."""
+    return SessionMetrics(
+        duration_min=duration_sec / 60,
+        laps=laps,
+        zone_pcts=_extract_zone_percentages(hr_zone_distribution),
+        pace_values=_extract_pace_values(laps),
+        lap_hr_stats=_analyze_lap_hr(laps),
+    )
+
+
 def classify_training_type(
     duration_sec: int,
-    hr_avg: Optional[int],  # noqa: ARG001
-    hr_max: Optional[int],  # noqa: ARG001
-    distance_km: Optional[float],  # noqa: ARG001
-    laps: Optional[list[dict]],
-    hr_zone_distribution: Optional[dict],
+    laps: Optional[list[dict]] = None,
+    hr_zone_distribution: Optional[dict] = None,
     thresholds: Optional[ClassifierThresholds] = None,
+    *,
+    # Legacy kwargs — nicht mehr genutzt, aber backward-kompatibel
+    hr_avg: Optional[int] = None,  # noqa: ARG001
+    hr_max: Optional[int] = None,  # noqa: ARG001
+    distance_km: Optional[float] = None,  # noqa: ARG001
 ) -> ClassificationResult:
     """Klassifiziert den Trainingstyp basierend auf Session-Metriken.
 
@@ -101,107 +126,15 @@ def classify_training_type(
         ClassificationResult mit training_type, confidence (0-100), und Begründungen.
     """
     t = thresholds or DEFAULT_THRESHOLDS
-    laps = laps or []
+    metrics = _build_metrics(duration_sec, laps or [], hr_zone_distribution)
 
-    duration_min = duration_sec / 60
+    candidates = [
+        (name, score, reasons)
+        for rule in CLASSIFICATION_RULES
+        for name, score, reasons in [rule(metrics, t)]
+        if score > 0
+    ]
 
-    # Extrahiere Zone-Prozentsaetze
-    zone_pcts = _extract_zone_percentages(hr_zone_distribution)
-
-    # Pace-Werte aus Laps extrahieren
-    pace_values = _extract_pace_values(laps)
-
-    # HR-Verteilung ueber Laps
-    lap_hr_stats = _analyze_lap_hr(laps)
-
-    # Kandidaten mit Scores berechnen
-    candidates: list[tuple[str, int, list[str]]] = []
-
-    # 1. Race Check (hoechste Prioritaet bei extremer Intensitaet)
-    race_score, race_reasons = _check_race(
-        duration_min,
-        zone_pcts,
-        t,
-    )
-    if race_score > 0:
-        candidates.append(("race", race_score, race_reasons))
-
-    # 2. Intervals Check
-    interval_score, interval_reasons = _check_intervals(
-        laps,
-        lap_hr_stats,
-        t,
-    )
-    if interval_score > 0:
-        candidates.append(("intervals", interval_score, interval_reasons))
-
-    # 3. Repetitions Check (vor Tempo — kurze schnelle Laps)
-    reps_score, reps_reasons = _check_repetitions(
-        laps,
-        lap_hr_stats,
-        t,
-    )
-    if reps_score > 0:
-        candidates.append(("repetitions", reps_score, reps_reasons))
-
-    # 4. Progression Check (vor Tempo — abnehmende Pace)
-    prog_score, prog_reasons = _check_progression(
-        laps,
-        pace_values,
-        zone_pcts,
-        t,
-    )
-    if prog_score > 0:
-        candidates.append(("progression", prog_score, prog_reasons))
-
-    # 5. Tempo Check
-    tempo_score, tempo_reasons = _check_tempo(
-        duration_min,
-        zone_pcts,
-        pace_values,
-        t,
-    )
-    if tempo_score > 0:
-        candidates.append(("tempo", tempo_score, tempo_reasons))
-
-    # 6. Fartlek Check (nach Tempo — gemischte Pace)
-    fartlek_score, fartlek_reasons = _check_fartlek(
-        laps,
-        pace_values,
-        lap_hr_stats,
-        t,
-    )
-    if fartlek_score > 0:
-        candidates.append(("fartlek", fartlek_score, fartlek_reasons))
-
-    # 7. Long Run Check
-    long_run_score, long_run_reasons = _check_long_run(
-        duration_min,
-        zone_pcts,
-        t,
-    )
-    if long_run_score > 0:
-        candidates.append(("long_run", long_run_score, long_run_reasons))
-
-    # 8. Recovery Check
-    recovery_score, recovery_reasons = _check_recovery(
-        duration_min,
-        zone_pcts,
-        t,
-    )
-    if recovery_score > 0:
-        candidates.append(("recovery", recovery_score, recovery_reasons))
-
-    # 9. Easy Run (Default-Kandidat)
-    easy_score, easy_reasons = _check_easy(
-        duration_min,
-        zone_pcts,
-        t,
-    )
-    if easy_score > 0:
-        candidates.append(("easy", easy_score, easy_reasons))
-
-    # Bester Kandidat
     if not candidates:
         return ClassificationResult(
             training_type="easy",
@@ -210,12 +143,11 @@ def classify_training_type(
         )
 
     candidates.sort(key=lambda c: c[1], reverse=True)
-    best = candidates[0]
-
+    best_name, best_score, best_reasons = candidates[0]
     return ClassificationResult(
-        training_type=best[0],
-        confidence=best[1],
-        reasons=best[2],
+        training_type=best_name,
+        confidence=best_score,
+        reasons=best_reasons,
     )
 
 
@@ -223,54 +155,50 @@ def classify_training_type(
 
 
 def _check_race(
-    duration_min: float,
-    zone_pcts: dict[str, float],
+    m: SessionMetrics,
     t: ClassifierThresholds,
-) -> tuple[int, list[str]]:
+) -> tuple[str, int, list[str]]:
     """Prueft ob die Session ein Wettkampf/Race ist."""
     reasons: list[str] = []
     score = 0
 
-    high_zone_pct = zone_pcts.get("zone_4_plus", 0)
+    high_zone_pct = m.zone_pcts.get("zone_4_plus", 0)
 
-    if high_zone_pct >= t.race_min_zone4_plus_pct and duration_min >= t.race_min_duration_min:
+    if high_zone_pct >= t.race_min_zone4_plus_pct and m.duration_min >= t.race_min_duration_min:
         score = 70
         reasons.append(f"{high_zone_pct:.0f}% in Zone 4+ (>= {t.race_min_zone4_plus_pct}%)")
-        reasons.append(f"Dauer {duration_min:.0f} min (>= {t.race_min_duration_min} min)")
+        reasons.append(f"Dauer {m.duration_min:.0f} min (>= {t.race_min_duration_min} min)")
 
-        # Bonus fuer sehr hohen HR-Anteil
         if high_zone_pct >= 80:
             score += 15
             reasons.append("Sehr hohe durchgehende Intensitaet")
         elif high_zone_pct >= 70:
             score += 10
 
-    return score, reasons
+    return "race", score, reasons
 
 
 def _check_intervals(
-    laps: list[dict],
-    lap_hr_stats: dict,
+    m: SessionMetrics,
     t: ClassifierThresholds,
-) -> tuple[int, list[str]]:
+) -> tuple[str, int, list[str]]:
     """Prueft ob die Session ein Intervalltraining ist."""
     reasons: list[str] = []
     score = 0
 
-    num_laps = len(laps)
+    num_laps = len(m.laps)
     if num_laps < t.intervals_min_laps:
-        return 0, []
+        return "intervals", 0, []
 
-    high_hr_laps = lap_hr_stats.get("high_hr_lap_count", 0)
+    high_hr_laps = m.lap_hr_stats.get("high_hr_lap_count", 0)
     high_hr_pct = (high_hr_laps / num_laps * 100) if num_laps > 0 else 0
 
-    hr_variability = lap_hr_stats.get("hr_cv", 0)
+    hr_variability = m.lap_hr_stats.get("hr_cv", 0)
 
     if high_hr_pct >= t.intervals_min_high_hr_laps_pct:
         score = 60
         reasons.append(f"{high_hr_laps}/{num_laps} Laps mit hoher HR")
 
-        # Bonus fuer HR-Variabilitaet (typisch fuer Intervalle)
         if hr_variability > 0.10:
             score += 20
             reasons.append(f"Hohe HR-Variabilitaet (CV={hr_variability:.2f})")
@@ -278,190 +206,171 @@ def _check_intervals(
             score += 10
             reasons.append(f"Moderate HR-Variabilitaet (CV={hr_variability:.2f})")
 
-        # Bonus fuer viele Laps
         if num_laps >= 6:
             score += 5
             reasons.append(f"{num_laps} Laps")
 
-    return score, reasons
+    return "intervals", score, reasons
 
 
 def _check_tempo(
-    duration_min: float,
-    zone_pcts: dict[str, float],
-    pace_values: list[float],
+    m: SessionMetrics,
     t: ClassifierThresholds,
-) -> tuple[int, list[str]]:
+) -> tuple[str, int, list[str]]:
     """Prueft ob die Session ein Tempodauerlauf ist."""
     reasons: list[str] = []
     score = 0
 
-    zone3_pct = zone_pcts.get("zone_3", 0)
+    zone3_pct = m.zone_pcts.get("zone_3", 0)
 
     if zone3_pct >= t.tempo_min_zone3_pct:
         score = 55
         reasons.append(f"{zone3_pct:.0f}% in Zone 3 (>= {t.tempo_min_zone3_pct}%)")
 
-        # Pace-Konsistenz pruefen
-        if len(pace_values) >= 2:
-            pace_cv = _coefficient_of_variation(pace_values)
+        if len(m.pace_values) >= 2:
+            pace_cv = _coefficient_of_variation(m.pace_values)
             if pace_cv <= t.tempo_max_pace_cv:
                 score += 20
                 reasons.append(f"Konstante Pace (CV={pace_cv:.2f})")
             elif pace_cv <= t.tempo_max_pace_cv * 1.5:
                 score += 10
 
-        # Bonus fuer moderate Dauer
-        if 20 <= duration_min <= 60:
+        if 20 <= m.duration_min <= 60:
             score += 5
-            reasons.append(f"Typische Tempo-Dauer ({duration_min:.0f} min)")
+            reasons.append(f"Typische Tempo-Dauer ({m.duration_min:.0f} min)")
 
-    return score, reasons
+    return "tempo", score, reasons
 
 
 def _check_long_run(
-    duration_min: float,
-    zone_pcts: dict[str, float],
+    m: SessionMetrics,
     t: ClassifierThresholds,
-) -> tuple[int, list[str]]:
+) -> tuple[str, int, list[str]]:
     """Prueft ob die Session ein Long Run ist."""
     reasons: list[str] = []
     score = 0
 
-    if duration_min >= t.long_run_min_duration_min:
+    if m.duration_min >= t.long_run_min_duration_min:
         score = 65
-        reasons.append(f"Dauer {duration_min:.0f} min (>= {t.long_run_min_duration_min} min)")
+        reasons.append(f"Dauer {m.duration_min:.0f} min (>= {t.long_run_min_duration_min} min)")
 
-        zone4_plus = zone_pcts.get("zone_4_plus", 0)
+        zone4_plus = m.zone_pcts.get("zone_4_plus", 0)
         if zone4_plus <= t.long_run_max_zone4_plus_pct:
             score += 15
             reasons.append(f"Niedrige Intensitaet ({zone4_plus:.0f}% Zone 4+)")
         elif zone4_plus <= t.long_run_max_zone4_plus_pct * 2:
             score += 5
 
-        # Bonus fuer sehr lange Laeufe
-        if duration_min >= 120:
+        if m.duration_min >= 120:
             score += 10
             reasons.append("Sehr langer Lauf (>= 120 min)")
 
-    return score, reasons
+    return "long_run", score, reasons
 
 
 def _check_recovery(
-    duration_min: float,
-    zone_pcts: dict[str, float],
+    m: SessionMetrics,
     t: ClassifierThresholds,
-) -> tuple[int, list[str]]:
+) -> tuple[str, int, list[str]]:
     """Prueft ob die Session ein Recovery Run ist."""
     reasons: list[str] = []
     score = 0
 
-    # Ohne HR-Daten kann Recovery nicht sicher bestimmt werden
-    if not zone_pcts:
-        return 0, []
+    if not m.zone_pcts:
+        return "recovery", 0, []
 
-    zone2_plus = zone_pcts.get("zone_2_plus", 0)
+    zone2_plus = m.zone_pcts.get("zone_2_plus", 0)
 
-    if duration_min <= t.recovery_max_duration_min and zone2_plus <= t.recovery_max_hr_zone_pct:
+    if m.duration_min <= t.recovery_max_duration_min and zone2_plus <= t.recovery_max_hr_zone_pct:
         score = 60
-        reasons.append(f"Kurze Dauer ({duration_min:.0f} min)")
+        reasons.append(f"Kurze Dauer ({m.duration_min:.0f} min)")
         reasons.append(f"Niedrige Intensitaet ({zone2_plus:.0f}% in Zone 2+)")
 
-        # Bonus fuer sehr niedrige HR
         if zone2_plus <= 30:
             score += 20
             reasons.append("Sehr niedrige HR-Verteilung")
         elif zone2_plus <= 45:
             score += 10
 
-    return score, reasons
+    return "recovery", score, reasons
 
 
 def _check_easy(
-    duration_min: float,
-    zone_pcts: dict[str, float],
+    m: SessionMetrics,
     t: ClassifierThresholds,
-) -> tuple[int, list[str]]:
+) -> tuple[str, int, list[str]]:
     """Prueft ob die Session ein Easy Run ist."""
     reasons: list[str] = []
     score = 0
 
-    zone3_plus = zone_pcts.get("zone_3_plus", 0)
+    zone3_plus = m.zone_pcts.get("zone_3_plus", 0)
 
     if zone3_plus <= t.easy_max_zone3_plus_pct:
         score = 45
         reasons.append(f"Geringe Intensitaet ({zone3_plus:.0f}% in Zone 3+)")
 
-        if t.easy_min_duration_min <= duration_min <= t.easy_max_duration_min:
+        if t.easy_min_duration_min <= m.duration_min <= t.easy_max_duration_min:
             score += 15
-            reasons.append(f"Typische Easy-Dauer ({duration_min:.0f} min)")
-        elif duration_min >= t.easy_min_duration_min:
+            reasons.append(f"Typische Easy-Dauer ({m.duration_min:.0f} min)")
+        elif m.duration_min >= t.easy_min_duration_min:
             score += 5
 
-    return score, reasons
+    return "easy", score, reasons
 
 
 def _check_progression(
-    _laps: list[dict],
-    pace_values: list[float],
-    zone_pcts: dict[str, float],
+    m: SessionMetrics,
     t: ClassifierThresholds,
-) -> tuple[int, list[str]]:
+) -> tuple[str, int, list[str]]:
     """Prueft ob die Session ein Steigerungslauf ist (Pace nimmt systematisch ab)."""
     reasons: list[str] = []
     score = 0
 
-    if len(pace_values) < t.progression_min_laps:
-        return 0, []
+    if len(m.pace_values) < t.progression_min_laps:
+        return "progression", 0, []
 
-    # Vergleiche erste Haelfte vs zweite Haelfte
-    mid = len(pace_values) // 2
-    first_half_avg = sum(pace_values[:mid]) / mid
-    second_half_avg = sum(pace_values[mid:]) / (len(pace_values) - mid)
+    mid = len(m.pace_values) // 2
+    first_half_avg = sum(m.pace_values[:mid]) / mid
+    second_half_avg = sum(m.pace_values[mid:]) / (len(m.pace_values) - mid)
 
     if first_half_avg <= 0:
-        return 0, []
+        return "progression", 0, []
 
-    # Pace-Drop: zweite Haelfte schneller (niedrigere min/km) als erste
     pace_drop_pct = ((first_half_avg - second_half_avg) / first_half_avg) * 100
 
     if pace_drop_pct >= t.progression_min_pace_drop_pct:
         score = 65
         reasons.append(f"Pace-Abnahme {pace_drop_pct:.0f}% (>= {t.progression_min_pace_drop_pct}%)")
 
-        # Zone 3+ zwischen 30-70% (Start Easy, Ende Tempo)
-        zone3_plus = zone_pcts.get("zone_3_plus", 0)
+        zone3_plus = m.zone_pcts.get("zone_3_plus", 0)
         if 30 <= zone3_plus <= 70:
             score += 10
             reasons.append(f"Moderate Intensitaet ({zone3_plus:.0f}% Zone 3+)")
 
-        # Bonus fuer monoton abnehmende Pace
         decreasing = sum(
-            1 for i in range(1, len(pace_values)) if pace_values[i] < pace_values[i - 1]
+            1 for i in range(1, len(m.pace_values)) if m.pace_values[i] < m.pace_values[i - 1]
         )
-        monotonic_pct = decreasing / (len(pace_values) - 1) * 100
+        monotonic_pct = decreasing / (len(m.pace_values) - 1) * 100
         if monotonic_pct >= 70:
             score += 10
             reasons.append(f"Nahezu monotone Pace-Abnahme ({monotonic_pct:.0f}%)")
 
-    return score, reasons
+    return "progression", score, reasons
 
 
 def _check_fartlek(
-    laps: list[dict],
-    pace_values: list[float],
-    lap_hr_stats: dict,
+    m: SessionMetrics,
     t: ClassifierThresholds,
-) -> tuple[int, list[str]]:
+) -> tuple[str, int, list[str]]:
     """Prueft ob die Session ein Fartlek (Fahrtspiel) ist — gemischte Pace."""
     reasons: list[str] = []
     score = 0
 
-    if len(laps) < t.fartlek_min_laps or len(pace_values) < t.fartlek_min_laps:
-        return 0, []
+    if len(m.laps) < t.fartlek_min_laps or len(m.pace_values) < t.fartlek_min_laps:
+        return "fartlek", 0, []
 
-    pace_cv = _coefficient_of_variation(pace_values)
-    hr_cv = lap_hr_stats.get("hr_cv", 0)
+    pace_cv = _coefficient_of_variation(m.pace_values)
+    hr_cv = m.lap_hr_stats.get("hr_cv", 0)
 
     if t.fartlek_min_pace_cv <= pace_cv <= t.fartlek_max_pace_cv:
         score = 50
@@ -475,29 +384,28 @@ def _check_fartlek(
             score += 5
 
         # Bonus fuer viele Laps
-        if len(laps) >= 6:
+        if len(m.laps) >= 6:
             score += 5
-            reasons.append(f"{len(laps)} Laps")
+            reasons.append(f"{len(m.laps)} Laps")
 
-    return score, reasons
+    return "fartlek", score, reasons
 
 
 def _check_repetitions(
-    laps: list[dict],
-    lap_hr_stats: dict,
+    m: SessionMetrics,
     t: ClassifierThresholds,
-) -> tuple[int, list[str]]:
+) -> tuple[str, int, list[str]]:
     """Prueft ob die Session Repetitions sind — kurze, schnelle Wiederholungen."""
     reasons: list[str] = []
     score = 0
 
-    num_laps = len(laps)
+    num_laps = len(m.laps)
     if num_laps < t.repetitions_min_laps:
-        return 0, []
+        return "repetitions", 0, []
 
     # Zaehle kurze Laps mit hoher HR
     short_fast_count = 0
-    for lap in laps:
+    for lap in m.laps:
         duration = lap.get("duration_seconds", 0)
         avg_hr = lap.get("avg_hr_bpm")
         if duration <= t.repetitions_max_work_lap_duration and avg_hr and avg_hr > 160:
@@ -510,7 +418,7 @@ def _check_repetitions(
         reasons.append(f"{short_fast_count} kurze schnelle Laps (<= 2 min, HR > 160)")
 
         # HR-Variabilitaet (typisch fuer Wechsel zwischen schnell und Pause)
-        hr_cv = lap_hr_stats.get("hr_cv", 0)
+        hr_cv = m.lap_hr_stats.get("hr_cv", 0)
         if hr_cv > 0.10:
             score += 15
             reasons.append(f"Hohe HR-Variabilitaet (CV={hr_cv:.2f})")
@@ -520,10 +428,10 @@ def _check_repetitions(
         # Unterscheidung zu Intervallen: Repetitions haben kuerzere Work-Phasen
         avg_work_duration = sum(
             lap.get("duration_seconds", 0)
-            for lap in laps
+            for lap in m.laps
             if lap.get("avg_hr_bpm", 0) and lap["avg_hr_bpm"] > 160
         )
-        work_laps = sum(1 for lap in laps if lap.get("avg_hr_bpm", 0) and lap["avg_hr_bpm"] > 160)
+        work_laps = sum(1 for lap in m.laps if lap.get("avg_hr_bpm", 0) and lap["avg_hr_bpm"] > 160)
         if work_laps > 0:
             avg_dur = avg_work_duration / work_laps
             if avg_dur <= 90:
@@ -533,7 +441,22 @@ def _check_repetitions(
                 score += 10
                 reasons.append(f"Kurze Work-Dauer {avg_dur:.0f}s (<= 120s)")
 
-    return score, reasons
+    return "repetitions", score, reasons
+
+
+# --- Rule Registry (OCP: neuer Typ = neue Funktion + Eintrag hier) ---
+
+CLASSIFICATION_RULES: list[RuleCheck] = [
+    _check_race,
+    _check_intervals,
+    _check_repetitions,
+    _check_progression,
+    _check_tempo,
+    _check_fartlek,
+    _check_long_run,
+    _check_recovery,
+    _check_easy,
+]
 
 
 # --- Helpers ---


### PR DESCRIPTION
## Summary
- `classify_training_type()` von 131 auf ~25 Zeilen reduziert (nur noch Orchestrierung)
- Alle 9 `_check_*`-Funktionen auf einheitliches Interface: `(SessionMetrics, ClassifierThresholds) -> (type, score, reasons)`
- `CLASSIFICATION_RULES` Registry-Liste: neuer Trainingstyp = neue Funktion + Eintrag in der Liste (Open/Closed Principle)
- `SessionMetrics` Dataclass als vorberechneter Input für alle Rules
- Legacy-Parameter (`hr_avg`, `hr_max`, `distance_km`) backward-kompatibel beibehalten
- Net -77 Zeilen

## Test plan
- [x] Alle 469 Backend-Tests grün (inkl. 14 Classifier-Tests)
- [x] Ruff check + format bestanden
- [x] Mypy bestanden
- [x] CI muss grün sein

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)