### PR TITLE
fix: Dashboard Branding-Test Timing (#229)

### DIFF
--- a/e2e/smoke/dashboard.spec.ts
+++ b/e2e/smoke/dashboard.spec.ts
@@ -20,19 +20,10 @@ test.describe("Dashboard", () => {
     await page.goto("/dashboard");
     await page.waitForLoadState("domcontentloaded");
 
-    // Zwei Logos existieren: Sidebar (hidden auf Mobile) + TopBar (hidden auf Desktop)
-    // Prüfe, dass mindestens eines sichtbar ist
-    const logos = page.locator('img[alt="Training Analyzer"]');
-    const count = await logos.count();
-    expect(count).toBeGreaterThan(0);
-
-    let anyVisible = false;
-    for (let i = 0; i < count; i++) {
-      if (await logos.nth(i).isVisible()) {
-        anyVisible = true;
-        break;
-      }
-    }
-    expect(anyVisible).toBeTruthy();
+    // Mindestens ein Logo mit alt="Training Analyzer" muss sichtbar sein
+    // (Sidebar auf Desktop, TopBar auf Mobile)
+    await expect(
+      page.locator('img[alt="Training Analyzer"]').first(),
+    ).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

- Dashboard „zeigt App-Branding" Test schlug fehl weil `logos.count()` ein sofortiger Snapshot ohne Auto-Retry ist
- Mit `domcontentloaded` (statt `networkidle`) ist React noch nicht fertig gerendert → 0 img-Elemente
- Fix: `expect(locator).toBeVisible()` nutzt Playwright Auto-Retry mit 15s Timeout

## Test plan

- [x] Playwright erkennt alle 32 Tests
- [x] `expect(...).toBeVisible()` hat Auto-Retry — wartet bis Logo da ist
- [ ] CI-Pipeline grün

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)