### PR TITLE
fix: SessionComparisonSection — Badge entfernt, Alert volle Breite

### DIFF
--- a/frontend/src/components/session-detail/SessionComparisonSection.test.tsx
+++ b/frontend/src/components/session-detail/SessionComparisonSection.test.tsx
@@ -51,20 +51,6 @@ describe('SessionComparisonSection — layout', () => {
     expect(screen.getByRole('table')).toBeDefined();
   });
 
-  it('renders run type badge when present', () => {
-    render(
-      <SessionComparisonSection
-        comparison={makeComparison({ planned_run_type: 'easy', segments: [makeMatched()] })}
-      />,
-    );
-    expect(screen.getByText('easy')).toBeDefined();
-  });
-
-  it('does not render run type badge when null', () => {
-    render(<SessionComparisonSection comparison={makeComparison({ segments: [makeMatched()] })} />);
-    expect(screen.queryByText('easy')).toBeNull();
-  });
-
   it('shows mismatch alert when has_mismatch is true', () => {
     const comparison = makeComparison({
       has_mismatch: true,

--- a/frontend/src/components/session-detail/SessionComparisonSection.tsx
+++ b/frontend/src/components/session-detail/SessionComparisonSection.tsx
@@ -110,19 +110,14 @@ export function SessionComparisonSection({ comparison }: SessionComparisonSectio
   return (
     <section aria-label="Soll/Ist-Vergleich">
       <Card elevation="raised">
-        <CardHeader className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
+        <CardHeader>
           <h2 className="text-sm font-semibold text-[var(--color-text-base)]">
             Soll/Ist-Vergleich
           </h2>
-          {comparison.planned_run_type && (
-            <Badge variant="neutral" size="xs">
-              {comparison.planned_run_type}
-            </Badge>
-          )}
         </CardHeader>
 
         {comparison.has_mismatch && (
-          <div className="px-[var(--spacing-card-padding-normal)] pb-3">
+          <div className="pb-3 -mt-1">
             <Alert variant="info">
               <AlertDescription>
                 Segment-Anzahl weicht ab: {comparison.planned_count} geplant,{' '}


### PR DESCRIPTION
## Summary
- Überflüssige run_type Badge aus CardHeader entfernt (redundant innerhalb einer Session)
- Alert-Wrapper-Padding entfernt für volle Breite innerhalb der Card (keine DS-Style-Overrides)
- 2 Badge-Tests entfernt, 9 Tests verbleiben

Closes #138

## Test plan
- [x] 160 Frontend-Tests grün
- [x] ESLint + Prettier + TSC clean
- [x] Visuell verifiziert via Preview-Screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)