### PR TITLE
fix: E2E Smoke Tests stabilisieren — False Positives eliminieren (#229)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,23 +211,27 @@ jobs:
         env:
           PROD_URL: http://training.89.167.78.223.sslip.io
         run: |
-          echo "Polling $PROD_URL/health alle 15 Sekunden (max 5 Minuten)..."
+          echo "Warte 30s damit Coolify den Build starten kann..."
+          sleep 30
+
+          echo "Polling $PROD_URL/health alle 15 Sekunden (max 6 Minuten)..."
 
           HEALTHY=false
-          for i in $(seq 1 20); do
-            echo "Versuch $i/20..."
+          for i in $(seq 1 24); do
+            echo "Versuch $i/24..."
             HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$PROD_URL/health" --connect-timeout 5 --max-time 10 2>/dev/null || echo "000")
 
             if [ "$HTTP_CODE" = "200" ]; then
               BODY=$(curl -s "$PROD_URL/health" --connect-timeout 5 --max-time 10 2>/dev/null || echo "{}")
               STATUS=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null || echo "")
+              DB_OK=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('db', False))" 2>/dev/null || echo "False")
 
-              if [ "$STATUS" = "ok" ]; then
-                echo "Health Check bestanden (Versuch $i)"
+              if [ "$STATUS" = "ok" ] && [ "$DB_OK" = "True" ]; then
+                echo "Health Check bestanden inkl. DB (Versuch $i)"
                 HEALTHY=true
                 break
               else
-                echo "HTTP 200 aber Status nicht 'ok': $BODY"
+                echo "HTTP 200 aber noch nicht voll bereit: $BODY"
               fi
             else
               echo "HTTP $HTTP_CODE — noch nicht bereit"
@@ -239,7 +243,7 @@ jobs:
           echo "healthy=$HEALTHY" >> $GITHUB_OUTPUT
 
           if [ "$HEALTHY" = "false" ]; then
-            echo "::error::Deployment Health Check fehlgeschlagen nach 5 Minuten"
+            echo "::error::Deployment Health Check fehlgeschlagen nach 6 Minuten"
             exit 1
           fi
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,10 +5,11 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
+from sqlalchemy import text
 
 from app.api.v1.router import api_router
 from app.core.config import settings
-from app.infrastructure.database.session import init_db
+from app.infrastructure.database.session import async_session_maker, init_db
 from app.routers import training
 
 
@@ -52,4 +53,9 @@ async def root():
 
 @app.get("/health")
 async def health():
-    return {"status": "ok", "environment": settings.environment}
+    try:
+        async with async_session_maker() as session:
+            await session.execute(text("SELECT 1"))
+    except Exception:
+        return {"status": "degraded", "environment": settings.environment, "db": False}
+    return {"status": "ok", "environment": settings.environment, "db": True}

--- a/backend/app/tests/test_health.py
+++ b/backend/app/tests/test_health.py
@@ -19,6 +19,7 @@ async def test_health_endpoint(client: AsyncClient):
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "ok"
+    assert data["db"] is True
 
 
 @pytest.mark.unit

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,17 +1,22 @@
 import type { FullConfig } from "@playwright/test";
 
 const POLL_INTERVAL_MS = 5_000;
-const MAX_WAIT_MS = 60_000;
+const MAX_WAIT_MS = 90_000;
 
 /**
- * Wartet bis der Production-Server gesund ist, bevor Tests starten.
- * Verhindert flaky Tests durch transiente Downtime nach Coolify-Deploy.
+ * Wartet bis der Production-Server vollständig bereit ist, bevor Tests starten.
+ * Prüft sowohl /health (inkl. DB-Ping) als auch einen API-Endpoint.
  */
 export default async function globalSetup(config: FullConfig): Promise<void> {
   const baseURL =
     config.projects[0]?.use?.baseURL ?? "http://training.89.167.78.223.sslip.io";
-  const healthURL = `${baseURL}/health`;
 
+  await waitForHealth(baseURL);
+  await waitForAPI(baseURL);
+}
+
+async function waitForHealth(baseURL: string): Promise<void> {
+  const healthURL = `${baseURL}/health`;
   console.log(`[global-setup] Warte auf Health Check: ${healthURL}`);
 
   const start = Date.now();
@@ -23,16 +28,19 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
       });
 
       if (response.ok) {
-        const body = (await response.json()) as { status?: string };
-        if (body.status === "ok") {
+        const body = (await response.json()) as {
+          status?: string;
+          db?: boolean;
+        };
+        if (body.status === "ok" && body.db === true) {
           const elapsed = ((Date.now() - start) / 1000).toFixed(1);
           console.log(
-            `[global-setup] Server gesund nach ${elapsed}s`,
+            `[global-setup] Server gesund (inkl. DB) nach ${elapsed}s`,
           );
           return;
         }
         console.log(
-          `[global-setup] HTTP 200 aber status="${body.status}" — retry...`,
+          `[global-setup] status="${body.status}", db=${body.db} — retry...`,
         );
       } else {
         console.log(
@@ -50,5 +58,38 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
 
   throw new Error(
     `[global-setup] Server nicht gesund nach ${MAX_WAIT_MS / 1000}s — Tests abgebrochen`,
+  );
+}
+
+async function waitForAPI(baseURL: string): Promise<void> {
+  const apiURL = `${baseURL}/api/v1/health`;
+  console.log(`[global-setup] Prüfe API-Readiness: ${apiURL}`);
+
+  const start = Date.now();
+  const apiTimeout = 30_000;
+
+  while (Date.now() - start < apiTimeout) {
+    try {
+      const response = await fetch(apiURL, {
+        signal: AbortSignal.timeout(5_000),
+      });
+
+      if (response.ok) {
+        const body = (await response.json()) as { status?: string };
+        if (body.status === "healthy") {
+          const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+          console.log(`[global-setup] API bereit nach ${elapsed}s`);
+          return;
+        }
+      }
+    } catch {
+      // retry
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+
+  throw new Error(
+    `[global-setup] API nicht bereit nach ${apiTimeout / 1000}s — Tests abgebrochen`,
   );
 }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -6,8 +6,8 @@ const PRODUCTION_URL =
 export default defineConfig({
   globalSetup: "./global-setup.ts",
   testDir: "./smoke",
-  timeout: 30_000,
-  expect: { timeout: 10_000 },
+  timeout: 45_000,
+  expect: { timeout: 15_000 },
   fullyParallel: true,
   retries: 2,
   reporter: [["html", { open: "never" }], ["list"]],

--- a/e2e/smoke/dashboard.spec.ts
+++ b/e2e/smoke/dashboard.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from "@playwright/test";
 test.describe("Dashboard", () => {
   test("lädt und zeigt Inhalt", async ({ page }) => {
     await page.goto("/dashboard");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     // Kein Error-Boundary sichtbar
     await expect(
@@ -18,7 +18,7 @@ test.describe("Dashboard", () => {
 
   test("zeigt App-Branding", async ({ page }) => {
     await page.goto("/dashboard");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     // Zwei Logos existieren: Sidebar (hidden auf Mobile) + TopBar (hidden auf Desktop)
     // Prüfe, dass mindestens eines sichtbar ist

--- a/e2e/smoke/navigation.spec.ts
+++ b/e2e/smoke/navigation.spec.ts
@@ -12,7 +12,7 @@ test.describe("Navigation", () => {
   for (const { path, name } of pages) {
     test(`${name} (${path}) ist erreichbar`, async ({ page }) => {
       await page.goto(path);
-      await page.waitForLoadState("networkidle");
+      await page.waitForLoadState("domcontentloaded");
 
       // Richtige URL
       await expect(page).toHaveURL(new RegExp(path));
@@ -29,7 +29,7 @@ test.describe("Navigation", () => {
 
   test("404-Seite bei unbekannter Route", async ({ page }) => {
     await page.goto("/diese-seite-gibt-es-nicht");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     // Sollte eine 404-Anzeige haben (oder Redirect)
     // Mindestens: kein weißer Screen

--- a/e2e/smoke/responsive.spec.ts
+++ b/e2e/smoke/responsive.spec.ts
@@ -5,7 +5,7 @@ test.describe("Responsive Layout", () => {
     test.skip(testInfo.project.name === "desktop", "Nur Mobile");
 
     await page.goto("/dashboard");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     // BottomNav enthält die 5 Navigations-Links
     const bottomNav = page.locator("nav").filter({
@@ -23,7 +23,7 @@ test.describe("Responsive Layout", () => {
     test.skip(testInfo.project.name === "desktop", "Nur Mobile");
 
     await page.goto("/dashboard");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     // Sidebar hat class "hidden lg:flex" — auf Mobile nicht sichtbar
     // Prüfen über den Sidebar-spezifischen User-Chip "NC"
@@ -37,7 +37,7 @@ test.describe("Responsive Layout", () => {
     test.skip(testInfo.project.name === "mobile", "Nur Desktop");
 
     await page.goto("/dashboard");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     // Sidebar mit "Training Analyzer" Branding und User-Chip
     const sidebar = page.locator("nav").filter({
@@ -58,7 +58,7 @@ test.describe("Responsive Layout", () => {
     test.skip(testInfo.project.name === "mobile", "Nur Desktop");
 
     await page.goto("/dashboard");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     // BottomNav hat class "lg:hidden" — auf Desktop nicht sichtbar
     const bottomNav = page.locator("nav").filter({

--- a/e2e/smoke/sessions.spec.ts
+++ b/e2e/smoke/sessions.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from "@playwright/test";
 test.describe("Sessions", () => {
   test("Sessions-Seite lädt", async ({ page }) => {
     await page.goto("/sessions");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     // Kein Error-Boundary
     await expect(


### PR DESCRIPTION
## Summary

- `/health` prüft jetzt DB-Verbindung (`SELECT 1`) — kein Fake-Check mehr
- `networkidle` → `domcontentloaded` in allen Smoke Tests (React Query kompatibel)
- globalSetup prüft `/health` (inkl. DB) UND `/api/v1/health` vor Teststart
- deploy-verify: 30s Initial-Wait + DB-Check + mehr Polling-Zeit (6 Min)
- Playwright Timeouts großzügiger (test 45s, expect 15s)

## Root Causes behoben

| Problem | Fix |
|---------|-----|
| `/health` gibt "ok" ohne DB-Check | `SELECT 1` gegen DB |
| `networkidle` timeout bei React Query Polling | `domcontentloaded` |
| globalSetup prüft nur `/health`, nicht API | Zusätzlich `/api/v1/health` |
| deploy-verify startet sofort nach Deploy-Trigger | 30s Initial-Wait |
| Zu knappe Timeouts (30s/10s) | 45s/15s |

Closes #229
Closes #227

## Test plan

- [ ] CI-Pipeline grün (Backend lint/test, Frontend lint/test/build)
- [ ] E2E Smoke Tests bestehen gegen Produktion
- [ ] `/health` gibt `{"status": "ok", "db": true}` zurück wenn DB erreichbar
- [ ] `/health` gibt `{"status": "degraded", "db": false}` zurück wenn DB offline

🤖 Generated with [Claude Code](https://claude.com/claude-code)