### PR TITLE
fix: Template-Pfad korrekt auflösen für Docker (#245)

### DIFF
--- a/backend/app/api/v1/training_plans.py
+++ b/backend/app/api/v1/training_plans.py
@@ -774,7 +774,9 @@ def _yaml_to_plan_create(data: dict[str, Any]) -> dict[str, Any]:  # noqa: C901 
     return result
 
 
-_TEMPLATE_PATH = Path(__file__).parent.parent.parent / "static" / "template-trainingsplan.yaml"
+_TEMPLATE_PATH = (
+    Path(__file__).resolve().parent.parent.parent.parent / "static" / "template-trainingsplan.yaml"
+)
 
 
 @router.get("/template")


### PR DESCRIPTION
## Summary
- `Path(__file__)` → `Path(__file__).resolve()` für kanonischen Pfad im Docker
- 3x `.parent` → 4x `.parent` (v1→api→app→root) damit der Pfad zum `static/`-Verzeichnis stimmt

Behebt den 404-Fehler beim Template-Download auf dem Server.

## Test plan
- [ ] `curl /api/v1/training-plans/template` → 200 (statt 404)
- [ ] Frontend: "Vorlage herunterladen" funktioniert auf dem Server

🤖 Generated with [Claude Code](https://claude.com/claude-code)