### PR TITLE
fix: Badge-Varianten aus lapTypeBadgeVariant wiederverwenden

### DIFF
--- a/frontend/src/components/session-detail/SessionComparisonSection.tsx
+++ b/frontend/src/components/session-detail/SessionComparisonSection.tsx
@@ -13,7 +13,7 @@ import {
 } from '@nordlig/components';
 import type { ComparisonResponse, MatchedSegment } from '@/api/training';
 import type { Segment } from '@/api/segment';
-import { lapTypeLabels } from '@/constants/training';
+import { lapTypeLabels, lapTypeBadgeVariant } from '@/constants/training';
 
 interface SessionComparisonSectionProps {
   comparison: ComparisonResponse;
@@ -91,7 +91,7 @@ function SegmentRow({ seg }: { seg: MatchedSegment }) {
         {seg.position + 1}
       </TableCell>
       <TableCell>
-        <Badge variant="neutral" size="xs">
+        <Badge variant={lapTypeBadgeVariant[seg.segment_type] ?? 'neutral'} size="xs">
           {d.typeLabel}
         </Badge>
       </TableCell>


### PR DESCRIPTION
## Summary
- `SessionComparisonSection` nutzte hardcoded `variant="neutral"` für alle Segment-Type-Badges
- Jetzt wird `lapTypeBadgeVariant` aus `constants/training.ts` wiederverwendet — dasselbe Mapping wie in `SessionSplitsSection`
- Badges sind damit konsistent über alle Tabellen hinweg

Closes #138

## Test plan
- [x] 160 Frontend-Tests grün
- [x] TSC + ESLint + Prettier clean
- [x] Badges visuell konsistent mit Lap-Tabelle

🤖 Generated with [Claude Code](https://claude.com/claude-code)