### PR TITLE
chore: CODEOWNERS für GitHub Pro Branch Protection (#241)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Default: Alle Änderungen brauchen Review von @NCS23
+* @NCS23
+
+# Frontend
+/frontend/ @NCS23
+
+# Backend
+/backend/ @NCS23
+
+# CI/CD & Infrastruktur
+/.github/ @NCS23
+/docker-compose*.yml @NCS23
+
+# E2E Tests
+/e2e/ @NCS23


### PR DESCRIPTION
## Summary
- `.github/CODEOWNERS` hinzugefügt — @NCS23 als Default-Owner für alle Pfade
- Branch Protection auf `main` bereits konfiguriert (Required Status Checks für alle 5 CI-Jobs)

Closes #241

## Test plan
- [ ] CI bestehen
- [ ] CODEOWNERS wird von GitHub erkannt

🤖 Generated with [Claude Code](https://claude.com/claude-code)