### PR TITLE
fix: E2E Smoke Tests stabilisieren (#229)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,9 @@ jobs:
         env:
           PROD_URL: http://training.89.167.78.223.sslip.io
         run: |
+          echo "Warte 30s auf Coolify Build-Start..."
+          sleep 30
+
           echo "Polling $PROD_URL/health alle 15 Sekunden (max 5 Minuten)..."
 
           HEALTHY=false
@@ -222,12 +225,14 @@ jobs:
               BODY=$(curl -s "$PROD_URL/health" --connect-timeout 5 --max-time 10 2>/dev/null || echo "{}")
               STATUS=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null || echo "")
 
-              if [ "$STATUS" = "ok" ]; then
-                echo "Health Check bestanden (Versuch $i)"
+              DB=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('database',''))" 2>/dev/null || echo "")
+
+              if [ "$STATUS" = "ok" ] && [ "$DB" = "True" ]; then
+                echo "Health Check bestanden (Versuch $i) — DB verbunden"
                 HEALTHY=true
                 break
               else
-                echo "HTTP 200 aber Status nicht 'ok': $BODY"
+                echo "HTTP 200 aber status='$STATUS', database='$DB': $BODY"
               fi
             else
               echo "HTTP $HTTP_CODE — noch nicht bereit"

--- a/backend/app/api/v1/health.py
+++ b/backend/app/api/v1/health.py
@@ -1,8 +1,24 @@
+import logging
+
 from fastapi import APIRouter
+from sqlalchemy import text
+
+from app.infrastructure.database.session import engine
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
 
 @router.get("/health")
 async def health_check():
-    return {"status": "healthy"}
+    db_ok = False
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+        db_ok = True
+    except Exception:
+        logger.warning("Health check: DB-Verbindung fehlgeschlagen")
+
+    status = "healthy" if db_ok else "degraded"
+    return {"status": status, "database": db_ok}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -5,11 +6,14 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
+from sqlalchemy import text
 
 from app.api.v1.router import api_router
 from app.core.config import settings
-from app.infrastructure.database.session import init_db
+from app.infrastructure.database.session import engine, init_db
 from app.routers import training
+
+logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
@@ -52,4 +56,13 @@ async def root():
 
 @app.get("/health")
 async def health():
-    return {"status": "ok", "environment": settings.environment}
+    db_ok = False
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+        db_ok = True
+    except Exception:
+        logger.warning("Health check: DB-Verbindung fehlgeschlagen")
+
+    status = "ok" if db_ok else "degraded"
+    return {"status": status, "environment": settings.environment, "database": db_ok}

--- a/backend/app/tests/test_streak.py
+++ b/backend/app/tests/test_streak.py
@@ -1,6 +1,6 @@
 """Tests for Streak Tracking (Issue #58)."""
 
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 
 import pytest
 from httpx import AsyncClient
@@ -10,9 +10,10 @@ from app.infrastructure.database.models import WorkoutModel
 
 
 async def _add_session(db: AsyncSession, days_ago: int) -> None:
-    """Add a training session N days ago."""
+    """Add a training session N days ago (uses date.today() for consistency with streak API)."""
+    target_date = date.today() - timedelta(days=days_ago)
     workout = WorkoutModel(
-        date=datetime.utcnow() - timedelta(days=days_ago),
+        date=datetime(target_date.year, target_date.month, target_date.day, 12, 0),
         workout_type="running",
         duration_sec=2700,
         distance_km=5.0,
@@ -104,5 +105,5 @@ async def test_calendar_heatmap(client: AsyncClient, db_session: AsyncSession) -
     # Should have exactly 2 entries
     assert len(calendar) == 2
     # Today should have count 2
-    today_str = datetime.utcnow().strftime("%Y-%m-%d")
+    today_str = date.today().isoformat()
     assert calendar.get(today_str) == 2

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -5,17 +5,21 @@ const MAX_WAIT_MS = 60_000;
 
 /**
  * Wartet bis der Production-Server gesund ist, bevor Tests starten.
+ * Prüft Health-Endpoint UND API-Readiness (/api/v1/sessions).
  * Verhindert flaky Tests durch transiente Downtime nach Coolify-Deploy.
  */
 export default async function globalSetup(config: FullConfig): Promise<void> {
   const baseURL =
-    config.projects[0]?.use?.baseURL ?? "http://training.89.167.78.223.sslip.io";
+    config.projects[0]?.use?.baseURL ??
+    "http://training.89.167.78.223.sslip.io";
   const healthURL = `${baseURL}/health`;
+  const apiURL = `${baseURL}/api/v1/sessions`;
 
   console.log(`[global-setup] Warte auf Health Check: ${healthURL}`);
 
   const start = Date.now();
 
+  // Phase 1: Health-Endpoint polling
   while (Date.now() - start < MAX_WAIT_MS) {
     try {
       const response = await fetch(healthURL, {
@@ -23,16 +27,19 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
       });
 
       if (response.ok) {
-        const body = (await response.json()) as { status?: string };
-        if (body.status === "ok") {
+        const body = (await response.json()) as {
+          status?: string;
+          database?: boolean;
+        };
+        if (body.status === "ok" && body.database === true) {
           const elapsed = ((Date.now() - start) / 1000).toFixed(1);
           console.log(
-            `[global-setup] Server gesund nach ${elapsed}s`,
+            `[global-setup] Server gesund nach ${elapsed}s (DB verbunden)`,
           );
-          return;
+          break;
         }
         console.log(
-          `[global-setup] HTTP 200 aber status="${body.status}" — retry...`,
+          `[global-setup] status="${body.status}", database=${body.database} — retry...`,
         );
       } else {
         console.log(
@@ -45,10 +52,38 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
       console.log(`[global-setup] Fehler: ${message} — retry...`);
     }
 
+    if (Date.now() - start >= MAX_WAIT_MS) {
+      throw new Error(
+        `[global-setup] Server nicht gesund nach ${MAX_WAIT_MS / 1000}s — Tests abgebrochen`,
+      );
+    }
+
     await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
   }
 
-  throw new Error(
-    `[global-setup] Server nicht gesund nach ${MAX_WAIT_MS / 1000}s — Tests abgebrochen`,
-  );
+  // Phase 2: API-Readiness prüfen
+  console.log(`[global-setup] Prüfe API-Readiness: ${apiURL}`);
+  try {
+    const response = await fetch(apiURL, {
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (response.ok) {
+      console.log(
+        `[global-setup] API erreichbar (HTTP ${response.status})`,
+      );
+    } else {
+      console.warn(
+        `[global-setup] API antwortet mit HTTP ${response.status} — Tests starten trotzdem`,
+      );
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `[global-setup] API-Check fehlgeschlagen: ${message} — Tests starten trotzdem`,
+    );
+  }
+
+  const total = ((Date.now() - start) / 1000).toFixed(1);
+  console.log(`[global-setup] Setup abgeschlossen nach ${total}s`);
 }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   globalSetup: "./global-setup.ts",
   testDir: "./smoke",
   timeout: 30_000,
-  expect: { timeout: 10_000 },
+  expect: { timeout: 15_000 },
   fullyParallel: true,
   retries: 2,
   reporter: [["html", { open: "never" }], ["list"]],

--- a/e2e/smoke/dashboard.spec.ts
+++ b/e2e/smoke/dashboard.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from "@playwright/test";
 test.describe("Dashboard", () => {
   test("lädt und zeigt Inhalt", async ({ page }) => {
     await page.goto("/dashboard");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     // Kein Error-Boundary sichtbar
     await expect(
@@ -18,7 +18,7 @@ test.describe("Dashboard", () => {
 
   test("zeigt App-Branding", async ({ page }) => {
     await page.goto("/dashboard");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     // Zwei Logos existieren: Sidebar (hidden auf Mobile) + TopBar (hidden auf Desktop)
     // Prüfe, dass mindestens eines sichtbar ist

--- a/e2e/smoke/health.spec.ts
+++ b/e2e/smoke/health.spec.ts
@@ -1,18 +1,20 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("Health Check", () => {
-  test("backend /health returns ok", async ({ request }) => {
+  test("backend /health returns ok with DB", async ({ request }) => {
     const response = await request.get("/health");
     expect(response.status()).toBe(200);
     const body = await response.json();
     expect(body.status).toBe("ok");
+    expect(body.database).toBe(true);
   });
 
-  test("API /api/v1/health returns healthy", async ({ request }) => {
+  test("API /api/v1/health returns healthy with DB", async ({ request }) => {
     const response = await request.get("/api/v1/health");
     expect(response.status()).toBe(200);
     const body = await response.json();
     expect(body.status).toBe("healthy");
+    expect(body.database).toBe(true);
   });
 
   test("frontend serves HTML at /", async ({ request }) => {

--- a/e2e/smoke/navigation.spec.ts
+++ b/e2e/smoke/navigation.spec.ts
@@ -12,7 +12,7 @@ test.describe("Navigation", () => {
   for (const { path, name } of pages) {
     test(`${name} (${path}) ist erreichbar`, async ({ page }) => {
       await page.goto(path);
-      await page.waitForLoadState("networkidle");
+      await page.waitForLoadState("domcontentloaded");
 
       // Richtige URL
       await expect(page).toHaveURL(new RegExp(path));
@@ -29,7 +29,7 @@ test.describe("Navigation", () => {
 
   test("404-Seite bei unbekannter Route", async ({ page }) => {
     await page.goto("/diese-seite-gibt-es-nicht");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     // Sollte eine 404-Anzeige haben (oder Redirect)
     // Mindestens: kein weißer Screen

--- a/e2e/smoke/responsive.spec.ts
+++ b/e2e/smoke/responsive.spec.ts
@@ -5,7 +5,7 @@ test.describe("Responsive Layout", () => {
     test.skip(testInfo.project.name === "desktop", "Nur Mobile");
 
     await page.goto("/dashboard");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     // BottomNav enthält die 5 Navigations-Links
     const bottomNav = page.locator("nav").filter({
@@ -23,7 +23,7 @@ test.describe("Responsive Layout", () => {
     test.skip(testInfo.project.name === "desktop", "Nur Mobile");
 
     await page.goto("/dashboard");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     // Sidebar hat class "hidden lg:flex" — auf Mobile nicht sichtbar
     // Prüfen über den Sidebar-spezifischen User-Chip "NC"
@@ -37,7 +37,7 @@ test.describe("Responsive Layout", () => {
     test.skip(testInfo.project.name === "mobile", "Nur Desktop");
 
     await page.goto("/dashboard");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     // Sidebar mit "Training Analyzer" Branding und User-Chip
     const sidebar = page.locator("nav").filter({
@@ -58,7 +58,7 @@ test.describe("Responsive Layout", () => {
     test.skip(testInfo.project.name === "mobile", "Nur Desktop");
 
     await page.goto("/dashboard");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     // BottomNav hat class "lg:hidden" — auf Desktop nicht sichtbar
     const bottomNav = page.locator("nav").filter({

--- a/e2e/smoke/sessions.spec.ts
+++ b/e2e/smoke/sessions.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from "@playwright/test";
 test.describe("Sessions", () => {
   test("Sessions-Seite lädt", async ({ page }) => {
     await page.goto("/sessions");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     // Kein Error-Boundary
     await expect(


### PR DESCRIPTION
## Summary

- `/health` prüft jetzt echte DB-Verbindung (`SELECT 1`) statt Fake-OK — gibt `database: true/false` zurück
- `networkidle` → `domcontentloaded` in allen 5 Smoke-Test-Dateien (verhindert Timeout bei React Query Polling)
- `globalSetup` prüft nach Health-OK auch API-Readiness (`/api/v1/sessions`)
- Expect-Timeout von 10s auf 15s erhöht
- `deploy-verify` wartet 30s vor Health-Polling (Coolify Build-Zeit) und prüft `database`-Feld
- Streak-Test Timezone-Bug behoben (`datetime.utcnow()` → `date.today()`)

## Test plan

- [x] Backend: Ruff + Mypy bestanden
- [x] Backend: 514 Tests grün (inkl. Streak-Fix)
- [x] E2E: Playwright erkennt alle 32 Tests korrekt
- [x] Health-Endpoints lokal verifiziert (`/health` + `/api/v1/health` geben `database: true`)
- [ ] CI-Pipeline grün

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)