### PR TITLE
fix: Übungserstellung 500 — Migration c030 idempotent (#270)

### DIFF
--- a/backend/alembic/versions/c030_generalize_ai_log.py
+++ b/backend/alembic/versions/c030_generalize_ai_log.py
@@ -16,8 +16,15 @@ depends_on = None
 
 def upgrade() -> None:
     op.alter_column("ai_analysis_log", "workout_id", existing_type=sa.Integer(), nullable=True)
-    op.add_column("ai_analysis_log", sa.Column("use_case", sa.String(50), nullable=False, server_default="session_analysis"))
-    op.add_column("ai_analysis_log", sa.Column("context_label", sa.String(200), nullable=True))
+
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_cols = {c["name"] for c in inspector.get_columns("ai_analysis_log")}
+
+    if "use_case" not in existing_cols:
+        op.add_column("ai_analysis_log", sa.Column("use_case", sa.String(50), nullable=False, server_default="session_analysis"))
+    if "context_label" not in existing_cols:
+        op.add_column("ai_analysis_log", sa.Column("context_label", sa.String(200), nullable=True))
 
 
 def downgrade() -> None:

--- a/backend/app/api/v1/exercise_library.py
+++ b/backend/app/api/v1/exercise_library.py
@@ -636,26 +636,6 @@ async def create_exercise(
     db: AsyncSession = Depends(get_db),
 ) -> ExerciseResponse:
     """Erstellt eine neue benutzerdefinierte Übung."""
-    import logging
-    import traceback
-
-    _logger = logging.getLogger(__name__)
-
-    try:
-        return await _create_exercise_impl(body, db)
-    except HTTPException:
-        raise
-    except Exception as exc:
-        tb = traceback.format_exc()
-        _logger.error("create_exercise failed: %s\n%s", exc, tb)
-        raise HTTPException(status_code=500, detail=f"Fehler: {exc}\n{tb}") from exc
-
-
-async def _create_exercise_impl(
-    body: ExerciseCreate,
-    db: AsyncSession,
-) -> ExerciseResponse:
-    """Implementierung für create_exercise."""
     if body.category not in VALID_CATEGORIES:
         raise HTTPException(
             status_code=400,


### PR DESCRIPTION
## Summary
- **Root Cause:** `init_db()._ensure_columns_exist()` added `use_case` and `context_label` columns to the DB before Alembic could run migration c030. When c030 then tried `add_column`, it failed because the columns already existed. As a result, `workout_id` was never made nullable, causing INSERT with `workout_id=NULL` to fail.
- **Fix:** c030 now checks if columns already exist before calling `add_column`. The `alter_column` for `workout_id` is already idempotent.
- Debug wrapper from PR #271 removed

## Test plan
- [x] All 569 backend tests pass
- [x] Ruff, Mypy bestanden
- [ ] Deploy und POST /api/v1/exercises testen
- [ ] KI-Log Einträge mit use_case="exercise_enrichment" prüfen

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)