### PR TITLE
fix: E2E Branding-Test — waitFor vor count() (#236)

### DIFF
--- a/e2e/smoke/dashboard.spec.ts
+++ b/e2e/smoke/dashboard.spec.ts
@@ -18,16 +18,16 @@ test.describe("Dashboard", () => {
 
   test("zeigt App-Branding", async ({ page }) => {
     await page.goto("/dashboard");
-    await page.waitForLoadState("domcontentloaded");
 
-    // Zwei Logos: Sidebar (Desktop) + TopBar (Mobile) — je nach Viewport ist nur eines sichtbar
-    const logos = page.locator('img[alt="Training Analyzer"]');
-    const count = await logos.count();
-    expect(count).toBeGreaterThan(0);
+    // Warten bis React gemountet hat und mindestens ein Logo im DOM ist
+    const logo = page.locator('img[alt="Training Analyzer"]');
+    await logo.first().waitFor({ state: "attached", timeout: 15_000 });
 
+    // Mindestens ein Logo muss sichtbar sein (Sidebar auf Desktop, TopBar auf Mobile)
+    const count = await logo.count();
     let anyVisible = false;
     for (let i = 0; i < count; i++) {
-      if (await logos.nth(i).isVisible()) {
+      if (await logo.nth(i).isVisible()) {
         anyVisible = true;
         break;
       }


### PR DESCRIPTION
## Summary
- `domcontentloaded` + sofortiges `count()` gibt 0 zurück wenn React noch nicht gemountet hat
- Fix: `waitFor({ state: "attached" })` wartet bis mindestens ein Logo-Element im DOM ist, bevor gezählt wird
- Entfernt unnötiges `waitForLoadState("domcontentloaded")` — `waitFor` reicht

Closes #236

## Test plan
- [ ] CI PR-Checks bestehen
- [ ] Nach Merge: E2E Smoke Tests auf main bestehen (Mobile + Desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)