### PR TITLE
fix: init_db() korrigiert Nullability-Mismatches (#270)

### DIFF
--- a/backend/app/infrastructure/database/session.py
+++ b/backend/app/infrastructure/database/session.py
@@ -34,16 +34,16 @@ async def init_db():
 
 
 def _ensure_columns_exist(conn):
-    """Add missing columns to existing tables (lightweight auto-migration)."""
+    """Add missing columns and fix nullability mismatches (lightweight auto-migration)."""
     from app.infrastructure.database.models import Base
 
     inspector = sa_inspect(conn)
     for table_name, table in Base.metadata.tables.items():
         if not inspector.has_table(table_name):
             continue
-        existing_cols = {c["name"] for c in inspector.get_columns(table_name)}
+        db_cols = {c["name"]: c for c in inspector.get_columns(table_name)}
         for col in table.columns:
-            if col.name not in existing_cols:
+            if col.name not in db_cols:
                 col_type = col.type.compile(conn.engine.dialect)
 
                 # Include DEFAULT clause from server_default so NOT NULL
@@ -72,3 +72,10 @@ def _ensure_columns_exist(conn):
                 )
                 logger.info(f"Adding missing column: {table_name}.{col.name}")
                 conn.execute(text(sql))
+            else:
+                # Fix nullability mismatch: model says nullable but DB says NOT NULL
+                db_nullable = db_cols[col.name].get("nullable", True)
+                if col.nullable and not db_nullable:
+                    sql = f'ALTER TABLE "{table_name}" ALTER COLUMN "{col.name}" DROP NOT NULL'
+                    logger.info(f"Fixing nullability: {table_name}.{col.name} → nullable")
+                    conn.execute(text(sql))

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -13,12 +13,18 @@ for i in $(seq 1 30); do
   sleep 2
 done
 
+echo "Current Alembic version:"
+alembic current 2>&1 || echo "Could not determine Alembic version."
+
 echo "Running Alembic migrations..."
 if alembic upgrade head; then
   echo "Migrations completed successfully."
 else
   echo "WARNING: Alembic migrations failed (exit code $?). Starting app anyway."
 fi
+
+echo "Alembic version after migration:"
+alembic current 2>&1 || echo "Could not determine Alembic version."
 
 echo "Starting uvicorn..."
 exec uvicorn app.main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
- `_ensure_columns_exist()` prüft jetzt auch Nullability-Mismatches zwischen Model und DB
- Wenn Model nullable definiert, DB aber NOT NULL hat → `DROP NOT NULL` wird ausgeführt
- Entrypoint.sh loggt Alembic-Version vor/nach Migration für Diagnose

## Kontext
Alembic-Migrationen c030 und c031 haben `workout_id` in `ai_analysis_log` nicht auf nullable gesetzt (wahrscheinlich weil `_ensure_columns_exist()` die Spalten use_case/context_label vor Alembic hinzugefügt hat, was die Migration zum Scheitern brachte).

Dieser Fix macht `init_db()` robust gegen solche Situationen — unabhängig von Alembic wird die Nullability beim Start korrigiert.

## Test plan
- [x] Ruff + Mypy bestanden
- [x] 569 Tests bestanden
- [ ] Deploy → POST /api/v1/exercises gibt 201 zurück

🤖 Generated with [Claude Code](https://claude.com/claude-code)