### PR TITLE
fix: Datum um einen Tag verschoben durch UTC-Konvertierung (#253)

### DIFF
--- a/frontend/src/components/plan-helpers.ts
+++ b/frontend/src/components/plan-helpers.ts
@@ -79,5 +79,8 @@ export function getCurrentWeekStart(): string {
   const today = new Date();
   const monday = new Date(today);
   monday.setDate(today.getDate() - today.getDay() + (today.getDay() === 0 ? -6 : 1));
-  return monday.toISOString().split('T')[0];
+  const y = monday.getFullYear();
+  const m = String(monday.getMonth() + 1).padStart(2, '0');
+  const d = String(monday.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
 }

--- a/frontend/src/features/strength/StrengthForm.tsx
+++ b/frontend/src/features/strength/StrengthForm.tsx
@@ -22,6 +22,7 @@ import { createStrengthSession } from '@/api/strength';
 import type { Exercise } from '@/api/exercises';
 import { listExercises } from '@/api/exercises';
 import { ExerciseCard } from './ExerciseCard';
+import { formatLocalDate } from '@/utils/weeklyPlanUtils';
 
 const defaultExercise: ExerciseInput = {
   name: '',
@@ -82,7 +83,7 @@ export function StrengthForm() {
 
     try {
       const result = await createStrengthSession({
-        date: date.toISOString().split('T')[0],
+        date: formatLocalDate(date),
         duration_minutes: duration,
         exercises,
         notes: notes.trim() || undefined,

--- a/frontend/src/hooks/usePlanSubmit.ts
+++ b/frontend/src/hooks/usePlanSubmit.ts
@@ -13,6 +13,7 @@ import {
   updatePhase,
   deletePhase,
 } from '@/api/training-plans';
+import { formatLocalDate } from '@/utils/weeklyPlanUtils';
 import type { PlanStatus } from '@/api/training-plans';
 import { type PhaseForm, phaseFormToParams } from '@/hooks/usePlanForm';
 
@@ -59,7 +60,7 @@ export function usePlanSubmit(opts: UsePlanSubmitOptions) {
     setSaving(true);
     setError(null);
 
-    const formatDate = (d: Date) => d.toISOString().split('T')[0];
+    const formatDate = formatLocalDate;
 
     try {
       if (isEdit) {

--- a/frontend/src/hooks/usePlannedSessionLinking.ts
+++ b/frontend/src/hooks/usePlannedSessionLinking.ts
@@ -4,13 +4,14 @@
 import { useState, useEffect } from 'react';
 import { getPlannedSessionsForDate } from '@/api/weekly-plan';
 import type { PlannedSessionOption } from '@/api/weekly-plan';
+import { formatLocalDate } from '@/utils/weeklyPlanUtils';
 
 export function usePlannedSessionLinking(trainingDate: Date) {
   const [plannedSessions, setPlannedSessions] = useState<PlannedSessionOption[]>([]);
   const [selectedPlannedId, setSelectedPlannedId] = useState<number | null>(null);
 
   useEffect(() => {
-    const dateStr = trainingDate.toISOString().split('T')[0];
+    const dateStr = formatLocalDate(trainingDate);
     getPlannedSessionsForDate(dateStr)
       .then(setPlannedSessions)
       .catch(() => setPlannedSessions([]));

--- a/frontend/src/hooks/useStrengthUpload.ts
+++ b/frontend/src/hooks/useStrengthUpload.ts
@@ -11,6 +11,7 @@ import { listExercises } from '@/api/exercises';
 import { listSessionTemplates, getSessionTemplate } from '@/api/session-templates';
 import type { SessionTemplateSummary } from '@/api/session-templates';
 import { useTonnageCalc, formatTonnage } from '@/hooks/useTonnageCalc';
+import { formatLocalDate } from '@/utils/weeklyPlanUtils';
 
 const defaultExercise: ExerciseInput = {
   name: '',
@@ -141,7 +142,7 @@ export function useStrengthUpload({
     setError(null);
     try {
       const result = await createStrengthSession({
-        date: trainingDate.toISOString().split('T')[0],
+        date: formatLocalDate(trainingDate),
         duration_minutes: duration,
         exercises,
         notes: notes.trim() || undefined,

--- a/frontend/src/hooks/useUploadForm.ts
+++ b/frontend/src/hooks/useUploadForm.ts
@@ -5,6 +5,7 @@ import { useState, useCallback } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { parseTraining, uploadTraining } from '@/api/training';
 import type { TrainingParseResponse } from '@/api/training';
+import { formatLocalDate } from '@/utils/weeklyPlanUtils';
 
 type TrainingType = 'running' | 'strength';
 
@@ -55,7 +56,7 @@ export function useUploadForm() {
     try {
       const result = await parseTraining({
         csvFile,
-        trainingDate: trainingDate.toISOString().split('T')[0],
+        trainingDate: formatLocalDate(trainingDate),
         trainingType,
         notes: notes || undefined,
       });
@@ -98,7 +99,7 @@ export function useUploadForm() {
       try {
         const result = await uploadTraining({
           csvFile,
-          trainingDate: trainingDate.toISOString().split('T')[0],
+          trainingDate: formatLocalDate(trainingDate),
           trainingType,
           notes: notes || undefined,
           rpe,

--- a/frontend/src/pages/StrengthSession.tsx
+++ b/frontend/src/pages/StrengthSession.tsx
@@ -13,6 +13,7 @@ import {
 } from '@nordlig/components';
 import { DatePicker } from '@nordlig/components';
 import { ClipboardList, Save, ArrowLeft, RotateCcw, TrendingUp, TrendingDown } from 'lucide-react';
+import { formatLocalDate } from '@/utils/weeklyPlanUtils';
 import { createStrengthSession, getLastCompleteStrengthSession } from '@/api/strength';
 import type {
   ExerciseCategory,
@@ -167,7 +168,7 @@ export function StrengthSessionPage() {
 
     try {
       const result = await createStrengthSession({
-        date: trainingDate.toISOString().split('T')[0],
+        date: formatLocalDate(trainingDate),
         duration_minutes: durationMinutes,
         exercises: validExercises.map((ex) => ({
           name: ex.name.trim(),

--- a/frontend/src/utils/weeklyPlanUtils.ts
+++ b/frontend/src/utils/weeklyPlanUtils.ts
@@ -7,18 +7,26 @@ export function categoryLabel(key: string): string {
   return CATEGORY_LABELS[key] ?? key;
 }
 
+/** Format a Date as YYYY-MM-DD using local timezone (not UTC). */
+export function formatLocalDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
 export function getMondayOfWeek(d: Date): string {
   const copy = new Date(d);
   const day = copy.getDay();
   const diff = day === 0 ? -6 : 1 - day;
   copy.setDate(copy.getDate() + diff);
-  return copy.toISOString().split('T')[0];
+  return formatLocalDate(copy);
 }
 
 export function addWeeks(dateStr: string, weeks: number): string {
   const d = new Date(dateStr);
   d.setDate(d.getDate() + weeks * 7);
-  return d.toISOString().split('T')[0];
+  return formatLocalDate(d);
 }
 
 export function formatDateRange(weekStart: string): string {


### PR DESCRIPTION
## Summary
- `Date.toISOString().split('T')[0]` konvertiert nach UTC — in UTC+1/+2 verschiebt das Daten um einen Tag
- Neue `formatLocalDate()` Funktion nutzt `getFullYear()/getMonth()/getDate()` (lokal)
- Alle 10 Vorkommen im Frontend ersetzt
- Behebt den Bug bei „Geplante Session zuordnen" und alle anderen datumsbasierten Abfragen

## Betroffene Dateien
- `weeklyPlanUtils.ts` — neue `formatLocalDate()`, Fix in `getMondayOfWeek`/`addWeeks`
- `usePlannedSessionLinking.ts` — Kern-Bug (falsche Woche bei Session-Zuordnung)
- `useUploadForm.ts` — Upload-Datum
- `useStrengthUpload.ts` — Kraft-Upload
- `usePlanSubmit.ts` — Plan-Erstellung
- `StrengthSession.tsx` — Kraft-Session
- `StrengthForm.tsx` — Kraft-Formular
- `plan-helpers.ts` — getCurrentWeekStart

## Test plan
- [ ] „Geplante Session zuordnen" zeigt Sessions für den korrekten Tag
- [ ] Upload-Datum stimmt mit gewähltem Datum überein
- [ ] Wochenplan zeigt korrekten Montag
- [ ] Trainingsplan-Erstellung nutzt korrekte Datumswerte

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)