### PR TITLE
feat: Kategorie-Tonnage Chart auf Analyseseite (#151)

### DIFF
--- a/backend/app/api/v1/strength.py
+++ b/backend/app/api/v1/strength.py
@@ -471,3 +471,43 @@ async def get_tonnage_trend(
         "avg_weekly_tonnage_kg": avg,
         "trend_direction": trend_direction,
     }
+
+
+@router.get("/category-tonnage-trend")
+async def get_category_tonnage_trend(
+    days: int = Query(default=90, ge=7, le=365, description="Zeitraum in Tagen"),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Woechentliche Tonnage nach Kategorie (push/pull/legs/core/...)."""
+    from app.services.progression_tracker import calculate_weekly_category_tonnage
+
+    cutoff = datetime.utcnow() - timedelta(days=days)
+    query = (
+        select(WorkoutModel)
+        .where(WorkoutModel.workout_type == "strength")
+        .where(WorkoutModel.exercises_json.isnot(None))
+        .where(WorkoutModel.date >= cutoff)
+        .order_by(WorkoutModel.date.asc())
+    )
+    result = await db.execute(query)
+    workouts = result.scalars().all()
+
+    sessions = []
+    for w in workouts:
+        if not w.exercises_json:
+            continue
+        model_date = w.date
+        date_str = (
+            model_date.date().isoformat() if isinstance(model_date, datetime) else str(model_date)
+        )
+        sessions.append(
+            {
+                "id": w.id,
+                "date": date_str,
+                "exercises": json.loads(str(w.exercises_json)),
+            }
+        )
+
+    data = calculate_weekly_category_tonnage(sessions)
+    data["period_days"] = days
+    return data

--- a/backend/app/models/category_tonnage.py
+++ b/backend/app/models/category_tonnage.py
@@ -1,0 +1,23 @@
+"""Response models for category tonnage trend analysis (#151)."""
+
+from pydantic import BaseModel, Field
+
+from app.models.weekly_plan import CategoryTonnage
+
+
+class WeeklyCategoryTonnage(BaseModel):
+    """Per-week category tonnage breakdown."""
+
+    week: str
+    week_start: str
+    categories: list[CategoryTonnage] = Field(default_factory=list)
+    total_tonnage_kg: float
+
+
+class CategoryTonnageTrendResponse(BaseModel):
+    """Multi-week category tonnage trend response."""
+
+    weeks: list[WeeklyCategoryTonnage]
+    aggregated: list[CategoryTonnage]
+    total_tonnage_kg: float
+    period_days: int

--- a/backend/app/services/progression_tracker.py
+++ b/backend/app/services/progression_tracker.py
@@ -267,6 +267,75 @@ def calculate_weekly_tonnage(
     return result
 
 
+def calculate_weekly_category_tonnage(
+    sessions: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Berechnet woechentliche Tonnage aufgeschluesselt nach Kategorie.
+
+    Kombiniert die Logik von calculate_weekly_tonnage() und
+    calculate_category_tonnage() fuer Multi-Wochen-Kategorie-Analyse.
+
+    Args:
+        sessions: Liste von Session-Dicts mit keys: id, date, exercises
+
+    Returns:
+        Dict mit weeks (pro Woche + Kategorien), aggregated, total_tonnage_kg
+    """
+    from app.services.tonnage_calculator import calculate_category_tonnage
+
+    weeks: dict[str, dict[str, Any]] = {}
+
+    for session in sessions:
+        exercises_raw = session.get("exercises", [])
+        if not exercises_raw:
+            continue
+
+        session_date = session["date"]
+        dt = (
+            datetime.strptime(session_date, "%Y-%m-%d")
+            if isinstance(session_date, str)
+            else session_date
+        )
+
+        week_key = dt.strftime("%G-W%V")
+        week_start = dt - timedelta(days=dt.weekday())
+
+        if week_key not in weeks:
+            weeks[week_key] = {
+                "week": week_key,
+                "week_start": week_start.strftime("%Y-%m-%d"),
+                "exercises": [],
+            }
+        weeks[week_key]["exercises"].extend(exercises_raw)
+
+    # Per-week category breakdown
+    week_results = []
+    all_exercises: list[dict[str, Any]] = []
+    for week_key in sorted(weeks.keys()):
+        w = weeks[week_key]
+        cats = calculate_category_tonnage(w["exercises"])
+        total = round(sum(c["tonnage_kg"] for c in cats), 1)
+        week_results.append(
+            {
+                "week": w["week"],
+                "week_start": w["week_start"],
+                "categories": cats,
+                "total_tonnage_kg": total,
+            }
+        )
+        all_exercises.extend(w["exercises"])
+
+    # Aggregated across all weeks
+    aggregated = calculate_category_tonnage(all_exercises)
+    grand_total = round(sum(c["tonnage_kg"] for c in aggregated), 1)
+
+    return {
+        "weeks": week_results,
+        "aggregated": aggregated,
+        "total_tonnage_kg": grand_total,
+    }
+
+
 def get_all_exercise_names(
     sessions: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:

--- a/backend/app/tests/test_strength.py
+++ b/backend/app/tests/test_strength.py
@@ -1,10 +1,11 @@
-"""Tests fuer Krafttraining (Issue #15)."""
+"""Tests fuer Krafttraining (Issue #15, #151)."""
 
 import json
 
 import pytest
 from httpx import AsyncClient
 
+from app.services.progression_tracker import calculate_weekly_category_tonnage
 from app.services.tonnage_calculator import calculate_category_tonnage, calculate_strength_metrics
 
 # --- Unit Tests: Tonnage Calculator ---
@@ -183,6 +184,140 @@ class TestCategoryTonnage:
         assert result[0]["exercise_count"] == 2
 
 
+# --- Unit Tests: Weekly Category Tonnage (#151) ---
+
+
+class TestWeeklyCategoryTonnage:
+    def test_single_week_single_category(self) -> None:
+        sessions = [
+            {
+                "id": 1,
+                "date": "2026-03-02",
+                "exercises": [
+                    {
+                        "name": "Bankdruecken",
+                        "category": "push",
+                        "sets": [{"reps": 10, "weight_kg": 60, "status": "completed"}],
+                    },
+                ],
+            },
+        ]
+        result = calculate_weekly_category_tonnage(sessions)
+        assert len(result["weeks"]) == 1
+        assert result["weeks"][0]["week"] == "2026-W10"
+        cats = result["weeks"][0]["categories"]
+        assert len(cats) == 1
+        assert cats[0]["category"] == "push"
+        assert cats[0]["tonnage_kg"] == 600.0
+        assert result["total_tonnage_kg"] == 600.0
+
+    def test_multiple_weeks_multiple_categories(self) -> None:
+        sessions = [
+            {
+                "id": 1,
+                "date": "2026-03-02",  # W10
+                "exercises": [
+                    {
+                        "name": "Bankdruecken",
+                        "category": "push",
+                        "sets": [{"reps": 10, "weight_kg": 60, "status": "completed"}],
+                    },
+                    {
+                        "name": "Kniebeugen",
+                        "category": "legs",
+                        "sets": [{"reps": 5, "weight_kg": 100, "status": "completed"}],
+                    },
+                ],
+            },
+            {
+                "id": 2,
+                "date": "2026-03-09",  # W11
+                "exercises": [
+                    {
+                        "name": "Bankdruecken",
+                        "category": "push",
+                        "sets": [{"reps": 10, "weight_kg": 65, "status": "completed"}],
+                    },
+                ],
+            },
+        ]
+        result = calculate_weekly_category_tonnage(sessions)
+        assert len(result["weeks"]) == 2
+
+        # Week 10: push 600 + legs 500
+        w10 = result["weeks"][0]
+        assert w10["total_tonnage_kg"] == 1100.0
+        cats_w10 = {c["category"]: c["tonnage_kg"] for c in w10["categories"]}
+        assert cats_w10["push"] == 600.0
+        assert cats_w10["legs"] == 500.0
+
+        # Week 11: push 650
+        w11 = result["weeks"][1]
+        assert w11["total_tonnage_kg"] == 650.0
+
+        # Aggregated: push 1250, legs 500
+        agg = {c["category"]: c["tonnage_kg"] for c in result["aggregated"]}
+        assert agg["push"] == 1250.0
+        assert agg["legs"] == 500.0
+        assert result["total_tonnage_kg"] == 1750.0
+
+    def test_empty_sessions(self) -> None:
+        result = calculate_weekly_category_tonnage([])
+        assert result["weeks"] == []
+        assert result["aggregated"] == []
+        assert result["total_tonnage_kg"] == 0.0
+
+    def test_skipped_sets_excluded(self) -> None:
+        sessions = [
+            {
+                "id": 1,
+                "date": "2026-03-02",
+                "exercises": [
+                    {
+                        "name": "Bankdruecken",
+                        "category": "push",
+                        "sets": [
+                            {"reps": 10, "weight_kg": 60, "status": "completed"},
+                            {"reps": 0, "weight_kg": 60, "status": "skipped"},
+                        ],
+                    },
+                ],
+            },
+        ]
+        result = calculate_weekly_category_tonnage(sessions)
+        cats = result["weeks"][0]["categories"]
+        assert cats[0]["tonnage_kg"] == 600.0
+
+    def test_aggregated_sorted_by_tonnage_desc(self) -> None:
+        sessions = [
+            {
+                "id": 1,
+                "date": "2026-03-02",
+                "exercises": [
+                    {
+                        "name": "Klimmzuege",
+                        "category": "pull",
+                        "sets": [{"reps": 8, "weight_kg": 20, "status": "completed"}],
+                    },
+                    {
+                        "name": "Kniebeugen",
+                        "category": "legs",
+                        "sets": [{"reps": 5, "weight_kg": 100, "status": "completed"}],
+                    },
+                    {
+                        "name": "Bankdruecken",
+                        "category": "push",
+                        "sets": [{"reps": 10, "weight_kg": 60, "status": "completed"}],
+                    },
+                ],
+            },
+        ]
+        result = calculate_weekly_category_tonnage(sessions)
+        cats = [c["category"] for c in result["aggregated"]]
+        # push=600, legs=500, pull=160
+        assert cats == ["push", "legs", "pull"]
+
+
 # --- Integration Tests: API ---
 
 EXERCISES_JSON = json.dumps(
@@ -315,3 +450,43 @@ async def test_create_validation_no_sets(client: AsyncClient) -> None:
         },
     )
     assert response.status_code == 422
+
+
+# --- Integration Tests: Category Tonnage Trend (#151) ---
+
+
+@pytest.mark.anyio
+async def test_category_tonnage_trend_endpoint(client: AsyncClient) -> None:
+    """Neuer Endpoint liefert Kategorie-Tonnage nach Wochen."""
+    await client.post("/api/v1/sessions/strength", data=VALID_FORM_DATA)
+
+    response = await client.get(
+        "/api/v1/sessions/strength/category-tonnage-trend",
+        params={"days": 90},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert "weeks" in body
+    assert "aggregated" in body
+    assert "total_tonnage_kg" in body
+    assert body["period_days"] == 90
+    assert body["total_tonnage_kg"] > 0
+
+    # Aggregated should have legs + push from test data
+    cats = {c["category"] for c in body["aggregated"]}
+    assert "legs" in cats
+    assert "push" in cats
+
+
+@pytest.mark.anyio
+async def test_category_tonnage_trend_empty(client: AsyncClient) -> None:
+    """Leerer Zeitraum liefert leere Listen."""
+    response = await client.get(
+        "/api/v1/sessions/strength/category-tonnage-trend",
+        params={"days": 7},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["weeks"] == []
+    assert body["aggregated"] == []
+    assert body["total_tonnage_kg"] == 0.0

--- a/frontend/src/api/progression.ts
+++ b/frontend/src/api/progression.ts
@@ -52,6 +52,27 @@ export interface TonnageTrendResponse {
   trend_direction: 'up' | 'down' | 'stable' | null;
 }
 
+export interface CategoryTonnageItem {
+  category: string;
+  tonnage_kg: number;
+  exercise_count: number;
+  set_count: number;
+}
+
+export interface WeeklyCategoryTonnage {
+  week: string;
+  week_start: string;
+  categories: CategoryTonnageItem[];
+  total_tonnage_kg: number;
+}
+
+export interface CategoryTonnageTrendResponse {
+  weeks: WeeklyCategoryTonnage[];
+  aggregated: CategoryTonnageItem[];
+  total_tonnage_kg: number;
+  period_days: number;
+}
+
 export interface ExerciseListItem {
   name: string;
   category: string;
@@ -91,6 +112,16 @@ export async function getPersonalRecords(sessionId?: number): Promise<PersonalRe
 export async function getTonnageTrend(days: number = 90): Promise<TonnageTrendResponse> {
   const response = await apiClient.get<TonnageTrendResponse>(
     '/api/v1/sessions/strength/tonnage-trend',
+    { params: { days } },
+  );
+  return response.data;
+}
+
+export async function getCategoryTonnageTrend(
+  days: number = 90,
+): Promise<CategoryTonnageTrendResponse> {
+  const response = await apiClient.get<CategoryTonnageTrendResponse>(
+    '/api/v1/sessions/strength/category-tonnage-trend',
     { params: { days } },
   );
   return response.data;

--- a/frontend/src/components/analysis/CategoryTonnageChart.test.tsx
+++ b/frontend/src/components/analysis/CategoryTonnageChart.test.tsx
@@ -1,0 +1,94 @@
+import { vi, describe, it, expect } from 'vitest';
+import { render, screen } from '@/test/test-utils';
+import { CategoryTonnageChart } from './CategoryTonnageChart';
+import type { CategoryTonnageTrendResponse } from '@/api/progression';
+
+// Mock recharts — jsdom has no ResizeObserver
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  BarChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Bar: () => <div />,
+  XAxis: () => <div />,
+  YAxis: () => <div />,
+  CartesianGrid: () => <div />,
+  Tooltip: () => <div />,
+  Legend: () => <div />,
+}));
+
+const MOCK_DATA: CategoryTonnageTrendResponse = {
+  weeks: [
+    {
+      week: '2026-W10',
+      week_start: '2026-03-02',
+      categories: [
+        { category: 'push', tonnage_kg: 600, exercise_count: 2, set_count: 6 },
+        { category: 'legs', tonnage_kg: 500, exercise_count: 1, set_count: 3 },
+      ],
+      total_tonnage_kg: 1100,
+    },
+    {
+      week: '2026-W11',
+      week_start: '2026-03-09',
+      categories: [
+        { category: 'push', tonnage_kg: 650, exercise_count: 2, set_count: 8 },
+        { category: 'pull', tonnage_kg: 300, exercise_count: 1, set_count: 4 },
+      ],
+      total_tonnage_kg: 950,
+    },
+  ],
+  aggregated: [
+    { category: 'push', tonnage_kg: 1250, exercise_count: 4, set_count: 14 },
+    { category: 'legs', tonnage_kg: 500, exercise_count: 1, set_count: 3 },
+    { category: 'pull', tonnage_kg: 300, exercise_count: 1, set_count: 4 },
+  ],
+  total_tonnage_kg: 2050,
+  period_days: 90,
+};
+
+describe('CategoryTonnageChart', () => {
+  it('renders heading and total tonnage', () => {
+    render(<CategoryTonnageChart data={MOCK_DATA} />);
+    expect(screen.getByText('Kategorie-Tonnage')).toBeInTheDocument();
+    expect(screen.getByText(/2\.0t/)).toBeInTheDocument();
+  });
+
+  it('renders view toggle with Gesamt and Trend', () => {
+    render(<CategoryTonnageChart data={MOCK_DATA} />);
+    expect(screen.getByText('Gesamt')).toBeInTheDocument();
+    expect(screen.getByText('Trend')).toBeInTheDocument();
+  });
+
+  it('renders nothing when data is null', () => {
+    render(<CategoryTonnageChart data={null} />);
+    expect(screen.queryByText('Kategorie-Tonnage')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when aggregated is empty', () => {
+    const emptyData: CategoryTonnageTrendResponse = {
+      weeks: [],
+      aggregated: [],
+      total_tonnage_kg: 0,
+      period_days: 90,
+    };
+    render(<CategoryTonnageChart data={emptyData} />);
+    expect(screen.queryByText('Kategorie-Tonnage')).not.toBeInTheDocument();
+  });
+
+  it('formats large tonnage as tons', () => {
+    const largeData: CategoryTonnageTrendResponse = {
+      ...MOCK_DATA,
+      total_tonnage_kg: 5400,
+    };
+    render(<CategoryTonnageChart data={largeData} />);
+    expect(screen.getByText(/5\.4t/)).toBeInTheDocument();
+  });
+
+  it('formats small tonnage as kg', () => {
+    const smallData: CategoryTonnageTrendResponse = {
+      ...MOCK_DATA,
+      total_tonnage_kg: 750,
+    };
+    render(<CategoryTonnageChart data={smallData} />);
+    expect(screen.getByText(/750 kg/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/analysis/CategoryTonnageChart.tsx
+++ b/frontend/src/components/analysis/CategoryTonnageChart.tsx
@@ -1,0 +1,209 @@
+import { useState, useMemo } from 'react';
+import { Card, CardBody, CardHeader, SegmentedControl } from '@nordlig/components';
+import { BarChart3 } from 'lucide-react';
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from 'recharts';
+import { CATEGORY_LABELS } from '@/constants/training';
+import type { CategoryTonnageTrendResponse } from '@/api/progression';
+
+type ViewMode = 'total' | 'trend';
+
+const VIEW_ITEMS = [
+  { value: 'total', label: 'Gesamt' },
+  { value: 'trend', label: 'Trend' },
+];
+
+/** Mapping category keys to chart color tokens */
+const CATEGORY_COLORS: Record<string, string> = {
+  push: 'var(--color-chart-1)',
+  pull: 'var(--color-chart-2)',
+  legs: 'var(--color-chart-3)',
+  core: 'var(--color-chart-4)',
+  cardio: 'var(--color-chart-5)',
+  drills: 'var(--color-chart-5)',
+};
+
+const TOOLTIP_STYLE = {
+  backgroundColor: 'var(--color-bg-elevated)',
+  border: '1px solid var(--color-border-default)',
+  borderRadius: '8px',
+  fontSize: '12px',
+};
+
+const AXIS_TICK = { fontSize: 11, fill: 'var(--color-text-muted)' };
+
+function categoryLabel(key: string): string {
+  return CATEGORY_LABELS[key] ?? key;
+}
+
+function formatTonnage(kg: number): string {
+  return kg >= 1000 ? `${(kg / 1000).toFixed(1)}t` : `${Math.round(kg)} kg`;
+}
+
+function formatWeekLabel(weekStart: string): string {
+  const [, month, day] = weekStart.split('-');
+  return `${day}.${month}.`;
+}
+
+interface Props {
+  data: CategoryTonnageTrendResponse | null;
+}
+
+/** Aggregated horizontal bar chart — tonnage per category over the entire period. */
+function AggregatedView({ data }: { data: CategoryTonnageTrendResponse }) {
+  const chartData = useMemo(
+    () =>
+      data.aggregated.map((c) => ({
+        category: categoryLabel(c.category),
+        tonnage: c.tonnage_kg,
+        fill: CATEGORY_COLORS[c.category] ?? 'var(--color-chart-1)',
+      })),
+    [data.aggregated],
+  );
+
+  if (chartData.length === 0) return null;
+
+  return (
+    <div className="h-[200px]" aria-label="Kategorie-Tonnage Balkendiagramm">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart
+          data={chartData}
+          layout="vertical"
+          margin={{ top: 5, right: 10, left: 0, bottom: 5 }}
+        >
+          <CartesianGrid
+            strokeDasharray="3 3"
+            stroke="var(--color-border-muted)"
+            horizontal={false}
+          />
+          <XAxis
+            type="number"
+            tick={AXIS_TICK}
+            tickLine={false}
+            axisLine={false}
+            tickFormatter={(v: number) => formatTonnage(v)}
+          />
+          <YAxis
+            type="category"
+            dataKey="category"
+            tick={AXIS_TICK}
+            tickLine={false}
+            axisLine={false}
+            width={60}
+          />
+          <Tooltip
+            contentStyle={TOOLTIP_STYLE}
+            formatter={(value: number) => [formatTonnage(value), 'Tonnage']}
+          />
+          <Bar dataKey="tonnage" radius={[0, 4, 4, 0]} isAnimationActive={false}>
+            {chartData.map((entry, i) => (
+              <rect key={i} fill={entry.fill} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+/** Stacked bar chart — week-over-week tonnage per category. */
+function TrendView({ data }: { data: CategoryTonnageTrendResponse }) {
+  const { chartData, categories } = useMemo(() => {
+    const allCats = new Set<string>();
+    for (const week of data.weeks) {
+      for (const c of week.categories) {
+        allCats.add(c.category);
+      }
+    }
+    const cats = Array.from(allCats).sort();
+
+    const rows = data.weeks.map((week) => {
+      const row: Record<string, string | number> = {
+        label: formatWeekLabel(week.week_start),
+      };
+      for (const cat of cats) {
+        const found = week.categories.find((c) => c.category === cat);
+        row[cat] = found ? found.tonnage_kg : 0;
+      }
+      return row;
+    });
+
+    return { chartData: rows, categories: cats };
+  }, [data.weeks]);
+
+  if (chartData.length === 0) return null;
+
+  return (
+    <div className="h-[220px]" aria-label="Kategorie-Tonnage Trend">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={chartData} margin={{ top: 5, right: 10, left: -10, bottom: 5 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-muted)" />
+          <XAxis dataKey="label" tick={AXIS_TICK} tickLine={false} axisLine={false} />
+          <YAxis
+            tick={AXIS_TICK}
+            tickLine={false}
+            axisLine={false}
+            tickFormatter={(v: number) => formatTonnage(v)}
+          />
+          <Tooltip
+            contentStyle={TOOLTIP_STYLE}
+            formatter={(value: number, name: string) => [formatTonnage(value), categoryLabel(name)]}
+          />
+          <Legend formatter={(value: string) => categoryLabel(value)} />
+          {categories.map((cat) => (
+            <Bar
+              key={cat}
+              dataKey={cat}
+              stackId="tonnage"
+              fill={CATEGORY_COLORS[cat] ?? 'var(--color-chart-1)'}
+              radius={[0, 0, 0, 0]}
+              isAnimationActive={false}
+            />
+          ))}
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+export function CategoryTonnageChart({ data }: Props) {
+  const [view, setView] = useState<ViewMode>('total');
+
+  if (!data || data.aggregated.length === 0) return null;
+
+  return (
+    <Card elevation="raised" padding="spacious">
+      <CardHeader>
+        <div className="flex items-center justify-between w-full">
+          <div className="flex items-center gap-2">
+            <BarChart3 className="w-4 h-4 text-[var(--color-text-primary)]" />
+            <h2 className="text-sm font-semibold text-[var(--color-text-base)]">
+              Kategorie-Tonnage
+            </h2>
+          </div>
+          <SegmentedControl
+            size="sm"
+            value={view}
+            onChange={(v) => setView(v as ViewMode)}
+            items={VIEW_ITEMS}
+          />
+        </div>
+        <p className="text-xs text-[var(--color-text-muted)] mt-1">
+          Tonnage nach Muskelgruppe{view === 'trend' ? ' pro Woche' : ' gesamt'}. Insgesamt{' '}
+          {formatTonnage(data.total_tonnage_kg)}.
+        </p>
+      </CardHeader>
+      <CardBody>
+        {view === 'total' ? <AggregatedView data={data} /> : <TrendView data={data} />}
+      </CardBody>
+    </Card>
+  );
+}

--- a/frontend/src/pages/StrengthProgression.tsx
+++ b/frontend/src/pages/StrengthProgression.tsx
@@ -28,13 +28,16 @@ import {
   getExerciseProgression,
   getPersonalRecords,
   getTonnageTrend,
+  getCategoryTonnageTrend,
 } from '@/api/progression';
 import { CATEGORY_LABELS, categoryBadgeVariant } from '@/constants/training';
+import { CategoryTonnageChart } from '@/components/analysis/CategoryTonnageChart';
 import type {
   ExerciseListItem,
   ExerciseHistoryResponse,
   PersonalRecord,
   TonnageTrendResponse,
+  CategoryTonnageTrendResponse,
 } from '@/api/progression';
 import { format, parseISO } from 'date-fns';
 import { de } from 'date-fns/locale';
@@ -79,6 +82,7 @@ export function StrengthProgressionContent({ timeRange }: { timeRange?: TimeRang
   const [history, setHistory] = useState<ExerciseHistoryResponse | null>(null);
   const [prs, setPrs] = useState<PersonalRecord[]>([]);
   const [tonnageTrend, setTonnageTrend] = useState<TonnageTrendResponse | null>(null);
+  const [categoryTonnage, setCategoryTonnage] = useState<CategoryTonnageTrendResponse | null>(null);
   const [internalTimeRange, setInternalTimeRange] = useState<TimeRange>('90');
   const effectiveTimeRange = timeRange ?? internalTimeRange;
   const [loading, setLoading] = useState(true);
@@ -90,14 +94,16 @@ export function StrengthProgressionContent({ timeRange }: { timeRange?: TimeRang
     setLoading(true);
     setError(null);
     try {
-      const [exerciseRes, prRes, tonnageRes] = await Promise.all([
+      const [exerciseRes, prRes, tonnageRes, catTonnageRes] = await Promise.all([
         getExerciseList(),
         getPersonalRecords(),
         getTonnageTrend(parseInt(effectiveTimeRange, 10)),
+        getCategoryTonnageTrend(parseInt(effectiveTimeRange, 10)),
       ]);
       setExercises(exerciseRes.exercises);
       setPrs(prRes.records);
       setTonnageTrend(tonnageRes);
+      setCategoryTonnage(catTonnageRes);
 
       // Auto-select first exercise
       if (exerciseRes.exercises.length > 0 && !selectedExercise) {
@@ -431,6 +437,9 @@ export function StrengthProgressionContent({ timeRange }: { timeRange?: TimeRang
           </CardBody>
         </Card>
       )}
+
+      {/* Category Tonnage (#151) */}
+      <CategoryTonnageChart data={categoryTonnage} />
 
       {/* Personal Records */}
       {Object.keys(prsByExercise).length > 0 && (


### PR DESCRIPTION
## Summary

- Neuer Backend-Endpoint `GET /api/v1/sessions/strength/category-tonnage-trend` für Multi-Wochen-Kategorie-Tonnage
- Neue `CategoryTonnageChart` Komponente mit zwei Views (Gesamt / Trend)
- Integration in den Kraft-Tab der Analyseseite

## Was wurde gemacht

### Backend
- `calculate_weekly_category_tonnage()` Service-Funktion (nutzt bestehende `calculate_category_tonnage()`)
- Pydantic Response Models (`CategoryTonnageTrendResponse`, `WeeklyCategoryTonnage`)
- 7 neue Tests (5 Unit + 2 Integration)

### Frontend
- `CategoryTonnageChart` mit SegmentedControl Toggle:
  - **Gesamt**: Horizontaler BarChart — Tonnage pro Kategorie aggregiert
  - **Trend**: Stacked BarChart — Wochen-Verlauf mit Kategorien gestapelt
- Deutsche Labels aus bestehendem `CATEGORY_LABELS`
- 6 Frontend-Tests

## Test plan

- [x] Backend: ruff check, mypy, pytest (476 Tests)
- [x] Frontend: ESLint 0 Warnings, TSC, Prettier, Vitest (151 Tests)
- [x] Nordlig DS Compliance Check (keine hardcodierten Farben/Radii/Shadows)
- [ ] CI-Pipeline grün
- [ ] Manuell: Analyse → Kraft-Tab → Kategorie-Tonnage prüfen
- [ ] Mobile 375px prüfen

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)