### PR TITLE
fix: .fit-Dateien auf iOS Safari auswählbar machen (#249)

### DIFF
--- a/frontend/src/features/strength/StrengthForm.tsx
+++ b/frontend/src/features/strength/StrengthForm.tsx
@@ -116,7 +116,7 @@ export function StrengthForm() {
         </CardHeader>
         <CardBody className="space-y-4">
           <FileUpload
-            accept=".csv,.fit"
+            accept=".csv,.fit,application/octet-stream"
             onUpload={(files) => {
               if (files[0]) setTrainingFile(files[0]);
             }}

--- a/frontend/src/pages/Upload.tsx
+++ b/frontend/src/pages/Upload.tsx
@@ -119,7 +119,7 @@ export default function UploadPage() {
             </CardHeader>
             <CardBody className="space-y-4">
               <FileUpload
-                accept=".csv,.fit"
+                accept=".csv,.fit,application/octet-stream"
                 onUpload={form.handleFileUpload}
                 onRemove={form.handleFileRemove}
                 instructionText={


### PR DESCRIPTION
## Summary
- `accept`-Attribut um `application/octet-stream` erweitert, damit iOS Safari `.fit`-Dateien im Picker nicht blockiert
- Betrifft Upload.tsx und StrengthForm.tsx
- Clientseitige + serverseitige Validierung bleibt bestehen

## Test plan
- [ ] iPhone Safari: `.fit`-Datei im Upload-Dialog auswählbar
- [ ] Desktop: `.csv` und `.fit` weiterhin auswählbar
- [ ] Upload einer `.fit`-Datei funktioniert Ende-zu-Ende

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)