### PR TITLE
feat: KI Session-Analyse (#32)

### DIFF
--- a/backend/app/api/v1/sessions.py
+++ b/backend/app/api/v1/sessions.py
@@ -16,6 +16,7 @@ from app.infrastructure.database.models import (
     WorkoutModel,
 )
 from app.infrastructure.database.session import get_db
+from app.models.ai_analysis import AnalyzeRequest, SessionAnalysisResponse
 from app.models.segment import ComparisonResponse, laps_to_segments
 from app.models.session import (
     DateUpdateRequest,
@@ -803,6 +804,26 @@ async def delete_session(
 
     await db.delete(workout)
     await db.commit()
+
+
+@router.post("/{session_id}/analyze", response_model=SessionAnalysisResponse)
+async def analyze_session(
+    session_id: int,
+    body: Optional[AnalyzeRequest] = None,
+    db: AsyncSession = Depends(get_db),
+) -> SessionAnalysisResponse:
+    """KI-gestützte Analyse einer Session (Cache-First)."""
+    from app.services.session_analysis_service import (
+        analyze_session as run_analysis,
+    )
+
+    force = body.force_refresh if body else False
+    try:
+        return await run_analysis(session_id, db, force_refresh=force)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"AI-Analyse fehlgeschlagen: {e}") from e
 
 
 @router.post("/{session_id}/recalculate-zones")

--- a/backend/app/models/ai_analysis.py
+++ b/backend/app/models/ai_analysis.py
@@ -1,0 +1,24 @@
+"""Pydantic Models für KI Session-Analyse."""
+
+from pydantic import BaseModel
+
+
+class AnalyzeRequest(BaseModel):
+    """Request für Session-Analyse."""
+
+    force_refresh: bool = False
+
+
+class SessionAnalysisResponse(BaseModel):
+    """Strukturierte KI-Analyse einer Trainingseinheit."""
+
+    session_id: int
+    provider: str
+    summary: str
+    intensity_rating: str  # leicht|moderat|intensiv|zu_intensiv
+    intensity_text: str
+    hr_zone_assessment: str
+    plan_comparison: str | None = None
+    fatigue_indicators: str | None = None
+    recommendations: list[str]
+    cached: bool = False

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 from datetime import date, datetime
 from typing import TYPE_CHECKING, Optional
@@ -101,6 +102,7 @@ class SessionResponse(BaseModel):
     planned_entry_id: Optional[int] = None  # S10: Soll/Ist-Link
     athlete_resting_hr: Optional[int] = None
     athlete_max_hr: Optional[int] = None
+    ai_analysis: Optional[dict] = None
     created_at: datetime
     updated_at: datetime
 
@@ -147,6 +149,12 @@ class SessionResponse(BaseModel):
         # Convert laps to unified segments (#133)
         segments = laps_to_segments(laps) if laps else None
 
+        # Gecachte AI-Analyse
+        ai_analysis = None
+        if model.ai_analysis:
+            with contextlib.suppress(json.JSONDecodeError):
+                ai_analysis = json.loads(str(model.ai_analysis))
+
         return cls(
             id=model.id,
             date=session_date,
@@ -170,6 +178,7 @@ class SessionResponse(BaseModel):
             planned_entry_id=model.planned_entry_id if model.planned_entry_id else None,
             athlete_resting_hr=model.athlete_resting_hr if model.athlete_resting_hr else None,
             athlete_max_hr=model.athlete_max_hr if model.athlete_max_hr else None,
+            ai_analysis=ai_analysis,
             created_at=model.created_at,
             updated_at=model.updated_at,
         )

--- a/backend/app/services/session_analysis_service.py
+++ b/backend/app/services/session_analysis_service.py
@@ -1,0 +1,350 @@
+"""KI Session-Analyse Service.
+
+Baut strukturierten Prompt mit vollem Session-Kontext und parst
+die JSON-Antwort des AI-Providers.
+"""
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.api_key_resolver import resolve_claude_api_key
+from app.infrastructure.ai.ai_service import ai_service
+from app.infrastructure.database.models import (
+    PlannedSessionModel,
+    RaceGoalModel,
+    WorkoutModel,
+)
+from app.models.ai_analysis import SessionAnalysisResponse
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AnalysisContext:
+    """Kontext-Daten für die Analyse."""
+
+    history: list[dict]
+    race_goal: dict | None
+    planned_session: dict | None
+
+
+async def analyze_session(
+    session_id: int,
+    db: AsyncSession,
+    *,
+    force_refresh: bool = False,
+) -> SessionAnalysisResponse:
+    """Analysiert eine Session mit KI (Cache-First)."""
+    workout = await _load_workout(session_id, db)
+
+    # Cache prüfen
+    if not force_refresh and workout.ai_analysis:
+        return _from_cache(session_id, workout.ai_analysis)
+
+    # Kontext laden, Prompt bauen, AI aufrufen
+    context = await _load_analysis_context(workout, db)
+    prompt = _build_analysis_prompt(workout, context)
+    api_key = await resolve_claude_api_key(db)
+
+    raw = await ai_service.chat(prompt, {}, api_key)
+    provider = ai_service.get_active_provider() or "unknown"
+
+    # Parsen + Cache speichern
+    analysis = _parse_analysis_json(raw, session_id, provider)
+    workout.ai_analysis = json.dumps(analysis.model_dump())
+    await db.commit()
+
+    return analysis
+
+
+async def _load_workout(session_id: int, db: AsyncSession) -> WorkoutModel:
+    """Lädt Workout oder wirft ValueError."""
+    result = await db.execute(select(WorkoutModel).where(WorkoutModel.id == session_id))
+    workout = result.scalar_one_or_none()
+    if not workout:
+        raise ValueError(f"Session {session_id} nicht gefunden")
+    return workout
+
+
+def _from_cache(session_id: int, raw: str) -> SessionAnalysisResponse:
+    """Liest gecachte Analyse aus dem DB-Feld."""
+    try:
+        data = json.loads(raw)
+        data["cached"] = True
+        data["session_id"] = session_id
+        return SessionAnalysisResponse(**data)
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        raise ValueError("Cache ungültig") from e
+
+
+async def _load_analysis_context(workout: WorkoutModel, db: AsyncSession) -> AnalysisContext:
+    """Lädt Trainingshistorie, Ziel und geplante Session."""
+    workout_date = workout.date.date() if isinstance(workout.date, datetime) else workout.date
+    four_weeks_ago = datetime.combine(workout_date - timedelta(weeks=4), datetime.min.time())
+
+    # Letzte 20 Sessions (4 Wochen)
+    hist_result = await db.execute(
+        select(WorkoutModel)
+        .where(
+            WorkoutModel.date >= four_weeks_ago,
+            WorkoutModel.id != workout.id,
+        )
+        .order_by(WorkoutModel.date.desc())
+        .limit(20)
+    )
+    history = [_workout_to_summary(w) for w in hist_result.scalars().all()]
+
+    # Aktives Wettkampfziel
+    goal_result = await db.execute(
+        select(RaceGoalModel).where(RaceGoalModel.is_active.is_(True)).limit(1)
+    )
+    goal_model = goal_result.scalar_one_or_none()
+    race_goal = _goal_to_dict(goal_model) if goal_model else None
+
+    # Geplante Session
+    planned = None
+    if workout.planned_entry_id:
+        ps_result = await db.execute(
+            select(PlannedSessionModel).where(PlannedSessionModel.id == workout.planned_entry_id)
+        )
+        ps = ps_result.scalar_one_or_none()
+        if ps:
+            planned = _planned_to_dict(ps)
+
+    return AnalysisContext(history=history, race_goal=race_goal, planned_session=planned)
+
+
+def _workout_to_summary(w: WorkoutModel) -> dict:
+    """Workout in Kurz-Dict für History."""
+    w_date = w.date.date() if isinstance(w.date, datetime) else w.date
+    return {
+        "date": str(w_date),
+        "type": str(w.workout_type),
+        "duration_min": round(w.duration_sec / 60) if w.duration_sec else None,
+        "distance_km": w.distance_km,
+        "pace": str(w.pace) if w.pace else None,
+        "hr_avg": w.hr_avg,
+    }
+
+
+def _goal_to_dict(g: RaceGoalModel) -> dict:
+    """RaceGoal in Dict für Prompt."""
+    target_pace = None
+    if g.target_time_seconds and g.distance_km and g.distance_km > 0:
+        pace_min = (g.target_time_seconds / 60) / g.distance_km
+        m = int(pace_min)
+        s = int((pace_min - m) * 60)
+        target_pace = f"{m}:{s:02d}"
+
+    return {
+        "title": g.title,
+        "date": str(g.race_date.date() if isinstance(g.race_date, datetime) else g.race_date),
+        "distance_km": g.distance_km,
+        "target_time_min": round(g.target_time_seconds / 60) if g.target_time_seconds else None,
+        "target_pace": target_pace,
+    }
+
+
+def _planned_to_dict(ps: PlannedSessionModel) -> dict:
+    """PlannedSession in Dict für Prompt."""
+    segments = None
+    if ps.run_details_json:
+        try:
+            rd = json.loads(str(ps.run_details_json))
+            segments = rd.get("segments")
+        except json.JSONDecodeError:
+            pass
+    return {
+        "training_type": str(ps.training_type),
+        "segments": segments,
+        "notes": str(ps.notes) if ps.notes else None,
+    }
+
+
+def _build_analysis_prompt(workout: WorkoutModel, ctx: AnalysisContext) -> str:
+    """Baut den vollständigen Analyse-Prompt."""
+    parts: list[str] = []
+
+    # Session-Daten
+    parts.append(_build_session_section(workout))
+
+    # Laps
+    if workout.laps_json:
+        parts.append(_build_laps_section(workout.laps_json))
+
+    # HF-Zonen
+    if workout.hr_zones_json:
+        parts.append(_build_hr_zones_section(workout.hr_zones_json))
+
+    # Trainingshistorie
+    if ctx.history:
+        parts.append(_build_history_section(ctx.history))
+
+    # Wettkampfziel
+    if ctx.race_goal:
+        parts.append(_build_goal_section(ctx.race_goal))
+
+    # Geplante Session (Soll/Ist)
+    if ctx.planned_session:
+        parts.append(_build_planned_section(ctx.planned_session))
+
+    # Anweisungen
+    parts.append(_build_instructions())
+
+    return "\n\n".join(parts)
+
+
+def _build_session_section(w: WorkoutModel) -> str:
+    """Session-Kerndaten."""
+    w_date = w.date.date() if isinstance(w.date, datetime) else w.date
+    dur_min = round(w.duration_sec / 60) if w.duration_sec else "?"
+    effective_type = str(w.training_type_override or w.training_type_auto or w.workout_type)
+
+    return f"""## Aktuelle Session
+- Datum: {w_date}
+- Typ: {w.workout_type}, Trainingsart: {effective_type}
+- Dauer: {dur_min} min
+- Distanz: {w.distance_km or "?"} km
+- Pace: {w.pace or "?"}
+- HF Ø/Max/Min: {w.hr_avg or "?"}/{w.hr_max or "?"}/{w.hr_min or "?"} bpm
+- Kadenz: {w.cadence_avg or "?"} spm
+- RPE: {w.rpe or "nicht angegeben"}"""
+
+
+def _build_laps_section(laps_json: str) -> str:
+    """Laps-Tabelle."""
+    try:
+        laps = json.loads(laps_json)
+    except json.JSONDecodeError:
+        return ""
+
+    lines = [
+        "## Laps",
+        "| # | Typ | Dauer | Distanz | Pace | HF Ø |",
+        "|---|-----|-------|---------|------|------|",
+    ]
+    for lap in laps:
+        typ = lap.get("user_override") or lap.get("suggested_type") or "-"
+        dur = lap.get("duration_formatted", "?")
+        dist = f"{lap.get('distance_km', 0):.2f}" if lap.get("distance_km") else "-"
+        pace = lap.get("pace_formatted") or "-"
+        hr = str(lap.get("avg_hr_bpm", "-"))
+        lines.append(f"| {lap.get('lap_number', '?')} | {typ} | {dur} | {dist} | {pace} | {hr} |")
+    return "\n".join(lines)
+
+
+def _build_hr_zones_section(hr_zones_json: str) -> str:
+    """HF-Zonen-Verteilung."""
+    try:
+        zones = json.loads(hr_zones_json)
+    except json.JSONDecodeError:
+        return ""
+
+    lines = ["## HF-Zonen"]
+    for key, zone in zones.items():
+        if isinstance(zone, dict):
+            label = zone.get("label", key)
+            pct = zone.get("percentage", 0)
+            secs = zone.get("seconds", 0)
+            lines.append(f"- {label}: {pct:.0f}% ({secs}s)")
+    return "\n".join(lines)
+
+
+def _build_history_section(history: list[dict]) -> str:
+    """Trainingshistorie der letzten 4 Wochen."""
+    lines = ["## Trainingshistorie (letzte 4 Wochen)"]
+    for h in history[:10]:
+        dur = f"{h['duration_min']}min" if h.get("duration_min") else "?"
+        dist = f"{h['distance_km']:.1f}km" if h.get("distance_km") else ""
+        pace = h.get("pace") or ""
+        lines.append(f"- {h['date']}: {h['type']} — {dur} {dist} {pace}")
+    return "\n".join(lines)
+
+
+def _build_goal_section(goal: dict) -> str:
+    """Wettkampfziel."""
+    return f"""## Wettkampfziel
+- {goal["title"]} am {goal["date"]}
+- Distanz: {goal["distance_km"]} km
+- Zielzeit: {goal.get("target_time_min", "?")} min
+- Zielpace: {goal.get("target_pace", "?")} min/km"""
+
+
+def _build_planned_section(planned: dict) -> str:
+    """Geplante Session für Soll/Ist-Vergleich."""
+    lines = ["## Geplante Session (Soll)", f"- Typ: {planned['training_type']}"]
+    if planned.get("notes"):
+        lines.append(f"- Hinweis: {planned['notes']}")
+    if planned.get("segments"):
+        lines.append("- Segmente:")
+        for seg in planned["segments"]:
+            lines.append(
+                f"  - {seg.get('type', '?')}: {seg.get('duration_minutes', '?')}min, Pace {seg.get('target_pace', '?')}"
+            )
+    return "\n".join(lines)
+
+
+def _build_instructions() -> str:
+    """Anweisungen für die KI."""
+    return """## Anweisungen
+Analysiere diese Trainingseinheit als erfahrener Lauftrainer. Antworte NUR mit validem JSON (ohne Markdown-Codeblock):
+
+{
+  "summary": "2-3 Sätze Gesamtbewertung der Einheit",
+  "intensity_rating": "leicht|moderat|intensiv|zu_intensiv",
+  "intensity_text": "Kurze Begründung der Intensitätsbewertung",
+  "hr_zone_assessment": "Bewertung der HF-Zonen-Verteilung im Kontext des Trainingstyps",
+  "plan_comparison": "Soll/Ist-Vergleich (null wenn kein Plan vorhanden)",
+  "fatigue_indicators": "Ermüdungs-Hinweise (null wenn keine erkennbar)",
+  "recommendations": ["Empfehlung 1", "Empfehlung 2", "Empfehlung 3"]
+}
+
+Regeln:
+- Sachlich, konkret, auf Deutsch
+- 2-4 Empfehlungen
+- intensity_rating MUSS einer der 4 Werte sein
+- Wenn kein Plan vorhanden: plan_comparison = null
+- Wenn keine Ermüdung erkennbar: fatigue_indicators = null"""
+
+
+def _parse_analysis_json(raw: str, session_id: int, provider: str) -> SessionAnalysisResponse:
+    """Parst die AI-Antwort als JSON, mit Fallback bei ungültigem Format."""
+    # Provider-Prefix entfernen (z.B. "[Claude (claude-sonnet-4-20250514)] {...}")
+    text = raw.strip()
+    if text.startswith("[") and "]" in text:
+        text = text[text.index("]") + 1 :].strip()
+
+    # Markdown-Codeblock entfernen falls vorhanden
+    if text.startswith("```"):
+        lines = text.split("\n")
+        text = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
+
+    try:
+        data = json.loads(text)
+        return SessionAnalysisResponse(
+            session_id=session_id,
+            provider=provider,
+            summary=data.get("summary", ""),
+            intensity_rating=data.get("intensity_rating", "moderat"),
+            intensity_text=data.get("intensity_text", ""),
+            hr_zone_assessment=data.get("hr_zone_assessment", ""),
+            plan_comparison=data.get("plan_comparison"),
+            fatigue_indicators=data.get("fatigue_indicators"),
+            recommendations=data.get("recommendations", []),
+        )
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("AI-Antwort konnte nicht als JSON geparst werden: %s", text[:200])
+        return SessionAnalysisResponse(
+            session_id=session_id,
+            provider=provider,
+            summary=text[:500],
+            intensity_rating="moderat",
+            intensity_text="Konnte nicht automatisch bestimmt werden.",
+            hr_zone_assessment="Keine strukturierte Bewertung verfügbar.",
+            recommendations=["Analyse erneut durchführen für detaillierte Ergebnisse."],
+        )

--- a/backend/app/tests/test_session_analysis.py
+++ b/backend/app/tests/test_session_analysis.py
@@ -1,0 +1,253 @@
+"""Tests für KI Session-Analyse (Issue #32)."""
+
+import json
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.infrastructure.database.models import WorkoutModel
+from app.models.ai_analysis import SessionAnalysisResponse
+from app.services.session_analysis_service import (
+    _build_analysis_prompt,
+    _parse_analysis_json,
+)
+
+MOCK_AI_RESPONSE = json.dumps(
+    {
+        "summary": "Gutes moderates Lauftraining im GA1-Bereich.",
+        "intensity_rating": "moderat",
+        "intensity_text": "HF und Pace passen zum Easy Run.",
+        "hr_zone_assessment": "80% in Zone 2 — ideal für Grundlagenausdauer.",
+        "plan_comparison": None,
+        "fatigue_indicators": None,
+        "recommendations": [
+            "Pace beibehalten",
+            "Nächste Woche Long Run einplanen",
+        ],
+    }
+)
+
+
+async def _create_test_workout(db: AsyncSession) -> WorkoutModel:
+    """Erstellt ein Test-Workout in der DB."""
+    workout = WorkoutModel(
+        date=datetime(2026, 3, 10, 8, 0),
+        workout_type="running",
+        duration_sec=3600,
+        distance_km=10.5,
+        pace="5:43",
+        hr_avg=145,
+        hr_max=162,
+        hr_min=120,
+        cadence_avg=178,
+        laps_json=json.dumps(
+            [
+                {
+                    "lap_number": 1,
+                    "duration_seconds": 600,
+                    "duration_formatted": "10:00",
+                    "distance_km": 1.7,
+                    "pace_formatted": "5:53",
+                    "avg_hr_bpm": 140,
+                    "suggested_type": "warmup",
+                },
+                {
+                    "lap_number": 2,
+                    "duration_seconds": 2400,
+                    "duration_formatted": "40:00",
+                    "distance_km": 7.0,
+                    "pace_formatted": "5:43",
+                    "avg_hr_bpm": 148,
+                    "suggested_type": "steady",
+                },
+                {
+                    "lap_number": 3,
+                    "duration_seconds": 600,
+                    "duration_formatted": "10:00",
+                    "distance_km": 1.8,
+                    "pace_formatted": "5:33",
+                    "avg_hr_bpm": 138,
+                    "suggested_type": "cooldown",
+                },
+            ]
+        ),
+        hr_zones_json=json.dumps(
+            {
+                "zone_1_recovery": {"seconds": 600, "percentage": 16.7, "label": "Zone 1"},
+                "zone_2_base": {"seconds": 2400, "percentage": 66.7, "label": "Zone 2"},
+                "zone_3_tempo": {"seconds": 600, "percentage": 16.7, "label": "Zone 3"},
+            }
+        ),
+    )
+    db.add(workout)
+    await db.commit()
+    await db.refresh(workout)
+    return workout
+
+
+class TestSessionAnalysisAPI:
+    """Integration-Tests für POST /sessions/{id}/analyze."""
+
+    @patch("app.services.session_analysis_service.ai_service")
+    async def test_analyze_returns_structured_response(
+        self, mock_ai: AsyncMock, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """Analyse liefert strukturierte Response."""
+        workout = await _create_test_workout(db_session)
+        mock_ai.chat = AsyncMock(return_value=MOCK_AI_RESPONSE)
+        mock_ai.get_active_provider.return_value = "Claude (test)"
+
+        response = await client.post(f"/api/v1/sessions/{workout.id}/analyze")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["session_id"] == workout.id
+        assert data["intensity_rating"] == "moderat"
+        assert data["summary"] == "Gutes moderates Lauftraining im GA1-Bereich."
+        assert len(data["recommendations"]) == 2
+        assert data["cached"] is False
+
+    @patch("app.services.session_analysis_service.ai_service")
+    async def test_cached_analysis_no_ai_call(
+        self, mock_ai: AsyncMock, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """Zweiter Aufruf liefert gecachte Analyse ohne AI-Call."""
+        workout = await _create_test_workout(db_session)
+        mock_ai.chat = AsyncMock(return_value=MOCK_AI_RESPONSE)
+        mock_ai.get_active_provider.return_value = "Claude (test)"
+
+        # Erster Aufruf — AI wird gerufen
+        await client.post(f"/api/v1/sessions/{workout.id}/analyze")
+        assert mock_ai.chat.call_count == 1
+
+        # Zweiter Aufruf — Cache
+        response = await client.post(f"/api/v1/sessions/{workout.id}/analyze")
+        assert response.status_code == 200
+        assert response.json()["cached"] is True
+        assert mock_ai.chat.call_count == 1  # Kein erneuter Aufruf
+
+    @patch("app.services.session_analysis_service.ai_service")
+    async def test_force_refresh_bypasses_cache(
+        self, mock_ai: AsyncMock, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """force_refresh=True umgeht den Cache."""
+        workout = await _create_test_workout(db_session)
+        mock_ai.chat = AsyncMock(return_value=MOCK_AI_RESPONSE)
+        mock_ai.get_active_provider.return_value = "Claude (test)"
+
+        # Erster Aufruf
+        await client.post(f"/api/v1/sessions/{workout.id}/analyze")
+
+        # Force refresh
+        response = await client.post(
+            f"/api/v1/sessions/{workout.id}/analyze",
+            json={"force_refresh": True},
+        )
+        assert response.status_code == 200
+        assert response.json()["cached"] is False
+        assert mock_ai.chat.call_count == 2
+
+    async def test_analyze_not_found(self, client: AsyncClient) -> None:
+        """404 bei ungültiger Session-ID."""
+        response = await client.post("/api/v1/sessions/99999/analyze")
+        assert response.status_code == 404
+
+    @patch("app.services.session_analysis_service.ai_service")
+    async def test_get_session_includes_cached_analysis(
+        self, mock_ai: AsyncMock, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """GET /sessions/{id} enthält ai_analysis wenn gecacht."""
+        workout = await _create_test_workout(db_session)
+        mock_ai.chat = AsyncMock(return_value=MOCK_AI_RESPONSE)
+        mock_ai.get_active_provider.return_value = "Claude (test)"
+
+        # Analyse triggern
+        await client.post(f"/api/v1/sessions/{workout.id}/analyze")
+
+        # GET prüfen
+        response = await client.get(f"/api/v1/sessions/{workout.id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["ai_analysis"] is not None
+        assert data["ai_analysis"]["summary"] == "Gutes moderates Lauftraining im GA1-Bereich."
+
+
+class TestPromptBuilding:
+    """Unit-Tests für Prompt-Aufbau."""
+
+    async def test_prompt_contains_session_data(self, db_session: AsyncSession) -> None:
+        """Prompt enthält Session-Kerndaten."""
+        workout = await _create_test_workout(db_session)
+        from app.services.session_analysis_service import AnalysisContext
+
+        ctx = AnalysisContext(history=[], race_goal=None, planned_session=None)
+        prompt = _build_analysis_prompt(workout, ctx)
+
+        assert "10.5" in prompt  # Distanz
+        assert "5:43" in prompt  # Pace
+        assert "145" in prompt  # HR avg
+        assert "running" in prompt
+
+    async def test_prompt_contains_laps(self, db_session: AsyncSession) -> None:
+        """Prompt enthält Laps-Tabelle."""
+        workout = await _create_test_workout(db_session)
+        from app.services.session_analysis_service import AnalysisContext
+
+        ctx = AnalysisContext(history=[], race_goal=None, planned_session=None)
+        prompt = _build_analysis_prompt(workout, ctx)
+
+        assert "## Laps" in prompt
+        assert "warmup" in prompt
+        assert "steady" in prompt
+        assert "cooldown" in prompt
+
+    async def test_prompt_contains_goal(self, db_session: AsyncSession) -> None:
+        """Prompt enthält Wettkampfziel wenn vorhanden."""
+        workout = await _create_test_workout(db_session)
+        from app.services.session_analysis_service import AnalysisContext
+
+        goal = {
+            "title": "Hamburg HM",
+            "date": "2026-04-26",
+            "distance_km": 21.1,
+            "target_time_min": 120,
+            "target_pace": "5:41",
+        }
+        ctx = AnalysisContext(history=[], race_goal=goal, planned_session=None)
+        prompt = _build_analysis_prompt(workout, ctx)
+
+        assert "Hamburg HM" in prompt
+        assert "5:41" in prompt
+
+
+class TestJsonParsing:
+    """Unit-Tests für _parse_analysis_json."""
+
+    def test_valid_json(self) -> None:
+        """Gültiges JSON wird korrekt geparst."""
+        result = _parse_analysis_json(MOCK_AI_RESPONSE, 1, "Claude")
+        assert isinstance(result, SessionAnalysisResponse)
+        assert result.intensity_rating == "moderat"
+        assert result.session_id == 1
+        assert result.provider == "Claude"
+
+    def test_json_with_provider_prefix(self) -> None:
+        """JSON mit Provider-Prefix wird korrekt geparst."""
+        raw = f"[Claude (claude-sonnet-4-20250514)] {MOCK_AI_RESPONSE}"
+        result = _parse_analysis_json(raw, 1, "Claude")
+        assert result.intensity_rating == "moderat"
+
+    def test_json_with_markdown_codeblock(self) -> None:
+        """JSON in Markdown-Codeblock wird korrekt geparst."""
+        raw = f"```json\n{MOCK_AI_RESPONSE}\n```"
+        result = _parse_analysis_json(raw, 1, "Claude")
+        assert result.intensity_rating == "moderat"
+
+    def test_invalid_json_fallback(self) -> None:
+        """Ungültiges JSON ergibt Fallback-Response."""
+        result = _parse_analysis_json("Das ist kein JSON.", 1, "Claude")
+        assert result.intensity_rating == "moderat"
+        assert "Das ist kein JSON." in result.summary
+        assert len(result.recommendations) >= 1

--- a/frontend/src/api/training.ts
+++ b/frontend/src/api/training.ts
@@ -260,8 +260,22 @@ export interface SessionDetail {
   planned_entry_id: number | null;
   athlete_resting_hr: number | null;
   athlete_max_hr: number | null;
+  ai_analysis: SessionAnalysis | null;
   created_at: string;
   updated_at: string;
+}
+
+export interface SessionAnalysis {
+  session_id: number;
+  provider: string;
+  summary: string;
+  intensity_rating: string;
+  intensity_text: string;
+  hr_zone_assessment: string;
+  plan_comparison: string | null;
+  fatigue_indicators: string | null;
+  recommendations: string[];
+  cached: boolean;
 }
 
 export async function updateTrainingType(
@@ -409,6 +423,18 @@ export async function recalculateSessionZones(
     `/api/v1/sessions/${sessionId}/recalculate-zones`,
     params ?? {},
   );
+  return response.data;
+}
+
+// --- KI Session-Analyse (#32) ---
+
+export async function analyzeSession(
+  sessionId: number,
+  forceRefresh = false,
+): Promise<SessionAnalysis> {
+  const response = await apiClient.post<SessionAnalysis>(`/api/v1/sessions/${sessionId}/analyze`, {
+    force_refresh: forceRefresh,
+  });
   return response.data;
 }
 

--- a/frontend/src/components/session-detail/SessionAIAnalysis.tsx
+++ b/frontend/src/components/session-detail/SessionAIAnalysis.tsx
@@ -1,0 +1,190 @@
+import { useState, useCallback } from 'react';
+import {
+  Card,
+  CardHeader,
+  CardBody,
+  Button,
+  Badge,
+  Spinner,
+  Alert,
+  AlertDescription,
+} from '@nordlig/components';
+import { Sparkles, RefreshCw, Lightbulb, AlertTriangle } from 'lucide-react';
+import { analyzeSession } from '@/api/training';
+import type { SessionAnalysis } from '@/api/training';
+
+interface SessionAIAnalysisProps {
+  sessionId: number;
+  cachedAnalysis: SessionAnalysis | null;
+  onAnalysisLoaded: (analysis: SessionAnalysis) => void;
+}
+
+const INTENSITY_CONFIG: Record<string, { label: string; variant: string }> = {
+  leicht: { label: 'Leicht', variant: 'success' },
+  moderat: { label: 'Moderat', variant: 'info' },
+  intensiv: { label: 'Intensiv', variant: 'warning' },
+  zu_intensiv: { label: 'Zu intensiv', variant: 'error' },
+};
+
+function IntensityBadge({ rating, text }: { rating: string; text: string }) {
+  const config = INTENSITY_CONFIG[rating] ?? INTENSITY_CONFIG.moderat;
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-medium text-[var(--color-text-default)]">Intensität</span>
+        <Badge variant={config.variant as 'success' | 'info' | 'warning' | 'error'}>
+          {config.label}
+        </Badge>
+      </div>
+      <p className="text-sm text-[var(--color-text-muted)]">{text}</p>
+    </div>
+  );
+}
+
+function RecommendationsList({ items }: { items: string[] }) {
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-1.5">
+        <Lightbulb className="w-4 h-4 text-[var(--color-text-warning)]" />
+        <span className="text-sm font-medium text-[var(--color-text-default)]">Empfehlungen</span>
+      </div>
+      <ul className="space-y-1 pl-5.5">
+        {items.map((item, i) => (
+          <li key={i} className="text-sm text-[var(--color-text-muted)] list-disc">
+            {item}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function AnalysisContent({
+  analysis,
+  onRefresh,
+  loading,
+  error,
+}: {
+  analysis: SessionAnalysis;
+  onRefresh: () => void;
+  loading: boolean;
+  error: string | null;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Sparkles className="w-4 h-4 text-[var(--color-text-primary)]" />
+            <span className="text-sm font-semibold text-[var(--color-text-default)]">
+              KI-Analyse
+            </span>
+          </div>
+          <Button variant="ghost" size="sm" onClick={onRefresh} disabled={loading}>
+            <RefreshCw className="w-3.5 h-3.5 mr-1" />
+            Neu
+          </Button>
+        </div>
+      </CardHeader>
+      <CardBody>
+        <div className="space-y-4">
+          <p className="text-sm text-[var(--color-text-default)]">{analysis.summary}</p>
+          <IntensityBadge rating={analysis.intensity_rating} text={analysis.intensity_text} />
+          <div className="space-y-1">
+            <span className="text-sm font-medium text-[var(--color-text-default)]">
+              HF-Zonen-Bewertung
+            </span>
+            <p className="text-sm text-[var(--color-text-muted)]">{analysis.hr_zone_assessment}</p>
+          </div>
+          {analysis.plan_comparison && (
+            <div className="space-y-1">
+              <span className="text-sm font-medium text-[var(--color-text-default)]">
+                Soll/Ist-Vergleich
+              </span>
+              <p className="text-sm text-[var(--color-text-muted)]">{analysis.plan_comparison}</p>
+            </div>
+          )}
+          {analysis.fatigue_indicators && (
+            <Alert variant="warning">
+              <AlertTriangle className="w-4 h-4" />
+              <AlertDescription>{analysis.fatigue_indicators}</AlertDescription>
+            </Alert>
+          )}
+          {analysis.recommendations.length > 0 && (
+            <RecommendationsList items={analysis.recommendations} />
+          )}
+          {error && <p className="text-sm text-[var(--color-text-error)]">{error}</p>}
+        </div>
+      </CardBody>
+    </Card>
+  );
+}
+
+export function SessionAIAnalysis({
+  sessionId,
+  cachedAnalysis,
+  onAnalysisLoaded,
+}: SessionAIAnalysisProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleAnalyze = useCallback(
+    async (forceRefresh = false) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await analyzeSession(sessionId, forceRefresh);
+        onAnalysisLoaded(result);
+      } catch {
+        setError('Analyse fehlgeschlagen. Bitte erneut versuchen.');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [sessionId, onAnalysisLoaded],
+  );
+
+  if (!cachedAnalysis && !loading) {
+    return (
+      <Card>
+        <CardBody>
+          <div className="flex flex-col items-center gap-3 py-4">
+            <Sparkles className="w-8 h-8 text-[var(--color-text-primary)]" />
+            <p className="text-sm text-[var(--color-text-muted)] text-center">
+              Lass dein Training von der KI analysieren
+            </p>
+            {error && <p className="text-sm text-[var(--color-text-error)]">{error}</p>}
+            <Button onClick={() => handleAnalyze(false)} disabled={loading}>
+              <Sparkles className="w-4 h-4 mr-1.5" />
+              KI-Analyse starten
+            </Button>
+          </div>
+        </CardBody>
+      </Card>
+    );
+  }
+
+  if (loading) {
+    return (
+      <Card>
+        <CardBody>
+          <div className="flex flex-col items-center gap-3 py-6">
+            <Spinner size="md" />
+            <p className="text-sm text-[var(--color-text-muted)]">Analyse läuft…</p>
+          </div>
+        </CardBody>
+      </Card>
+    );
+  }
+
+  if (!cachedAnalysis) return null;
+
+  return (
+    <AnalysisContent
+      analysis={cachedAnalysis}
+      onRefresh={() => handleAnalyze(true)}
+      loading={loading}
+      error={error}
+    />
+  );
+}

--- a/frontend/src/components/session-detail/index.ts
+++ b/frontend/src/components/session-detail/index.ts
@@ -5,3 +5,4 @@ export { SessionSplitsSection } from './SessionSplitsSection';
 export { SessionExercisesSection } from './SessionExercisesSection';
 export { SessionEditFields } from './SessionEditFields';
 export { SessionComparisonSection } from './SessionComparisonSection';
+export { SessionAIAnalysis } from './SessionAIAnalysis';

--- a/frontend/src/pages/SessionDetail.test.tsx
+++ b/frontend/src/pages/SessionDetail.test.tsx
@@ -96,6 +96,7 @@ const mockSession: SessionDetail = {
   athlete_resting_hr: 65,
   athlete_max_hr: 185,
   exercises: null,
+  ai_analysis: null,
   created_at: '2025-02-25T08:00:00',
   updated_at: '2025-02-25T08:15:00',
 };

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -60,6 +60,7 @@ import {
   SessionExercisesSection,
   SessionEditFields,
   SessionComparisonSection,
+  SessionAIAnalysis,
 } from '@/components/session-detail';
 
 const workoutTypeHeadings: Record<string, string> = {
@@ -329,6 +330,15 @@ export function SessionDetailPage() {
           </Card>
         </section>
       )}
+
+      {/* KI-Analyse (#32) */}
+      <SessionAIAnalysis
+        sessionId={sessionId}
+        cachedAnalysis={session.ai_analysis ?? null}
+        onAnalysisLoaded={(analysis) =>
+          data.setSession((prev) => (prev ? { ...prev, ai_analysis: analysis } : prev))
+        }
+      />
 
       {/* Exercises (Strength) */}
       {session.exercises && session.exercises.length > 0 && (


### PR DESCRIPTION
## Summary
- Strukturierte KI-Analyse für Trainingseinheiten mit Claude API (Fallback: Ollama)
- Vollständiger Prompt-Kontext: Session-Daten, Laps, HR-Zonen, Trainingshistorie (4 Wochen), Wettkampfziel, geplante Session
- JSON-basierte Response: Gesamtbewertung, Intensitäts-Rating, HF-Zonen-Bewertung, Plan-Vergleich, Ermüdungs-Hinweise, Empfehlungen
- Cache in bestehender `ai_analysis`-Spalte — GET /sessions/{id} liefert gecachte Analyse mit
- Frontend: SessionAIAnalysis Komponente mit "KI-Analyse starten" Button, strukturierter Darstellung, "Neu analysieren" Option

## Änderungen
- **Backend**: `session_analysis_service.py` (Service), `ai_analysis.py` (Models), Endpoint in `sessions.py`, `SessionResponse` erweitert
- **Frontend**: `SessionAIAnalysis.tsx`, API-Client in `training.ts`, Integration in `SessionDetail.tsx`
- **Tests**: 8 Backend-Tests (API, Prompt, Parsing), Frontend-Mock aktualisiert

## Test plan
- [ ] Session Detail öffnen → "KI-Analyse starten" klicken → Strukturierte Analyse prüfen
- [ ] Seite neu laden → Analyse aus Cache geladen (kein erneuter API-Call)
- [ ] "Neu analysieren" klicken → Frische Analyse
- [ ] Backend-Tests: `pytest app/tests/test_session_analysis.py`
- [ ] Frontend-Tests: `npx vitest --run`

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)