### PR TITLE
feat: Claude API Fallback für Übungs-Anreicherung (#75)

### DIFF
--- a/backend/app/api/v1/exercise_library.py
+++ b/backend/app/api/v1/exercise_library.py
@@ -631,8 +631,12 @@ async def create_exercise(
         is_favorite=False,
     )
 
-    # Try to enrich from free-exercise-db
+    # Try to enrich from free-exercise-db, then Claude API fallback
     enrichment = enrich_exercise_model(body.name)
+    if not enrichment:
+        from app.services.exercise_ai_enrichment import generate_exercise_enrichment
+
+        enrichment = await generate_exercise_enrichment(body.name, body.category)
     if enrichment:
         _apply_enrichment(exercise, enrichment)
 
@@ -761,6 +765,15 @@ async def enrich_exercise(
         enrichment = enrich_exercise_model_by_id(body.exercise_db_id)
     else:
         enrichment = enrich_exercise_model(str(exercise.name))
+
+    if not enrichment:
+        # Fallback: Claude API für Anreicherung nutzen
+        from app.services.exercise_ai_enrichment import generate_exercise_enrichment
+
+        enrichment = await generate_exercise_enrichment(
+            str(exercise.name),
+            str(exercise.category),
+        )
 
     if not enrichment:
         raise HTTPException(

--- a/backend/app/services/exercise_ai_enrichment.py
+++ b/backend/app/services/exercise_ai_enrichment.py
@@ -1,0 +1,172 @@
+"""Claude API Fallback für Übungs-Anreicherung.
+
+Wenn free-exercise-db keinen Match liefert, generiert Claude
+Anleitungen, Muskelgruppen und Metadaten für eine Übung.
+"""
+
+import json
+import logging
+from typing import Optional
+
+import anthropic
+
+from app.core.config import settings
+from app.services.exercise_enrichment import VALID_MUSCLES
+
+logger = logging.getLogger(__name__)
+
+# Erlaubte Werte für strukturierte Felder
+_VALID_EQUIPMENT = {
+    "barbell",
+    "dumbbell",
+    "cable",
+    "machine",
+    "kettlebell",
+    "body_only",
+    "bands",
+    "medicine_ball",
+    "exercise_ball",
+    "foam_roll",
+    "e-z_curl_bar",
+    "other",
+}
+_VALID_LEVELS = {"beginner", "intermediate", "advanced"}
+_VALID_FORCE = {"push", "pull", "static"}
+_VALID_MECHANIC = {"compound", "isolation"}
+
+
+def _build_prompt(exercise_name: str, category: str) -> str:
+    """Erstelle den Prompt für die Übungs-Anreicherung."""
+    muscles_list = ", ".join(sorted(VALID_MUSCLES))
+    equipment_list = ", ".join(sorted(_VALID_EQUIPMENT))
+
+    return f"""Du bist ein Fitness-Experte. Generiere detaillierte Informationen für folgende Übung:
+
+Name: {exercise_name}
+Kategorie: {category}
+
+Antworte ausschließlich mit validem JSON (kein Markdown, keine Erklärung).
+Das JSON muss exakt dieses Schema haben:
+
+{{
+  "instructions": ["Schritt 1...", "Schritt 2...", "Schritt 3..."],
+  "primary_muscles": ["muscle1", "muscle2"],
+  "secondary_muscles": ["muscle3"],
+  "equipment": "equipment_type",
+  "level": "beginner|intermediate|advanced",
+  "force": "push|pull|static",
+  "mechanic": "compound|isolation"
+}}
+
+Regeln:
+- "instructions": 3-6 Schritte auf Deutsch, präzise Ausführungsbeschreibung
+- "primary_muscles": Hauptmuskeln (englisch), erlaubt: {muscles_list}
+- "secondary_muscles": Hilfsmuskeln (englisch), erlaubt: {muscles_list}
+- "equipment": eines von: {equipment_list}
+- "level": eines von: beginner, intermediate, advanced
+- "force": eines von: push, pull, static
+- "mechanic": eines von: compound, isolation
+
+Nur valides JSON ausgeben, nichts anderes."""
+
+
+def _validate_and_normalize(data: dict) -> Optional[dict]:
+    """Validiere und normalisiere die Claude-Antwort."""
+    # instructions: muss Liste von Strings sein
+    instructions = data.get("instructions")
+    if not isinstance(instructions, list) or len(instructions) == 0:
+        logger.warning("Claude-Antwort: instructions fehlt oder leer")
+        return None
+    instructions = [str(s) for s in instructions if s]
+    if not instructions:
+        return None
+
+    # primary_muscles: muss Liste sein, nur gültige Werte
+    primary = data.get("primary_muscles", [])
+    if not isinstance(primary, list):
+        primary = []
+    primary = [m for m in primary if m in VALID_MUSCLES]
+    if not primary:
+        logger.warning("Claude-Antwort: keine gültigen primary_muscles")
+        return None
+
+    # secondary_muscles: optional, nur gültige Werte
+    secondary = data.get("secondary_muscles", [])
+    if not isinstance(secondary, list):
+        secondary = []
+    secondary = [m for m in secondary if m in VALID_MUSCLES]
+
+    # Skalare Felder validieren
+    equipment = data.get("equipment")
+    if equipment not in _VALID_EQUIPMENT:
+        equipment = None
+
+    level = data.get("level")
+    if level not in _VALID_LEVELS:
+        level = None
+
+    force = data.get("force")
+    if force not in _VALID_FORCE:
+        force = None
+
+    mechanic = data.get("mechanic")
+    if mechanic not in _VALID_MECHANIC:
+        mechanic = None
+
+    return {
+        "instructions_json": json.dumps(instructions),
+        "primary_muscles_json": json.dumps(primary),
+        "secondary_muscles_json": json.dumps(secondary),
+        "image_urls_json": json.dumps([]),
+        "equipment": equipment,
+        "level": level,
+        "force": force,
+        "mechanic": mechanic,
+        "exercise_db_id": None,
+    }
+
+
+async def generate_exercise_enrichment(
+    exercise_name: str,
+    category: str,
+) -> Optional[dict[str, Optional[str]]]:
+    """Generiere Übungs-Anreicherung über Claude API.
+
+    Fallback wenn free-exercise-db keinen Match hat.
+    Gibt DB-ready Column-Values zurück (gleiches Format wie
+    ``exercise_enrichment._to_db_columns``), oder ``None`` bei Fehler.
+    """
+    if not settings.claude_api_key:
+        logger.debug("Claude API Key nicht konfiguriert — Fallback übersprungen")
+        return None
+
+    prompt = _build_prompt(exercise_name, category)
+
+    try:
+        client = anthropic.Anthropic(api_key=settings.claude_api_key)
+        response = client.messages.create(
+            model=settings.claude_model,
+            max_tokens=1000,
+            temperature=0.2,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        raw_text = response.content[0].text  # type: ignore[union-attr]
+    except Exception:
+        logger.exception("Claude API Fehler bei Übungs-Anreicherung für '%s'", exercise_name)
+        return None
+
+    # JSON parsen
+    try:
+        data = json.loads(raw_text)
+    except json.JSONDecodeError:
+        logger.warning(
+            "Claude-Antwort ist kein valides JSON für '%s': %s",
+            exercise_name,
+            raw_text[:200],
+        )
+        return None
+
+    result = _validate_and_normalize(data)
+    if result:
+        logger.info("Claude AI Enrichment erfolgreich für '%s'", exercise_name)
+    return result

--- a/backend/app/tests/test_exercise_ai_enrichment.py
+++ b/backend/app/tests/test_exercise_ai_enrichment.py
@@ -1,0 +1,256 @@
+"""Tests für Claude API Fallback bei Übungs-Anreicherung."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.exercise_ai_enrichment import (
+    _validate_and_normalize,
+    generate_exercise_enrichment,
+)
+
+
+class TestValidateAndNormalize:
+    """Unit Tests für die Validierung der Claude-Antwort."""
+
+    def test_valid_response(self) -> None:
+        """Vollständige gültige Antwort wird korrekt normalisiert."""
+        data = {
+            "instructions": ["Schritt 1", "Schritt 2", "Schritt 3"],
+            "primary_muscles": ["chest", "triceps"],
+            "secondary_muscles": ["shoulders"],
+            "equipment": "barbell",
+            "level": "intermediate",
+            "force": "push",
+            "mechanic": "compound",
+        }
+        result = _validate_and_normalize(data)
+        assert result is not None
+        assert json.loads(result["instructions_json"]) == ["Schritt 1", "Schritt 2", "Schritt 3"]
+        assert json.loads(result["primary_muscles_json"]) == ["chest", "triceps"]
+        assert json.loads(result["secondary_muscles_json"]) == ["shoulders"]
+        assert json.loads(result["image_urls_json"]) == []
+        assert result["equipment"] == "barbell"
+        assert result["level"] == "intermediate"
+        assert result["force"] == "push"
+        assert result["mechanic"] == "compound"
+        assert result["exercise_db_id"] is None
+
+    def test_missing_instructions_returns_none(self) -> None:
+        """Fehlende Anleitungen führen zu None."""
+        data = {
+            "instructions": [],
+            "primary_muscles": ["chest"],
+        }
+        assert _validate_and_normalize(data) is None
+
+    def test_missing_primary_muscles_returns_none(self) -> None:
+        """Fehlende Hauptmuskeln führen zu None."""
+        data = {
+            "instructions": ["Schritt 1"],
+            "primary_muscles": [],
+        }
+        assert _validate_and_normalize(data) is None
+
+    def test_invalid_muscles_filtered(self) -> None:
+        """Ungültige Muskelnamen werden herausgefiltert."""
+        data = {
+            "instructions": ["Schritt 1"],
+            "primary_muscles": ["chest", "invalid_muscle", "biceps"],
+            "secondary_muscles": ["fake_muscle"],
+        }
+        result = _validate_and_normalize(data)
+        assert result is not None
+        assert json.loads(result["primary_muscles_json"]) == ["chest", "biceps"]
+        assert json.loads(result["secondary_muscles_json"]) == []
+
+    def test_invalid_equipment_becomes_none(self) -> None:
+        """Ungültiges Equipment wird zu None."""
+        data = {
+            "instructions": ["Schritt 1"],
+            "primary_muscles": ["chest"],
+            "equipment": "invalid_thing",
+        }
+        result = _validate_and_normalize(data)
+        assert result is not None
+        assert result["equipment"] is None
+
+    def test_invalid_level_becomes_none(self) -> None:
+        """Ungültiges Level wird zu None."""
+        data = {
+            "instructions": ["Schritt 1"],
+            "primary_muscles": ["chest"],
+            "level": "expert",
+        }
+        result = _validate_and_normalize(data)
+        assert result is not None
+        assert result["level"] is None
+
+    def test_invalid_force_becomes_none(self) -> None:
+        """Ungültige Force wird zu None."""
+        data = {
+            "instructions": ["Schritt 1"],
+            "primary_muscles": ["chest"],
+            "force": "twist",
+        }
+        result = _validate_and_normalize(data)
+        assert result is not None
+        assert result["force"] is None
+
+    def test_invalid_mechanic_becomes_none(self) -> None:
+        """Ungültige Mechanic wird zu None."""
+        data = {
+            "instructions": ["Schritt 1"],
+            "primary_muscles": ["chest"],
+            "mechanic": "hybrid",
+        }
+        result = _validate_and_normalize(data)
+        assert result is not None
+        assert result["mechanic"] is None
+
+    def test_instructions_not_a_list(self) -> None:
+        """Instructions als String statt Liste gibt None."""
+        data = {
+            "instructions": "nur ein string",
+            "primary_muscles": ["chest"],
+        }
+        assert _validate_and_normalize(data) is None
+
+    def test_minimal_valid_response(self) -> None:
+        """Minimale gültige Antwort (nur Pflichtfelder)."""
+        data = {
+            "instructions": ["Mach das"],
+            "primary_muscles": ["quadriceps"],
+        }
+        result = _validate_and_normalize(data)
+        assert result is not None
+        assert json.loads(result["instructions_json"]) == ["Mach das"]
+        assert json.loads(result["primary_muscles_json"]) == ["quadriceps"]
+        assert json.loads(result["secondary_muscles_json"]) == []
+        assert result["equipment"] is None
+        assert result["level"] is None
+
+
+class TestGenerateExerciseEnrichment:
+    """Tests für die Claude API Integration."""
+
+    @pytest.mark.asyncio
+    async def test_no_api_key_returns_none(self) -> None:
+        """Ohne API-Key wird sofort None zurückgegeben."""
+        with patch("app.services.exercise_ai_enrichment.settings") as mock_settings:
+            mock_settings.claude_api_key = ""
+            result = await generate_exercise_enrichment("Test Übung", "push")
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_successful_api_call(self) -> None:
+        """Erfolgreicher API-Call gibt normalisierte Daten zurück."""
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(
+                text=json.dumps(
+                    {
+                        "instructions": ["Schritt 1", "Schritt 2"],
+                        "primary_muscles": ["chest", "triceps"],
+                        "secondary_muscles": ["shoulders"],
+                        "equipment": "barbell",
+                        "level": "intermediate",
+                        "force": "push",
+                        "mechanic": "compound",
+                    }
+                )
+            )
+        ]
+
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = mock_response
+
+        with (
+            patch("app.services.exercise_ai_enrichment.settings") as mock_settings,
+            patch("app.services.exercise_ai_enrichment.anthropic") as mock_anthropic,
+        ):
+            mock_settings.claude_api_key = "test-key"
+            mock_settings.claude_model = "claude-sonnet-4-20250514"
+            mock_anthropic.Anthropic.return_value = mock_client
+
+            result = await generate_exercise_enrichment("Bankdrücken", "push")
+
+        assert result is not None
+        instructions_json = result["instructions_json"]
+        assert instructions_json is not None
+        assert json.loads(instructions_json) == ["Schritt 1", "Schritt 2"]
+        primary_json = result["primary_muscles_json"]
+        assert primary_json is not None
+        assert json.loads(primary_json) == ["chest", "triceps"]
+        assert result["equipment"] == "barbell"
+        assert result["exercise_db_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_api_error_returns_none(self) -> None:
+        """API-Fehler gibt None zurück."""
+        mock_client = MagicMock()
+        mock_client.messages.create.side_effect = Exception("API timeout")
+
+        with (
+            patch("app.services.exercise_ai_enrichment.settings") as mock_settings,
+            patch("app.services.exercise_ai_enrichment.anthropic") as mock_anthropic,
+        ):
+            mock_settings.claude_api_key = "test-key"
+            mock_settings.claude_model = "claude-sonnet-4-20250514"
+            mock_anthropic.Anthropic.return_value = mock_client
+
+            result = await generate_exercise_enrichment("Test", "push")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_response_returns_none(self) -> None:
+        """Ungültiges JSON von der API gibt None zurück."""
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text="Das ist kein JSON")]
+
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = mock_response
+
+        with (
+            patch("app.services.exercise_ai_enrichment.settings") as mock_settings,
+            patch("app.services.exercise_ai_enrichment.anthropic") as mock_anthropic,
+        ):
+            mock_settings.claude_api_key = "test-key"
+            mock_settings.claude_model = "claude-sonnet-4-20250514"
+            mock_anthropic.Anthropic.return_value = mock_client
+
+            result = await generate_exercise_enrichment("Test", "push")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_valid_json_but_invalid_content_returns_none(self) -> None:
+        """Gültiges JSON aber ungültiger Inhalt gibt None zurück."""
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(
+                text=json.dumps(
+                    {
+                        "instructions": [],
+                        "primary_muscles": [],
+                    }
+                )
+            )
+        ]
+
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = mock_response
+
+        with (
+            patch("app.services.exercise_ai_enrichment.settings") as mock_settings,
+            patch("app.services.exercise_ai_enrichment.anthropic") as mock_anthropic,
+        ):
+            mock_settings.claude_api_key = "test-key"
+            mock_settings.claude_model = "claude-sonnet-4-20250514"
+            mock_anthropic.Anthropic.return_value = mock_client
+
+            result = await generate_exercise_enrichment("Test", "push")
+
+        assert result is None

--- a/backend/app/tests/test_exercise_enrichment.py
+++ b/backend/app/tests/test_exercise_enrichment.py
@@ -1,6 +1,7 @@
 """Tests für Exercise Enrichment Service."""
 
 import json
+from unittest.mock import patch
 
 from httpx import AsyncClient
 
@@ -196,13 +197,77 @@ class TestExerciseEnrichmentAPI:
         assert data["instructions"] is not None
         assert data["primary_muscles"] is not None
 
-    async def test_enrich_endpoint_unknown_exercise(self, client: AsyncClient) -> None:
-        """POST /exercises/{id}/enrich returns 404 for unknown exercise."""
+    async def test_enrich_endpoint_unknown_exercise_no_api_key(self, client: AsyncClient) -> None:
+        """POST /exercises/{id}/enrich returns 404 when no DB match and no API key."""
         create_response = await client.post(
             "/api/v1/exercises",
             json={"name": "ZZZ Unknown Custom", "category": "core"},
         )
         exercise_id = create_response.json()["id"]
 
-        response = await client.post(f"/api/v1/exercises/{exercise_id}/enrich")
+        with patch("app.services.exercise_ai_enrichment.settings") as mock_settings:
+            mock_settings.claude_api_key = ""
+            response = await client.post(f"/api/v1/exercises/{exercise_id}/enrich")
         assert response.status_code == 404
+
+    async def test_enrich_endpoint_claude_fallback(self, client: AsyncClient) -> None:
+        """POST /exercises/{id}/enrich uses Claude API when no DB match."""
+        create_response = await client.post(
+            "/api/v1/exercises",
+            json={"name": "Spezialübung XYZ", "category": "core"},
+        )
+        exercise_id = create_response.json()["id"]
+
+        mock_enrichment = {
+            "instructions_json": json.dumps(["Schritt 1", "Schritt 2"]),
+            "primary_muscles_json": json.dumps(["abdominals"]),
+            "secondary_muscles_json": json.dumps([]),
+            "image_urls_json": json.dumps([]),
+            "equipment": "body_only",
+            "level": "intermediate",
+            "force": "static",
+            "mechanic": "isolation",
+            "exercise_db_id": None,
+        }
+
+        with patch(
+            "app.services.exercise_ai_enrichment.generate_exercise_enrichment",
+            return_value=mock_enrichment,
+        ):
+            response = await client.post(f"/api/v1/exercises/{exercise_id}/enrich")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["instructions"] == ["Schritt 1", "Schritt 2"]
+        assert data["primary_muscles"] == ["abdominals"]
+        assert data["equipment"] == "body_only"
+        assert data["exercise_db_id"] is None
+
+    async def test_create_exercise_claude_fallback(self, client: AsyncClient) -> None:
+        """POST /exercises uses Claude fallback for unknown exercises."""
+        mock_enrichment = {
+            "instructions_json": json.dumps(["Ausführung 1"]),
+            "primary_muscles_json": json.dumps(["quadriceps"]),
+            "secondary_muscles_json": json.dumps(["glutes"]),
+            "image_urls_json": json.dumps([]),
+            "equipment": "body_only",
+            "level": "beginner",
+            "force": "push",
+            "mechanic": "compound",
+            "exercise_db_id": None,
+        }
+
+        with patch(
+            "app.services.exercise_ai_enrichment.generate_exercise_enrichment",
+            return_value=mock_enrichment,
+        ):
+            response = await client.post(
+                "/api/v1/exercises",
+                json={"name": "Einzigartige Übung 123", "category": "legs"},
+            )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["instructions"] == ["Ausführung 1"]
+        assert data["primary_muscles"] == ["quadriceps"]
+        assert data["equipment"] == "body_only"


### PR DESCRIPTION
## Summary
- Neuer Service `exercise_ai_enrichment.py`: Claude API generiert Anleitungen, Muskelgruppen und Metadaten für Custom-Übungen wenn free-exercise-db keinen Match liefert
- Enrich-Endpoint (`POST /exercises/{id}/enrich`) nutzt Claude Fallback vor 404-Antwort
- Create-Endpoint (`POST /exercises`) enriched Custom-Übungen automatisch via Claude API

## Test plan
- [x] 15 Unit Tests für `_validate_and_normalize()` und `generate_exercise_enrichment()`
- [x] 3 Integration Tests für Claude Fallback in Enrich- und Create-Endpoints
- [x] Alle 531 Tests grün
- [x] Ruff, Mypy, Ruff Format bestanden

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)