### PR TITLE
feat: KI Debug Log — transparente AI-Kommunikation (#261)

### DIFF
--- a/backend/alembic/versions/c029_add_ai_analysis_log.py
+++ b/backend/alembic/versions/c029_add_ai_analysis_log.py
@@ -1,0 +1,33 @@
+"""add ai_analysis_log table
+
+Revision ID: c029
+Revises: c028
+Create Date: 2026-03-15
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "c029"
+down_revision = "c028"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ai_analysis_log",
+        sa.Column("id", sa.Integer(), primary_key=True, index=True),
+        sa.Column("workout_id", sa.Integer(), sa.ForeignKey("workouts.id", ondelete="CASCADE"), nullable=False, index=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("provider", sa.String(100), nullable=False),
+        sa.Column("system_prompt", sa.Text(), nullable=False),
+        sa.Column("user_prompt", sa.Text(), nullable=False),
+        sa.Column("raw_response", sa.Text(), nullable=False),
+        sa.Column("parsed_ok", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("duration_ms", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("ai_analysis_log")

--- a/backend/app/api/v1/ai_log.py
+++ b/backend/app/api/v1/ai_log.py
@@ -1,0 +1,117 @@
+"""API-Endpoints fuer KI Analyse-Log."""
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.infrastructure.database.models import AIAnalysisLogModel, WorkoutModel
+from app.infrastructure.database.session import get_db
+
+router = APIRouter(prefix="/ai/log")
+
+
+class AILogListEntry(BaseModel):
+    """Kurzform fuer Liste."""
+
+    id: int
+    workout_id: int
+    created_at: datetime
+    provider: str
+    parsed_ok: bool
+    duration_ms: int | None
+    session_date: str
+    session_type: str
+
+
+class AILogDetail(AILogListEntry):
+    """Vollstaendiger Eintrag mit Prompts und Response."""
+
+    system_prompt: str
+    user_prompt: str
+    raw_response: str
+
+
+class AILogListResponse(BaseModel):
+    """Paginierte Antwort."""
+
+    items: list[AILogListEntry]
+    total: int
+
+
+@router.get("", response_model=AILogListResponse)
+async def list_ai_logs(
+    db: AsyncSession = Depends(get_db),
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+) -> AILogListResponse:
+    """Paginierte Liste aller KI-Analyse-Logs (neueste zuerst)."""
+    # Total count
+    count_result = await db.execute(select(func.count(AIAnalysisLogModel.id)))
+    total = count_result.scalar_one()
+
+    # Logs mit Workout-Daten joinen
+    stmt = (
+        select(AIAnalysisLogModel, WorkoutModel.date, WorkoutModel.workout_type)
+        .join(WorkoutModel, AIAnalysisLogModel.workout_id == WorkoutModel.id)
+        .order_by(AIAnalysisLogModel.created_at.desc())
+        .offset(offset)
+        .limit(limit)
+    )
+    result = await db.execute(stmt)
+    rows = result.all()
+
+    items = []
+    for log, w_date, w_type in rows:
+        session_date = w_date.date().isoformat() if isinstance(w_date, datetime) else str(w_date)
+        items.append(
+            AILogListEntry(
+                id=log.id,
+                workout_id=log.workout_id,
+                created_at=log.created_at,
+                provider=log.provider,
+                parsed_ok=log.parsed_ok,
+                duration_ms=log.duration_ms,
+                session_date=session_date,
+                session_type=str(w_type),
+            )
+        )
+
+    return AILogListResponse(items=items, total=total)
+
+
+@router.get("/{log_id}", response_model=AILogDetail)
+async def get_ai_log_detail(
+    log_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> AILogDetail:
+    """Einzelner Log-Eintrag mit vollem Prompt und Response."""
+    stmt = (
+        select(AIAnalysisLogModel, WorkoutModel.date, WorkoutModel.workout_type)
+        .join(WorkoutModel, AIAnalysisLogModel.workout_id == WorkoutModel.id)
+        .where(AIAnalysisLogModel.id == log_id)
+    )
+    result = await db.execute(stmt)
+    row = result.one_or_none()
+
+    if not row:
+        raise HTTPException(status_code=404, detail="Log-Eintrag nicht gefunden")
+
+    log, w_date, w_type = row
+    session_date = w_date.date().isoformat() if isinstance(w_date, datetime) else str(w_date)
+
+    return AILogDetail(
+        id=log.id,
+        workout_id=log.workout_id,
+        created_at=log.created_at,
+        provider=log.provider,
+        parsed_ok=log.parsed_ok,
+        duration_ms=log.duration_ms,
+        session_date=session_date,
+        session_type=str(w_type),
+        system_prompt=log.system_prompt,
+        user_prompt=log.user_prompt,
+        raw_response=log.raw_response,
+    )

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 
 from app.api.v1 import (
     ai,
+    ai_log,
     athlete,
     exercise_library,
     goals,
@@ -27,6 +28,7 @@ api_router.include_router(sessions.router, tags=["sessions"])
 api_router.include_router(athlete.router, tags=["athlete"])
 api_router.include_router(goals.router, tags=["goals"])
 api_router.include_router(ai.router, tags=["ai"])
+api_router.include_router(ai_log.router, tags=["ai-log"])
 api_router.include_router(trends.router, tags=["trends"])
 api_router.include_router(exercise_library.router, tags=["exercises"])
 api_router.include_router(session_templates.router, tags=["session-templates"])

--- a/backend/app/infrastructure/database/models.py
+++ b/backend/app/infrastructure/database/models.py
@@ -1,6 +1,17 @@
 from datetime import date, datetime
 
-from sqlalchemy import Date, DateTime, Float, Integer, String, Text, UniqueConstraint
+from sqlalchemy import (
+    Boolean,
+    Date,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
@@ -219,6 +230,22 @@ class PlannedSessionModel(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
     )
+
+
+class AIAnalysisLogModel(Base):
+    __tablename__ = "ai_analysis_log"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    workout_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("workouts.id", ondelete="CASCADE"), index=True
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+    provider: Mapped[str] = mapped_column(String(100))
+    system_prompt: Mapped[str] = mapped_column(Text)
+    user_prompt: Mapped[str] = mapped_column(Text)
+    raw_response: Mapped[str] = mapped_column(Text)
+    parsed_ok: Mapped[bool] = mapped_column(Boolean, server_default="true")
+    duration_ms: Mapped[int | None] = mapped_column(Integer, default=None)
 
 
 class PlanChangeLogModel(Base):

--- a/backend/app/services/session_analysis_service.py
+++ b/backend/app/services/session_analysis_service.py
@@ -7,6 +7,7 @@ die JSON-Antwort des AI-Providers.
 import contextlib
 import json
 import logging
+import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
@@ -16,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.api_key_resolver import resolve_claude_api_key
 from app.infrastructure.ai.ai_service import ai_service
 from app.infrastructure.database.models import (
+    AIAnalysisLogModel,
     AthleteModel,
     PlannedSessionModel,
     RaceGoalModel,
@@ -55,12 +57,26 @@ async def analyze_session(
     system_prompt = _build_system_prompt(context)
     api_key = await resolve_claude_api_key(db)
 
+    t0 = time.monotonic()
     raw = await ai_service.chat(prompt, {"system_prompt": system_prompt}, api_key)
+    duration_ms = int((time.monotonic() - t0) * 1000)
     provider = ai_service.get_active_provider() or "unknown"
 
-    # Parsen + Cache speichern
+    # Parsen + Cache speichern + Log schreiben
     analysis = _parse_analysis_json(raw, session_id, provider)
+    parsed_ok = analysis.summary != raw[:500]  # Fallback hat raw als summary
     workout.ai_analysis = json.dumps(analysis.model_dump())
+    db.add(
+        AIAnalysisLogModel(
+            workout_id=session_id,
+            provider=provider,
+            system_prompt=system_prompt,
+            user_prompt=prompt,
+            raw_response=raw,
+            parsed_ok=parsed_ok,
+            duration_ms=duration_ms,
+        )
+    )
     await db.commit()
 
     return analysis

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -105,6 +105,7 @@ const GoalsPage = lazy(() => import('./pages/Goals').then((m) => ({ default: m.G
 const AthleteProfilePage = lazy(() =>
   import('./pages/AthleteProfile').then((m) => ({ default: m.AthleteProfilePage })),
 );
+const KiLogPage = lazy(() => import('./pages/KiLog').then((m) => ({ default: m.KiLogPage })));
 const NotFoundPage = lazy(() =>
   import('./pages/NotFound').then((m) => ({ default: m.NotFoundPage })),
 );
@@ -156,6 +157,7 @@ function App() {
 
                   {/* Profil (formerly Einstellungen > Athletenprofil) */}
                   <Route path="/profile" element={<AthleteProfilePage />} />
+                  <Route path="/ki-log" element={<KiLogPage />} />
 
                   {/* Redirects for old /settings paths */}
                   <Route path="/settings" element={<Navigate to="/plan" replace />} />

--- a/frontend/src/api/training.ts
+++ b/frontend/src/api/training.ts
@@ -473,6 +473,42 @@ export async function getSessionComparison(sessionId: number): Promise<Compariso
   return response.data;
 }
 
+// --- KI Debug Log (#261) ---
+
+export interface AILogEntry {
+  id: number;
+  workout_id: number;
+  created_at: string;
+  provider: string;
+  parsed_ok: boolean;
+  duration_ms: number | null;
+  session_date: string;
+  session_type: string;
+}
+
+export interface AILogDetail extends AILogEntry {
+  system_prompt: string;
+  user_prompt: string;
+  raw_response: string;
+}
+
+export interface AILogListResponse {
+  items: AILogEntry[];
+  total: number;
+}
+
+export async function fetchAILog(limit = 20, offset = 0): Promise<AILogListResponse> {
+  const response = await apiClient.get<AILogListResponse>('/api/v1/ai/log', {
+    params: { limit, offset },
+  });
+  return response.data;
+}
+
+export async function fetchAILogDetail(logId: number): Promise<AILogDetail> {
+  const response = await apiClient.get<AILogDetail>(`/api/v1/ai/log/${logId}`);
+  return response.data;
+}
+
 export async function healthCheck(): Promise<{ status: string }> {
   const response = await apiClient.get<{ status: string }>('/health');
   return response.data;

--- a/frontend/src/pages/AthleteProfile.tsx
+++ b/frontend/src/pages/AthleteProfile.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
+import { Link } from 'react-router-dom';
 import {
   Card,
   CardHeader,
@@ -319,6 +320,23 @@ export function AthleteProfilePage() {
 
       {/* API Keys */}
       <ApiKeyCard keys={apiKeys} />
+
+      {/* KI Debug Log Link */}
+      <Card elevation="raised" padding="spacious">
+        <CardBody className="flex items-center justify-between">
+          <div>
+            <h3 className="text-sm font-semibold">KI Analyse-Log</h3>
+            <p className="text-xs text-[var(--color-text-muted)]">
+              Alle KI-Anfragen und -Antworten einsehen
+            </p>
+          </div>
+          <Link to="/ki-log">
+            <Button variant="secondary" size="sm">
+              Log öffnen
+            </Button>
+          </Link>
+        </CardBody>
+      </Card>
     </div>
   );
 }

--- a/frontend/src/pages/KiLog.tsx
+++ b/frontend/src/pages/KiLog.tsx
@@ -1,0 +1,248 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  Card,
+  CardHeader,
+  CardBody,
+  Badge,
+  Button,
+  Spinner,
+  Breadcrumbs,
+  BreadcrumbItem,
+} from '@nordlig/components';
+import { fetchAILog, fetchAILogDetail } from '@/api/training';
+import type { AILogEntry, AILogDetail } from '@/api/training';
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('de-DE', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function PromptBlock({ label, content }: { label: string; content: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const preview = content.slice(0, 200);
+  const isLong = content.length > 200;
+
+  return (
+    <div className="space-y-1">
+      <h4 className="text-xs font-semibold text-[var(--color-text-muted)] uppercase tracking-wide">
+        {label}
+      </h4>
+      <pre className="text-xs whitespace-pre-wrap bg-[var(--color-bg-subtle)] rounded-[var(--radius-component-sm)] p-3 overflow-auto max-h-[400px] text-[var(--color-text-base)]">
+        {expanded || !isLong ? content : `${preview}...`}
+      </pre>
+      {isLong && (
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="text-xs text-[var(--color-text-link)] hover:underline"
+        >
+          {expanded ? 'Weniger anzeigen' : 'Mehr anzeigen'}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function LogDetail({ logId, onClose }: { logId: number; onClose: () => void }) {
+  const [detail, setDetail] = useState<AILogDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchAILogDetail(logId)
+      .then(setDetail)
+      .finally(() => setLoading(false));
+  }, [logId]);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Spinner size="md" />
+      </div>
+    );
+  }
+
+  if (!detail) return null;
+
+  return (
+    <Card elevation="raised" padding="spacious">
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <h3 className="text-base font-semibold">
+            Analyse #{detail.id} — Session vom {detail.session_date}
+          </h3>
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            Schließen
+          </Button>
+        </div>
+        <div className="flex gap-2 mt-1 text-xs text-[var(--color-text-muted)]">
+          <span>{detail.provider}</span>
+          <span>&middot;</span>
+          <span>{formatDate(detail.created_at)}</span>
+          {detail.duration_ms != null && (
+            <>
+              <span>&middot;</span>
+              <span>{(detail.duration_ms / 1000).toFixed(1)}s</span>
+            </>
+          )}
+        </div>
+      </CardHeader>
+      <CardBody className="space-y-4">
+        <PromptBlock label="System-Prompt" content={detail.system_prompt} />
+        <PromptBlock label="User-Prompt" content={detail.user_prompt} />
+        <PromptBlock label="KI-Antwort" content={detail.raw_response} />
+      </CardBody>
+    </Card>
+  );
+}
+
+function LogTable({
+  entries,
+  onSelect,
+}: {
+  entries: AILogEntry[];
+  onSelect: (id: number) => void;
+}) {
+  return (
+    <Card elevation="raised" padding="compact">
+      <CardBody className="p-0">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[var(--color-border-subtle)] text-left text-xs text-[var(--color-text-muted)] uppercase tracking-wide">
+                <th className="px-4 py-3">Datum</th>
+                <th className="px-4 py-3">Session</th>
+                <th className="px-4 py-3">Provider</th>
+                <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3">Dauer</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((entry) => (
+                <tr
+                  key={entry.id}
+                  onClick={() => onSelect(entry.id)}
+                  className="border-b border-[var(--color-border-subtle)] cursor-pointer hover:bg-[var(--color-bg-subtle)] transition-colors"
+                >
+                  <td className="px-4 py-3 whitespace-nowrap">{formatDate(entry.created_at)}</td>
+                  <td className="px-4 py-3">
+                    <Link
+                      to={`/sessions/${entry.workout_id}`}
+                      onClick={(e) => e.stopPropagation()}
+                      className="text-[var(--color-text-link)] hover:underline"
+                    >
+                      {entry.session_date} ({entry.session_type})
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-[var(--color-text-muted)]">{entry.provider}</td>
+                  <td className="px-4 py-3">
+                    <Badge variant={entry.parsed_ok ? 'success' : 'error'}>
+                      {entry.parsed_ok ? 'OK' : 'Fehler'}
+                    </Badge>
+                  </td>
+                  <td className="px-4 py-3 text-[var(--color-text-muted)]">
+                    {entry.duration_ms != null
+                      ? `${(entry.duration_ms / 1000).toFixed(1)}s`
+                      : '\u2014'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}
+
+export function KiLogPage() {
+  const [entries, setEntries] = useState<AILogEntry[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [offset, setOffset] = useState(0);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const limit = 20;
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await fetchAILog(limit, offset);
+      setEntries(data.items);
+      setTotal(data.total);
+    } finally {
+      setLoading(false);
+    }
+  }, [offset]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <div className="p-4 pt-6 md:p-6 md:pt-8 max-w-5xl mx-auto space-y-6">
+      <div className="space-y-2 pb-2">
+        <Breadcrumbs>
+          <BreadcrumbItem>
+            <Link to="/profile">Profil</Link>
+          </BreadcrumbItem>
+          <BreadcrumbItem isCurrent>KI Log</BreadcrumbItem>
+        </Breadcrumbs>
+        <h1 className="text-2xl md:text-3xl font-semibold">KI Analyse-Log</h1>
+        <p className="text-xs text-[var(--color-text-muted)]">
+          Transparente Übersicht aller KI-Anfragen und -Antworten
+        </p>
+      </div>
+
+      {selectedId != null && <LogDetail logId={selectedId} onClose={() => setSelectedId(null)} />}
+
+      {loading ? (
+        <div className="flex justify-center py-12">
+          <Spinner size="lg" />
+        </div>
+      ) : entries.length === 0 ? (
+        <Card elevation="raised" padding="spacious">
+          <CardBody>
+            <p className="text-sm text-[var(--color-text-muted)] text-center py-8">
+              Noch keine KI-Analysen durchgeführt.
+            </p>
+          </CardBody>
+        </Card>
+      ) : (
+        <>
+          <LogTable entries={entries} onSelect={setSelectedId} />
+
+          {total > limit && (
+            <div className="flex justify-between items-center text-sm">
+              <span className="text-[var(--color-text-muted)]">
+                {offset + 1}–{Math.min(offset + limit, total)} von {total}
+              </span>
+              <div className="flex gap-2">
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  disabled={offset === 0}
+                  onClick={() => setOffset(Math.max(0, offset - limit))}
+                >
+                  Zurück
+                </Button>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  disabled={offset + limit >= total}
+                  onClick={() => setOffset(offset + limit)}
+                >
+                  Weiter
+                </Button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Neue DB-Tabelle `ai_analysis_log` speichert bei jeder KI-Analyse: System-Prompt, User-Prompt, Raw Response, Provider, Parse-Status, Antwortzeit
- API-Endpoints `GET /ai/log` (paginiert) und `GET /ai/log/{id}` (Detail mit Prompts)
- Eigene Frontend-Seite `/ki-log` mit Tabellen-Übersicht und Detail-Ansicht
- Link zur KI-Log-Seite im Profil

## Test plan
- [x] Backend: Ruff, Mypy, 565 Pytest bestanden
- [x] Frontend: TSC, ESLint, Prettier, 160 Vitest bestanden
- [ ] Manuell: Session analysieren → Log-Eintrag erscheint in `/ki-log`
- [ ] Manuell: Eintrag öffnen → System-Prompt, User-Prompt, Raw Response sichtbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)