### PR TITLE
fix: Exercise AI Enrichment — api_key_resolver nutzen (#266)

### DIFF
--- a/backend/app/api/v1/exercise_library.py
+++ b/backend/app/api/v1/exercise_library.py
@@ -657,9 +657,11 @@ async def create_exercise(
     # Try to enrich from free-exercise-db, then Claude API fallback
     enrichment = enrich_exercise_model(body.name)
     if not enrichment:
+        from app.core.api_key_resolver import resolve_claude_api_key
         from app.services.exercise_ai_enrichment import generate_exercise_enrichment
 
-        enrichment = await generate_exercise_enrichment(body.name, body.category)
+        api_key = await resolve_claude_api_key(db)
+        enrichment = await generate_exercise_enrichment(body.name, body.category, api_key)
     if enrichment:
         _apply_enrichment(exercise, enrichment)
 
@@ -791,11 +793,14 @@ async def enrich_exercise(
 
     if not enrichment:
         # Fallback: Claude API für Anreicherung nutzen
+        from app.core.api_key_resolver import resolve_claude_api_key
         from app.services.exercise_ai_enrichment import generate_exercise_enrichment
 
+        api_key = await resolve_claude_api_key(db)
         enrichment = await generate_exercise_enrichment(
             str(exercise.name),
             str(exercise.category),
+            api_key,
         )
 
     if not enrichment:

--- a/backend/app/services/exercise_ai_enrichment.py
+++ b/backend/app/services/exercise_ai_enrichment.py
@@ -129,21 +129,25 @@ def _validate_and_normalize(data: dict) -> Optional[dict]:
 async def generate_exercise_enrichment(
     exercise_name: str,
     category: str,
+    api_key: str = "",
 ) -> Optional[dict[str, Optional[str]]]:
     """Generiere Übungs-Anreicherung über Claude API.
 
     Fallback wenn free-exercise-db keinen Match hat.
     Gibt DB-ready Column-Values zurück (gleiches Format wie
     ``exercise_enrichment._to_db_columns``), oder ``None`` bei Fehler.
+
+    Args:
+        api_key: Resolved API-Key (via ``resolve_claude_api_key``).
     """
-    if not settings.claude_api_key:
+    if not api_key:
         logger.debug("Claude API Key nicht konfiguriert — Fallback übersprungen")
         return None
 
     prompt = _build_prompt(exercise_name, category)
 
     try:
-        client = anthropic.Anthropic(api_key=settings.claude_api_key)
+        client = anthropic.Anthropic(api_key=api_key)
         response = client.messages.create(
             model=settings.claude_model,
             max_tokens=1000,

--- a/backend/app/tests/test_exercise_ai_enrichment.py
+++ b/backend/app/tests/test_exercise_ai_enrichment.py
@@ -138,10 +138,8 @@ class TestGenerateExerciseEnrichment:
     @pytest.mark.asyncio
     async def test_no_api_key_returns_none(self) -> None:
         """Ohne API-Key wird sofort None zurückgegeben."""
-        with patch("app.services.exercise_ai_enrichment.settings") as mock_settings:
-            mock_settings.claude_api_key = ""
-            result = await generate_exercise_enrichment("Test Übung", "push")
-            assert result is None
+        result = await generate_exercise_enrichment("Test Übung", "push", "")
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_successful_api_call(self) -> None:
@@ -170,11 +168,10 @@ class TestGenerateExerciseEnrichment:
             patch("app.services.exercise_ai_enrichment.settings") as mock_settings,
             patch("app.services.exercise_ai_enrichment.anthropic") as mock_anthropic,
         ):
-            mock_settings.claude_api_key = "test-key"
             mock_settings.claude_model = "claude-sonnet-4-20250514"
             mock_anthropic.Anthropic.return_value = mock_client
 
-            result = await generate_exercise_enrichment("Bankdrücken", "push")
+            result = await generate_exercise_enrichment("Bankdrücken", "push", "test-key")
 
         assert result is not None
         instructions_json = result["instructions_json"]
@@ -196,11 +193,10 @@ class TestGenerateExerciseEnrichment:
             patch("app.services.exercise_ai_enrichment.settings") as mock_settings,
             patch("app.services.exercise_ai_enrichment.anthropic") as mock_anthropic,
         ):
-            mock_settings.claude_api_key = "test-key"
             mock_settings.claude_model = "claude-sonnet-4-20250514"
             mock_anthropic.Anthropic.return_value = mock_client
 
-            result = await generate_exercise_enrichment("Test", "push")
+            result = await generate_exercise_enrichment("Test", "push", "test-key")
 
         assert result is None
 
@@ -217,11 +213,10 @@ class TestGenerateExerciseEnrichment:
             patch("app.services.exercise_ai_enrichment.settings") as mock_settings,
             patch("app.services.exercise_ai_enrichment.anthropic") as mock_anthropic,
         ):
-            mock_settings.claude_api_key = "test-key"
             mock_settings.claude_model = "claude-sonnet-4-20250514"
             mock_anthropic.Anthropic.return_value = mock_client
 
-            result = await generate_exercise_enrichment("Test", "push")
+            result = await generate_exercise_enrichment("Test", "push", "test-key")
 
         assert result is None
 
@@ -247,10 +242,9 @@ class TestGenerateExerciseEnrichment:
             patch("app.services.exercise_ai_enrichment.settings") as mock_settings,
             patch("app.services.exercise_ai_enrichment.anthropic") as mock_anthropic,
         ):
-            mock_settings.claude_api_key = "test-key"
             mock_settings.claude_model = "claude-sonnet-4-20250514"
             mock_anthropic.Anthropic.return_value = mock_client
 
-            result = await generate_exercise_enrichment("Test", "push")
+            result = await generate_exercise_enrichment("Test", "push", "test-key")
 
         assert result is None


### PR DESCRIPTION
## Summary
- `generate_exercise_enrichment()` las den API-Key direkt aus `settings.claude_api_key` (Umgebungsvariable)
- Jetzt wird der Key als Parameter übergeben und über `resolve_claude_api_key(db)` aufgelöst
- Damit funktioniert die KI-Anreicherung auch wenn nur ein User-Key im Profil hinterlegt ist (kein Server-seitiger Key nötig)
- Beide Call-Sites (`POST /exercises` und `POST /exercises/{id}/enrich`) aktualisiert
- 15 Tests angepasst und grün

## Test plan
- [ ] Übung anlegen ohne Server-ANTHROPIC_API_KEY, nur mit User-Key im Profil → KI-Anreicherung funktioniert
- [ ] Übung anlegen mit Server-Key → weiterhin funktional
- [ ] `POST /exercises/{id}/enrich` ohne DB-Match → Claude-Fallback greift

🤖 Generated with [Claude Code](https://claude.com/claude-code)