### PR TITLE
feat: Soll/Ist-Vergleich — Segment-Matching + Vergleichs-UI (#138)

### DIFF
--- a/backend/app/api/v1/sessions.py
+++ b/backend/app/api/v1/sessions.py
@@ -16,6 +16,7 @@ from app.infrastructure.database.models import (
     WorkoutModel,
 )
 from app.infrastructure.database.session import get_db
+from app.models.segment import ComparisonResponse, laps_to_segments
 from app.models.session import (
     DateUpdateRequest,
     LapOverrideRequest,
@@ -33,10 +34,12 @@ from app.models.session import (
     TrainingTypeOverrideRequest,
 )
 from app.models.training import TrainingSubType, TrainingType
+from app.models.weekly_plan import RunDetails
 from app.services.csv_parser import TrainingCSVParser
 from app.services.fit_parser import TrainingFITParser
 from app.services.hr_zone_calculator import calculate_zone_distribution
 from app.services.km_split_calculator import calculate_km_splits, calculate_session_gap
+from app.services.segment_matcher import build_comparison
 from app.services.training_type_classifier import classify_training_type
 
 router = APIRouter(prefix="/sessions", tags=["sessions"])
@@ -553,6 +556,65 @@ async def get_working_zones(
     gps_track = json.loads(str(workout.gps_track_json)) if workout.gps_track_json else None
     _, hr_zones = _calculate_working_laps_metrics(laps_raw, resting_hr, max_hr, gps_track)
     return {"hr_zones_working": hr_zones}
+
+
+@router.get("/{session_id}/comparison", response_model=ComparisonResponse)
+async def get_session_comparison(
+    session_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> ComparisonResponse:
+    """Soll/Ist-Vergleich: matcht geplante Segmente mit tatsächlichen Laps."""
+    query = select(WorkoutModel).where(WorkoutModel.id == session_id)
+    result = await db.execute(query)
+    workout = result.scalar_one_or_none()
+
+    if not workout:
+        raise HTTPException(status_code=404, detail="Session nicht gefunden.")
+
+    if workout.planned_entry_id is None:
+        raise HTTPException(status_code=404, detail="Session hat keine zugeordnete Planung.")
+
+    # Load planned session
+    ps_query = select(PlannedSessionModel).where(PlannedSessionModel.id == workout.planned_entry_id)
+    ps_result = await db.execute(ps_query)
+    planned_session = ps_result.scalar_one_or_none()
+
+    if not planned_session or not planned_session.run_details_json:
+        raise HTTPException(
+            status_code=404, detail="Geplante Session oder Run-Details nicht gefunden."
+        )
+
+    # Parse planned segments
+    run_details = _parse_run_details(str(planned_session.run_details_json))
+    if not run_details or not run_details.segments:
+        raise HTTPException(status_code=404, detail="Keine geplanten Segmente vorhanden.")
+
+    # Parse actual laps → segments
+    actual_segments = []
+    if workout.laps_json:
+        from app.models.session import LapResponse as LapResponseCls
+
+        laps_raw = json.loads(str(workout.laps_json))
+        laps = [LapResponseCls(**lap) for lap in laps_raw]
+        actual_segments = laps_to_segments(laps)
+
+    return build_comparison(
+        planned_segments=run_details.segments,
+        actual_segments=actual_segments,
+        planned_entry_id=workout.planned_entry_id,
+        planned_run_type=run_details.run_type,
+    )
+
+
+def _parse_run_details(raw: str | None) -> RunDetails | None:
+    """Parse run_details_json string to RunDetails model."""
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+        return RunDetails(**data)
+    except (json.JSONDecodeError, ValueError):
+        return None
 
 
 @router.patch("/{session_id}/laps", response_model=LapOverrideResponse)

--- a/backend/app/models/segment.py
+++ b/backend/app/models/segment.py
@@ -267,3 +267,38 @@ def laps_to_template_segments(laps: list[LapResponse]) -> list[Segment]:
             updates["target_pace_min"] = seg.actual_pace_formatted
         result.append(seg.model_copy(update=updates) if updates else seg)
     return result
+
+
+# --- Soll/Ist-Vergleich Models (#138) ---
+
+
+class SegmentDelta(BaseModel):
+    """Delta zwischen Soll und Ist fuer eine einzelne Metrik."""
+
+    pace_delta_seconds: int | None = None
+    pace_delta_formatted: str | None = None
+    hr_avg_delta: int | None = None
+    duration_delta_seconds: float | None = None
+    distance_delta_km: float | None = None
+
+
+class MatchedSegment(BaseModel):
+    """Ein gematchtes Segment-Paar im Soll/Ist-Vergleich."""
+
+    position: int
+    segment_type: str
+    match_quality: str  # "matched" | "unmatched_planned" | "unmatched_actual"
+    planned: Segment | None = None
+    actual: Segment | None = None
+    delta: SegmentDelta | None = None
+
+
+class ComparisonResponse(BaseModel):
+    """Vollstaendiger Soll/Ist-Vergleich fuer eine Session."""
+
+    planned_entry_id: int
+    planned_run_type: str | None = None
+    segments: list[MatchedSegment]
+    has_mismatch: bool
+    planned_count: int
+    actual_count: int

--- a/backend/app/services/segment_matcher.py
+++ b/backend/app/services/segment_matcher.py
@@ -1,0 +1,164 @@
+"""Soll/Ist Segment-Matching Service (Issue #138).
+
+Matcht geplante Segmente mit tatsaechlichen Laps und berechnet Deltas.
+"""
+
+from __future__ import annotations
+
+from itertools import zip_longest
+
+from app.models.segment import (
+    ComparisonResponse,
+    MatchedSegment,
+    Segment,
+    SegmentDelta,
+)
+
+
+def pace_str_to_seconds(pace: str | None) -> int | None:
+    """Konvertiert Pace-String '5:30' zu Sekunden (330)."""
+    if not pace:
+        return None
+    try:
+        parts = pace.strip().split(":")
+        return int(parts[0]) * 60 + int(parts[1])
+    except (ValueError, IndexError):
+        return None
+
+
+def _seconds_to_pace_str(seconds: int) -> str:
+    """Konvertiert Sekunden zu Pace-String mit Vorzeichen ('+0:12' / '-0:05')."""
+    sign = "+" if seconds >= 0 else "-"
+    abs_sec = abs(seconds)
+    minutes = abs_sec // 60
+    secs = abs_sec % 60
+    return f"{sign}{minutes}:{secs:02d}"
+
+
+def _range_delta(actual: int, lo: int | None, hi: int | None) -> int | None:
+    """Berechnet Abweichung eines Wertes von einer Range.
+
+    Innerhalb [lo, hi] → 0. Darunter → negativ. Darüber → positiv.
+    Falls nur eine Grenze gesetzt ist, wird direkte Differenz berechnet.
+    """
+    if lo is not None and hi is not None:
+        if actual < lo:
+            return actual - lo
+        if actual > hi:
+            return actual - hi
+        return 0
+    if lo is not None:
+        return actual - lo
+    if hi is not None:
+        return actual - hi
+    return None
+
+
+def _pace_delta(planned: Segment, actual: Segment) -> tuple[int | None, str | None]:
+    """Berechnet Pace-Delta (Sekunden + formatiert)."""
+    actual_sec = pace_str_to_seconds(actual.actual_pace_formatted)
+    if actual_sec is None:
+        return None, None
+
+    target_min = pace_str_to_seconds(planned.target_pace_min)
+    target_max = pace_str_to_seconds(planned.target_pace_max)
+    delta = _range_delta(actual_sec, target_min, target_max)
+
+    if delta is None:
+        return None, None
+    return delta, _seconds_to_pace_str(delta)
+
+
+def _hr_delta(planned: Segment, actual: Segment) -> int | None:
+    """Berechnet HR-Delta (Schläge)."""
+    if actual.actual_hr_avg is None:
+        return None
+    return _range_delta(actual.actual_hr_avg, planned.target_hr_min, planned.target_hr_max)
+
+
+def _compute_delta(planned: Segment, actual: Segment) -> SegmentDelta:
+    """Berechnet Deltas zwischen Soll- und Ist-Segment."""
+    pace_delta_sec, pace_delta_fmt = _pace_delta(planned, actual)
+
+    dur_delta: float | None = None
+    if actual.actual_duration_seconds is not None and planned.target_duration_minutes is not None:
+        dur_delta = round(actual.actual_duration_seconds - planned.target_duration_minutes * 60, 1)
+
+    dist_delta: float | None = None
+    if actual.actual_distance_km is not None and planned.target_distance_km is not None:
+        dist_delta = round(actual.actual_distance_km - planned.target_distance_km, 3)
+
+    return SegmentDelta(
+        pace_delta_seconds=pace_delta_sec,
+        pace_delta_formatted=pace_delta_fmt,
+        hr_avg_delta=_hr_delta(planned, actual),
+        duration_delta_seconds=dur_delta,
+        distance_delta_km=dist_delta,
+    )
+
+
+def match_segments(
+    planned: list[Segment],
+    actual: list[Segment],
+) -> list[MatchedSegment]:
+    """Matcht geplante Segmente mit Ist-Segmenten positionsbasiert.
+
+    Geplante Segmente werden zuerst expandiert (repeats aufloesen).
+    """
+    expanded = []
+    for seg in planned:
+        expanded.extend(seg.expand())
+
+    result: list[MatchedSegment] = []
+    for i, (p, a) in enumerate(zip_longest(expanded, actual)):
+        if p is not None and a is not None:
+            result.append(
+                MatchedSegment(
+                    position=i,
+                    segment_type=a.segment_type,
+                    match_quality="matched",
+                    planned=p,
+                    actual=a,
+                    delta=_compute_delta(p, a),
+                )
+            )
+        elif p is not None:
+            result.append(
+                MatchedSegment(
+                    position=i,
+                    segment_type=p.segment_type,
+                    match_quality="unmatched_planned",
+                    planned=p,
+                )
+            )
+        elif a is not None:
+            result.append(
+                MatchedSegment(
+                    position=i,
+                    segment_type=a.segment_type,
+                    match_quality="unmatched_actual",
+                    actual=a,
+                )
+            )
+
+    return result
+
+
+def build_comparison(
+    planned_segments: list[Segment],
+    actual_segments: list[Segment],
+    planned_entry_id: int,
+    planned_run_type: str | None = None,
+) -> ComparisonResponse:
+    """Erstellt eine vollstaendige ComparisonResponse."""
+    expanded_count = sum(len(seg.expand()) for seg in planned_segments)
+    matched = match_segments(planned_segments, actual_segments)
+
+    return ComparisonResponse(
+        planned_entry_id=planned_entry_id,
+        planned_run_type=planned_run_type,
+        segments=matched,
+        has_mismatch=expanded_count != len(actual_segments),
+        planned_count=expanded_count,
+        actual_count=len(actual_segments),
+    )

--- a/backend/app/tests/test_segment_matcher.py
+++ b/backend/app/tests/test_segment_matcher.py
@@ -1,0 +1,308 @@
+"""Tests für Soll/Ist Segment-Matching (Issue #138)."""
+
+import pytest
+
+from app.models.segment import Segment
+from app.services.segment_matcher import (
+    _range_delta,
+    build_comparison,
+    match_segments,
+    pace_str_to_seconds,
+)
+
+# --- pace_str_to_seconds ---
+
+
+class TestPaceStrToSeconds:
+    def test_valid(self) -> None:
+        assert pace_str_to_seconds("5:30") == 330
+
+    def test_zero_seconds(self) -> None:
+        assert pace_str_to_seconds("6:00") == 360
+
+    def test_none(self) -> None:
+        assert pace_str_to_seconds(None) is None
+
+    def test_empty(self) -> None:
+        assert pace_str_to_seconds("") is None
+
+    def test_invalid(self) -> None:
+        assert pace_str_to_seconds("abc") is None
+
+    def test_whitespace(self) -> None:
+        assert pace_str_to_seconds(" 5:30 ") == 330
+
+
+# --- _range_delta ---
+
+
+class TestRangeDelta:
+    def test_within_range(self) -> None:
+        assert _range_delta(150, 140, 160) == 0
+
+    def test_below_range(self) -> None:
+        assert _range_delta(130, 140, 160) == -10
+
+    def test_above_range(self) -> None:
+        assert _range_delta(170, 140, 160) == 10
+
+    def test_at_lower_boundary(self) -> None:
+        assert _range_delta(140, 140, 160) == 0
+
+    def test_at_upper_boundary(self) -> None:
+        assert _range_delta(160, 140, 160) == 0
+
+    def test_only_lo(self) -> None:
+        assert _range_delta(150, 140, None) == 10
+
+    def test_only_hi(self) -> None:
+        assert _range_delta(150, None, 160) == -10
+
+    def test_no_bounds(self) -> None:
+        assert _range_delta(150, None, None) is None
+
+
+# --- match_segments ---
+
+
+def _planned(
+    segment_type: str = "steady",
+    pace_min: str | None = None,
+    pace_max: str | None = None,
+    hr_min: int | None = None,
+    hr_max: int | None = None,
+    duration_min: float | None = None,
+    distance_km: float | None = None,
+    repeats: int = 1,
+) -> Segment:
+    return Segment(
+        position=0,
+        segment_type=segment_type,
+        target_pace_min=pace_min,
+        target_pace_max=pace_max,
+        target_hr_min=hr_min,
+        target_hr_max=hr_max,
+        target_duration_minutes=duration_min,
+        target_distance_km=distance_km,
+        repeats=repeats,
+    )
+
+
+def _actual(
+    segment_type: str = "steady",
+    pace: str | None = None,
+    hr_avg: int | None = None,
+    duration_sec: float | None = None,
+    distance_km: float | None = None,
+) -> Segment:
+    return Segment(
+        position=0,
+        segment_type=segment_type,
+        actual_pace_formatted=pace,
+        actual_hr_avg=hr_avg,
+        actual_duration_seconds=duration_sec,
+        actual_distance_km=distance_km,
+    )
+
+
+class TestMatchSegments:
+    def test_equal_count_all_matched(self) -> None:
+        planned = [_planned(segment_type="warmup"), _planned(), _planned(segment_type="cooldown")]
+        actual = [_actual(segment_type="warmup"), _actual(), _actual(segment_type="cooldown")]
+        result = match_segments(planned, actual)
+
+        assert len(result) == 3
+        assert all(m.match_quality == "matched" for m in result)
+        assert all(m.planned is not None and m.actual is not None for m in result)
+
+    def test_more_actual_unmatched(self) -> None:
+        planned = [_planned()]
+        actual = [_actual(), _actual(), _actual()]
+        result = match_segments(planned, actual)
+
+        assert len(result) == 3
+        assert result[0].match_quality == "matched"
+        assert result[1].match_quality == "unmatched_actual"
+        assert result[2].match_quality == "unmatched_actual"
+
+    def test_more_planned_unmatched(self) -> None:
+        planned = [_planned(), _planned(), _planned()]
+        actual = [_actual()]
+        result = match_segments(planned, actual)
+
+        assert len(result) == 3
+        assert result[0].match_quality == "matched"
+        assert result[1].match_quality == "unmatched_planned"
+        assert result[2].match_quality == "unmatched_planned"
+
+    def test_empty_both(self) -> None:
+        assert match_segments([], []) == []
+
+    def test_empty_planned(self) -> None:
+        result = match_segments([], [_actual()])
+        assert len(result) == 1
+        assert result[0].match_quality == "unmatched_actual"
+
+    def test_empty_actual(self) -> None:
+        result = match_segments([_planned()], [])
+        assert len(result) == 1
+        assert result[0].match_quality == "unmatched_planned"
+
+    def test_repeats_expanded(self) -> None:
+        """repeats=4 wird zu 4 Work + 3 Recovery = 7 Segmente expandiert."""
+        planned = [_planned(segment_type="work", repeats=4)]
+        actual = [_actual() for _ in range(7)]
+        result = match_segments(planned, actual)
+
+        assert len(result) == 7
+        assert all(m.match_quality == "matched" for m in result)
+
+    def test_segment_type_from_actual_on_match(self) -> None:
+        """Bei matched pair kommt segment_type vom actual."""
+        planned = [_planned(segment_type="steady")]
+        actual = [_actual(segment_type="work")]
+        result = match_segments(planned, actual)
+
+        assert result[0].segment_type == "work"
+
+
+# --- Delta-Berechnung ---
+
+
+class TestDeltaComputation:
+    def test_pace_within_range_zero_delta(self) -> None:
+        planned = [_planned(pace_min="5:00", pace_max="5:30")]
+        actual = [_actual(pace="5:15")]
+        result = match_segments(planned, actual)
+
+        assert result[0].delta is not None
+        assert result[0].delta.pace_delta_seconds == 0
+        assert result[0].delta.pace_delta_formatted == "+0:00"
+
+    def test_pace_slower_than_max(self) -> None:
+        planned = [_planned(pace_min="5:00", pace_max="5:30")]
+        actual = [_actual(pace="5:42")]  # 12 Sekunden zu langsam
+        result = match_segments(planned, actual)
+
+        assert result[0].delta is not None
+        assert result[0].delta.pace_delta_seconds == 12
+        assert result[0].delta.pace_delta_formatted == "+0:12"
+
+    def test_pace_faster_than_min(self) -> None:
+        planned = [_planned(pace_min="5:00", pace_max="5:30")]
+        actual = [_actual(pace="4:55")]  # 5 Sekunden schneller
+        result = match_segments(planned, actual)
+
+        assert result[0].delta is not None
+        assert result[0].delta.pace_delta_seconds == -5
+        assert result[0].delta.pace_delta_formatted == "-0:05"
+
+    def test_pace_no_target(self) -> None:
+        planned = [_planned()]
+        actual = [_actual(pace="5:15")]
+        result = match_segments(planned, actual)
+
+        assert result[0].delta is not None
+        assert result[0].delta.pace_delta_seconds is None
+
+    def test_hr_within_range(self) -> None:
+        planned = [_planned(hr_min=140, hr_max=160)]
+        actual = [_actual(hr_avg=150)]
+        result = match_segments(planned, actual)
+
+        assert result[0].delta is not None
+        assert result[0].delta.hr_avg_delta == 0
+
+    def test_hr_above_range(self) -> None:
+        planned = [_planned(hr_min=140, hr_max=160)]
+        actual = [_actual(hr_avg=170)]
+        result = match_segments(planned, actual)
+
+        assert result[0].delta is not None
+        assert result[0].delta.hr_avg_delta == 10
+
+    def test_hr_below_range(self) -> None:
+        planned = [_planned(hr_min=140, hr_max=160)]
+        actual = [_actual(hr_avg=130)]
+        result = match_segments(planned, actual)
+
+        assert result[0].delta is not None
+        assert result[0].delta.hr_avg_delta == -10
+
+    def test_duration_delta(self) -> None:
+        planned = [_planned(duration_min=10.0)]  # 10 Minuten = 600s
+        actual = [_actual(duration_sec=630.0)]  # 30s länger
+        result = match_segments(planned, actual)
+
+        assert result[0].delta is not None
+        assert result[0].delta.duration_delta_seconds == 30.0
+
+    def test_distance_delta(self) -> None:
+        planned = [_planned(distance_km=5.0)]
+        actual = [_actual(distance_km=5.123)]
+        result = match_segments(planned, actual)
+
+        assert result[0].delta is not None
+        assert result[0].delta.distance_delta_km == 0.123
+
+    def test_no_actual_data_no_deltas(self) -> None:
+        planned = [_planned(pace_min="5:00", hr_min=140, duration_min=10.0)]
+        actual = [_actual()]
+        result = match_segments(planned, actual)
+
+        delta = result[0].delta
+        assert delta is not None
+        assert delta.pace_delta_seconds is None
+        assert delta.hr_avg_delta is None
+        assert delta.duration_delta_seconds is None
+
+    def test_unmatched_no_delta(self) -> None:
+        planned = [_planned()]
+        result = match_segments(planned, [])
+
+        assert result[0].delta is None
+
+
+# --- build_comparison ---
+
+
+class TestBuildComparison:
+    def test_basic(self) -> None:
+        planned = [_planned(), _planned(segment_type="cooldown")]
+        actual = [_actual(), _actual(segment_type="cooldown")]
+        resp = build_comparison(planned, actual, planned_entry_id=42, planned_run_type="easy")
+
+        assert resp.planned_entry_id == 42
+        assert resp.planned_run_type == "easy"
+        assert resp.planned_count == 2
+        assert resp.actual_count == 2
+        assert resp.has_mismatch is False
+        assert len(resp.segments) == 2
+
+    def test_mismatch_detected(self) -> None:
+        planned = [_planned()]
+        actual = [_actual(), _actual()]
+        resp = build_comparison(planned, actual, planned_entry_id=1)
+
+        assert resp.has_mismatch is True
+        assert resp.planned_count == 1
+        assert resp.actual_count == 2
+
+    @pytest.mark.parametrize(
+        ("repeats", "actual_count", "expected_mismatch"),
+        [
+            (3, 5, False),  # 3 work + 2 recovery = 5
+            (3, 4, True),  # mismatch
+            (1, 1, False),  # no expansion
+        ],
+    )
+    def test_repeats_expansion_count(
+        self, repeats: int, actual_count: int, expected_mismatch: bool
+    ) -> None:
+        planned = [_planned(segment_type="work", repeats=repeats)]
+        actual = [_actual() for _ in range(actual_count)]
+        resp = build_comparison(planned, actual, planned_entry_id=1)
+
+        expected_expanded = repeats + max(0, repeats - 1)  # work + recovery
+        assert resp.planned_count == expected_expanded
+        assert resp.has_mismatch is expected_mismatch

--- a/frontend/src/api/training.ts
+++ b/frontend/src/api/training.ts
@@ -412,6 +412,41 @@ export async function recalculateSessionZones(
   return response.data;
 }
 
+// --- Soll/Ist-Vergleich (#138) ---
+
+export interface SegmentDelta {
+  pace_delta_seconds: number | null;
+  pace_delta_formatted: string | null;
+  hr_avg_delta: number | null;
+  duration_delta_seconds: number | null;
+  distance_delta_km: number | null;
+}
+
+export interface MatchedSegment {
+  position: number;
+  segment_type: string;
+  match_quality: 'matched' | 'unmatched_planned' | 'unmatched_actual';
+  planned: import('./segment').Segment | null;
+  actual: import('./segment').Segment | null;
+  delta: SegmentDelta | null;
+}
+
+export interface ComparisonResponse {
+  planned_entry_id: number;
+  planned_run_type: string | null;
+  segments: MatchedSegment[];
+  has_mismatch: boolean;
+  planned_count: number;
+  actual_count: number;
+}
+
+export async function getSessionComparison(sessionId: number): Promise<ComparisonResponse> {
+  const response = await apiClient.get<ComparisonResponse>(
+    `/api/v1/sessions/${sessionId}/comparison`,
+  );
+  return response.data;
+}
+
 export async function healthCheck(): Promise<{ status: string }> {
   const response = await apiClient.get<{ status: string }>('/health');
   return response.data;

--- a/frontend/src/components/session-detail/SessionComparisonSection.test.tsx
+++ b/frontend/src/components/session-detail/SessionComparisonSection.test.tsx
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@/test/test-utils';
+import { SessionComparisonSection } from './SessionComparisonSection';
+import type { ComparisonResponse, MatchedSegment, SegmentDelta } from '@/api/training';
+import { createEmptySegment } from '@/api/segment';
+
+function makeSegment(overrides: Partial<ReturnType<typeof createEmptySegment>> = {}) {
+  return createEmptySegment(0, { segment_type: 'steady', ...overrides });
+}
+
+function makeComparison(overrides: Partial<ComparisonResponse> = {}): ComparisonResponse {
+  return {
+    planned_entry_id: 1,
+    planned_run_type: null,
+    segments: [],
+    has_mismatch: false,
+    planned_count: 0,
+    actual_count: 0,
+    ...overrides,
+  };
+}
+
+const nullDelta: SegmentDelta = {
+  pace_delta_seconds: null,
+  pace_delta_formatted: null,
+  hr_avg_delta: null,
+  duration_delta_seconds: null,
+  distance_delta_km: null,
+};
+
+function makeMatched(overrides: Partial<MatchedSegment> = {}): MatchedSegment {
+  return {
+    position: 0,
+    segment_type: 'steady',
+    match_quality: 'matched',
+    planned: makeSegment({ target_pace_min: '5:00', target_pace_max: '5:30' }),
+    actual: makeSegment({ actual_pace_formatted: '5:15' }),
+    delta: { ...nullDelta, pace_delta_seconds: 0, pace_delta_formatted: '+0:00' },
+    ...overrides,
+  };
+}
+
+function makeDelta(overrides: Partial<SegmentDelta> = {}): SegmentDelta {
+  return { ...nullDelta, ...overrides };
+}
+
+describe('SessionComparisonSection — layout', () => {
+  it('renders heading and table', () => {
+    render(<SessionComparisonSection comparison={makeComparison({ segments: [makeMatched()] })} />);
+    expect(screen.getByText('Soll/Ist-Vergleich')).toBeDefined();
+    expect(screen.getByRole('table')).toBeDefined();
+  });
+
+  it('renders run type badge when present', () => {
+    render(
+      <SessionComparisonSection
+        comparison={makeComparison({ planned_run_type: 'easy', segments: [makeMatched()] })}
+      />,
+    );
+    expect(screen.getByText('easy')).toBeDefined();
+  });
+
+  it('does not render run type badge when null', () => {
+    render(<SessionComparisonSection comparison={makeComparison({ segments: [makeMatched()] })} />);
+    expect(screen.queryByText('easy')).toBeNull();
+  });
+
+  it('shows mismatch alert when has_mismatch is true', () => {
+    const comparison = makeComparison({
+      has_mismatch: true,
+      planned_count: 3,
+      actual_count: 5,
+      segments: [makeMatched()],
+    });
+    render(<SessionComparisonSection comparison={comparison} />);
+    expect(screen.getByText(/Segment-Anzahl weicht ab/)).toBeDefined();
+    expect(screen.getByText(/3 geplant/)).toBeDefined();
+  });
+
+  it('hides mismatch alert when has_mismatch is false', () => {
+    render(<SessionComparisonSection comparison={makeComparison({ segments: [makeMatched()] })} />);
+    expect(screen.queryByText(/Segment-Anzahl weicht ab/)).toBeNull();
+  });
+});
+
+describe('SessionComparisonSection — rows + deltas', () => {
+  it('renders correct position numbers', () => {
+    const comparison = makeComparison({
+      segments: [makeMatched({ position: 0 }), makeMatched({ position: 1 })],
+    });
+    render(<SessionComparisonSection comparison={comparison} />);
+    expect(screen.getByText('1')).toBeDefined();
+    expect(screen.getByText('2')).toBeDefined();
+  });
+
+  it('shows pace delta text', () => {
+    const comparison = makeComparison({
+      segments: [
+        makeMatched({
+          delta: makeDelta({ pace_delta_seconds: 12, pace_delta_formatted: '+0:12' }),
+        }),
+      ],
+    });
+    render(<SessionComparisonSection comparison={comparison} />);
+    expect(screen.getByText('+0:12')).toBeDefined();
+  });
+
+  it('shows dash for missing delta values', () => {
+    const comparison = makeComparison({
+      segments: [
+        makeMatched({
+          planned: null,
+          actual: null,
+          match_quality: 'unmatched_planned',
+          delta: null,
+        }),
+      ],
+    });
+    render(<SessionComparisonSection comparison={comparison} />);
+    expect(screen.getAllByText('–').length).toBeGreaterThan(0);
+  });
+
+  it('renders duration delta formatted', () => {
+    const comparison = makeComparison({
+      segments: [makeMatched({ delta: makeDelta({ duration_delta_seconds: 65 }) })],
+    });
+    render(<SessionComparisonSection comparison={comparison} />);
+    expect(screen.getByText('+1:05')).toBeDefined();
+  });
+
+  it('applies error color for positive (slower) pace delta', () => {
+    const comparison = makeComparison({
+      segments: [
+        makeMatched({
+          delta: makeDelta({ pace_delta_seconds: 12, pace_delta_formatted: '+0:12' }),
+        }),
+      ],
+    });
+    render(<SessionComparisonSection comparison={comparison} />);
+    expect(screen.getByText('+0:12').closest('td')?.className).toContain('color-text-error');
+  });
+
+  it('applies success color for negative (faster) pace delta', () => {
+    const comparison = makeComparison({
+      segments: [
+        makeMatched({
+          delta: makeDelta({ pace_delta_seconds: -5, pace_delta_formatted: '-0:05' }),
+        }),
+      ],
+    });
+    render(<SessionComparisonSection comparison={comparison} />);
+    expect(screen.getByText('-0:05').closest('td')?.className).toContain('color-text-success');
+  });
+});

--- a/frontend/src/components/session-detail/SessionComparisonSection.tsx
+++ b/frontend/src/components/session-detail/SessionComparisonSection.tsx
@@ -1,0 +1,162 @@
+import {
+  Card,
+  CardHeader,
+  Alert,
+  AlertDescription,
+  Badge,
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@nordlig/components';
+import type { ComparisonResponse, MatchedSegment } from '@/api/training';
+import type { Segment } from '@/api/segment';
+import { lapTypeLabels } from '@/constants/training';
+
+interface SessionComparisonSectionProps {
+  comparison: ComparisonResponse;
+}
+
+function formatDelta(seconds: number): string {
+  const sign = seconds >= 0 ? '+' : '-';
+  const abs = Math.abs(seconds);
+  const min = Math.floor(abs / 60);
+  const sec = Math.round(abs % 60);
+  if (min > 0) {
+    return `${sign}${min}:${String(sec).padStart(2, '0')}`;
+  }
+  return `${sign}${sec}s`;
+}
+
+function deltaColor(value: number | null): string {
+  if (value == null || value === 0) return '';
+  return value < 0 ? 'text-[var(--color-text-success)]' : 'text-[var(--color-text-error)]';
+}
+
+function formatPaceRange(planned: Segment | null): string {
+  if (!planned) return '–';
+  const { target_pace_min: lo, target_pace_max: hi } = planned;
+  if (lo && hi) return `${lo}–${hi}`;
+  return lo ?? hi ?? '–';
+}
+
+function formatHrRange(planned: Segment | null): string {
+  if (!planned) return '–';
+  const { target_hr_min: lo, target_hr_max: hi } = planned;
+  if (lo != null && hi != null) return `${lo}–${hi}`;
+  return String(lo ?? hi ?? '–');
+}
+
+function formatHrDelta(value: number | null): string {
+  if (value == null) return '–';
+  if (value > 0) return `+${value}`;
+  return String(value);
+}
+
+function formatDurationDelta(seconds: number | null): string {
+  if (seconds == null) return '–';
+  return formatDelta(seconds);
+}
+
+function prepareRowData(seg: MatchedSegment) {
+  const { planned, actual, delta } = seg;
+  const paceDelta = delta?.pace_delta_seconds ?? null;
+  const hrDelta = delta?.hr_avg_delta ?? null;
+  const durDelta = delta?.duration_delta_seconds ?? null;
+
+  return {
+    rowClass: seg.match_quality !== 'matched' ? 'bg-[var(--color-bg-muted)]' : '',
+    typeLabel: lapTypeLabels[seg.segment_type] ?? seg.segment_type,
+    sollPace: formatPaceRange(planned),
+    istPace: actual?.actual_pace_formatted ?? '–',
+    paceDeltaText: delta?.pace_delta_formatted ?? '–',
+    paceDeltaColor: deltaColor(paceDelta),
+    sollHr: formatHrRange(planned),
+    istHr: actual?.actual_hr_avg ?? '–',
+    hrDeltaText: formatHrDelta(hrDelta),
+    hrDeltaColor: deltaColor(hrDelta),
+    durDeltaText: formatDurationDelta(durDelta),
+    durDeltaColor: deltaColor(durDelta),
+  };
+}
+
+function SegmentRow({ seg }: { seg: MatchedSegment }) {
+  const d = prepareRowData(seg);
+
+  return (
+    <TableRow className={d.rowClass}>
+      <TableCell className="font-medium text-[var(--color-text-muted)] sticky left-0 z-10 bg-[var(--color-bg-elevated)]">
+        {seg.position + 1}
+      </TableCell>
+      <TableCell>
+        <Badge variant="neutral" size="xs">
+          {d.typeLabel}
+        </Badge>
+      </TableCell>
+      <TableCell className="hidden sm:table-cell">{d.sollPace}</TableCell>
+      <TableCell>{d.istPace}</TableCell>
+      <TableCell className={d.paceDeltaColor}>{d.paceDeltaText}</TableCell>
+      <TableCell className="hidden sm:table-cell">{d.sollHr}</TableCell>
+      <TableCell className="hidden sm:table-cell">{d.istHr}</TableCell>
+      <TableCell className={`hidden sm:table-cell ${d.hrDeltaColor}`}>{d.hrDeltaText}</TableCell>
+      <TableCell className={d.durDeltaColor}>{d.durDeltaText}</TableCell>
+    </TableRow>
+  );
+}
+
+export function SessionComparisonSection({ comparison }: SessionComparisonSectionProps) {
+  return (
+    <section aria-label="Soll/Ist-Vergleich">
+      <Card elevation="raised">
+        <CardHeader className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
+          <h2 className="text-sm font-semibold text-[var(--color-text-base)]">
+            Soll/Ist-Vergleich
+          </h2>
+          {comparison.planned_run_type && (
+            <Badge variant="neutral" size="xs">
+              {comparison.planned_run_type}
+            </Badge>
+          )}
+        </CardHeader>
+
+        {comparison.has_mismatch && (
+          <div className="px-[var(--spacing-card-padding-normal)] pb-3">
+            <Alert variant="info">
+              <AlertDescription>
+                Segment-Anzahl weicht ab: {comparison.planned_count} geplant,{' '}
+                {comparison.actual_count} tatsächlich
+              </AlertDescription>
+            </Alert>
+          </div>
+        )}
+
+        <div className="overflow-x-auto -mx-[var(--spacing-card-padding-normal)]">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-12 sticky left-0 z-10 bg-[var(--color-table-header-bg)]">
+                  #
+                </TableHead>
+                <TableHead>Typ</TableHead>
+                <TableHead className="hidden sm:table-cell">Soll Pace</TableHead>
+                <TableHead>Ist Pace</TableHead>
+                <TableHead>± Pace</TableHead>
+                <TableHead className="hidden sm:table-cell">Soll HF</TableHead>
+                <TableHead className="hidden sm:table-cell">Ist HF</TableHead>
+                <TableHead className="hidden sm:table-cell">± HF</TableHead>
+                <TableHead>± Dauer</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {comparison.segments.map((seg) => (
+                <SegmentRow key={seg.position} seg={seg} />
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </Card>
+    </section>
+  );
+}

--- a/frontend/src/components/session-detail/index.ts
+++ b/frontend/src/components/session-detail/index.ts
@@ -4,3 +4,4 @@ export { SessionHRZonesSection } from './SessionHRZonesSection';
 export { SessionSplitsSection } from './SessionSplitsSection';
 export { SessionExercisesSection } from './SessionExercisesSection';
 export { SessionEditFields } from './SessionEditFields';
+export { SessionComparisonSection } from './SessionComparisonSection';

--- a/frontend/src/hooks/useSessionData.ts
+++ b/frontend/src/hooks/useSessionData.ts
@@ -1,7 +1,20 @@
 import { useState, useCallback, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
-import { getSession, getSessionTrack, getWorkingZones, getKmSplits } from '@/api/training';
-import type { SessionDetail, LapDetail, HRZone, GPSTrack, KmSplit } from '@/api/training';
+import {
+  getSession,
+  getSessionTrack,
+  getWorkingZones,
+  getKmSplits,
+  getSessionComparison,
+} from '@/api/training';
+import type {
+  SessionDetail,
+  LapDetail,
+  HRZone,
+  GPSTrack,
+  KmSplit,
+  ComparisonResponse,
+} from '@/api/training';
 import { useToast } from '@nordlig/components';
 
 export interface SessionData {
@@ -17,6 +30,7 @@ export interface SessionData {
   sessionGap: string | null;
   workingHrZones: Record<string, HRZone> | null;
   setWorkingHrZones: React.Dispatch<React.SetStateAction<Record<string, HRZone> | null>>;
+  comparison: ComparisonResponse | null;
   reload: () => Promise<void>;
 }
 
@@ -33,6 +47,7 @@ export function useSessionData(sessionId: number): SessionData {
   const [kmSplits, setKmSplits] = useState<KmSplit[] | null>(null);
   const [sessionGap, setSessionGap] = useState<string | null>(null);
   const [workingHrZones, setWorkingHrZones] = useState<Record<string, HRZone> | null>(null);
+  const [comparison, setComparison] = useState<ComparisonResponse | null>(null);
 
   // eslint-disable-next-line complexity -- loading multiple dependent resources
   const loadSession = useCallback(async () => {
@@ -80,6 +95,16 @@ export function useSessionData(sessionId: number): SessionData {
           // working HR zones are optional
         }
       }
+
+      // Soll/Ist-Vergleich laden (nur wenn planned_entry_id vorhanden)
+      if (data.planned_entry_id != null) {
+        try {
+          const compData = await getSessionComparison(sessionId);
+          setComparison(compData);
+        } catch {
+          // comparison is optional
+        }
+      }
     } catch {
       setError('Session konnte nicht geladen werden.');
     } finally {
@@ -112,6 +137,7 @@ export function useSessionData(sessionId: number): SessionData {
     sessionGap,
     workingHrZones,
     setWorkingHrZones,
+    comparison,
     reload: loadSession,
   };
 }

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -59,6 +59,7 @@ import {
   SessionSplitsSection,
   SessionExercisesSection,
   SessionEditFields,
+  SessionComparisonSection,
 } from '@/components/session-detail';
 
 const workoutTypeHeadings: Record<string, string> = {
@@ -359,6 +360,9 @@ export function SessionDetailPage() {
       {hrZones && Object.keys(hrZones).length > 0 && (
         <SessionHRZonesSection hrZones={hrZones} workingHrZones={workingHrZones} />
       )}
+
+      {/* Soll/Ist-Vergleich */}
+      {data.comparison && <SessionComparisonSection comparison={data.comparison} />}
 
       {/* Laps / Km Splits */}
       {(data.localLaps.length > 0 || kmSplits) && (


### PR DESCRIPTION
## Summary

- Backend: Segment-Matching-Service (`segment_matcher.py`) — expandiert geplante Segmente, paired positionsbasiert mit Actual-Laps, berechnet Pace/HR/Dauer/Distanz-Deltas (Range-basiert: 0 wenn innerhalb Soll-Bereich)
- Backend: `GET /api/v1/sessions/{id}/comparison` Endpoint mit `ComparisonResponse` Pydantic Model
- Frontend: `SessionComparisonSection` Komponente — Vergleichstabelle mit Farbcodierung (grün=schneller, rot=langsamer), Mismatch-Alert, responsive (hidden columns auf Mobile)
- 38 Backend-Tests (Unit + Integration), 11 Frontend-Tests

Closes #138

## Test plan

- [x] Backend: `pytest app/tests/test_segment_matcher.py -x` — 38 Tests bestanden
- [x] Frontend: `npx vitest --run` — 162 Tests bestanden (11 neue)
- [x] TSC, ESLint 0 Warnings, Prettier, Ruff, Mypy — alle grün
- [x] Preview-Server: Session mit `planned_entry_id` zeigt Vergleichstabelle korrekt an
- [ ] CI-Pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)