### PR TITLE
fix: KI-Analyse History enthält zukünftige Sessions (#259)

### DIFF
--- a/backend/app/services/session_analysis_service.py
+++ b/backend/app/services/session_analysis_service.py
@@ -87,11 +87,13 @@ async def _load_analysis_context(workout: WorkoutModel, db: AsyncSession) -> Ana
     workout_date = workout.date.date() if isinstance(workout.date, datetime) else workout.date
     four_weeks_ago = datetime.combine(workout_date - timedelta(weeks=4), datetime.min.time())
 
-    # Letzte 20 Sessions (4 Wochen)
+    # Letzte 20 Sessions (4 Wochen VOR der aktuellen Session)
+    workout_dt = datetime.combine(workout_date, datetime.max.time())
     hist_result = await db.execute(
         select(WorkoutModel)
         .where(
             WorkoutModel.date >= four_weeks_ago,
+            WorkoutModel.date <= workout_dt,
             WorkoutModel.id != workout.id,
         )
         .order_by(WorkoutModel.date.desc())


### PR DESCRIPTION
## Summary
- History-Query in `_load_analysis_context()` hatte keine obere Datumsgrenze
- Sessions nach der analysierten Session wurden als vergangene History an die KI übergeben
- Fix: `WorkoutModel.date <= workout_dt` als Filter hinzugefügt

## Test plan
- [x] Bestehende Tests grün (565 passed)
- [x] Ruff, Mypy bestehen
- [ ] Manuell: Ältere Session analysieren → History enthält keine neueren Sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)