### PR TITLE
fix: workout_id nullable — Migration c031 (#270)

### DIFF
--- a/backend/alembic/versions/c031_fix_workout_id_nullable.py
+++ b/backend/alembic/versions/c031_fix_workout_id_nullable.py
@@ -1,0 +1,31 @@
+"""fix workout_id nullable — c030 was recorded but ALTER failed
+
+init_db()._ensure_columns_exist() added use_case/context_label
+before Alembic c030 could run its add_column calls, causing c030
+to fail. But alembic_version was already at c030, so the
+alter_column for workout_id was never applied.
+
+Revision ID: c031
+Revises: c030
+Create Date: 2026-03-15
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "c031"
+down_revision = "c030"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "ai_analysis_log", "workout_id", existing_type=sa.Integer(), nullable=True
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "ai_analysis_log", "workout_id", existing_type=sa.Integer(), nullable=False
+    )


### PR DESCRIPTION
## Summary
- New migration c031 that just runs `ALTER COLUMN workout_id DROP NOT NULL`
- Root cause: `init_db()._ensure_columns_exist()` pre-empted c030's `add_column` calls, causing c030 to fail. But `alembic_version` was recorded as c030, so the `alter_column` for workout_id was never applied.
- c030 was also made idempotent (checks if columns exist before adding) in PR #272

## Test plan
- [x] All 569 backend tests pass
- [x] Ruff, Mypy bestanden
- [ ] Deploy und POST /api/v1/exercises testen
- [ ] KI-Log Einträge mit use_case="exercise_enrichment" prüfen

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)