### PR TITLE
feat: Recharts 2→3 Upgrade mit Tooltip-API Anpassung

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,7 +23,7 @@
         "react-dom": "^19.2.4",
         "react-is": "^19.2.4",
         "react-router-dom": "^7.13.1",
-        "recharts": "^2.10.0",
+        "recharts": "^3.8.0",
         "zod": "^4.3.6",
         "zustand": "^5.0.12"
       },
@@ -173,6 +173,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -801,12 +802,6 @@
         "react-dom": ">=18.0.0"
       }
     },
-    "node_modules/@nordlig/components/node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "license": "MIT"
-    },
     "node_modules/@nordlig/components/node_modules/lucide-react": {
       "version": "0.563.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.563.0.tgz",
@@ -814,58 +809,6 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@nordlig/components/node_modules/recharts": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
-      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
-      "license": "MIT",
-      "workspaces": [
-        "www"
-      ],
-      "dependencies": {
-        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
-        "clsx": "^2.1.1",
-        "decimal.js-light": "^2.5.1",
-        "es-toolkit": "^1.39.3",
-        "eventemitter3": "^5.0.1",
-        "immer": "^10.1.1",
-        "react-redux": "8.x.x || 9.x.x",
-        "reselect": "5.1.1",
-        "tiny-invariant": "^1.3.3",
-        "use-sync-external-store": "^1.2.2",
-        "victory-vendor": "^37.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@nordlig/components/node_modules/victory-vendor": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
-      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
-      "license": "MIT AND ISC",
-      "dependencies": {
-        "@types/d3-array": "^3.0.3",
-        "@types/d3-ease": "^3.0.0",
-        "@types/d3-interpolate": "^3.0.1",
-        "@types/d3-scale": "^4.0.2",
-        "@types/d3-shape": "^3.1.0",
-        "@types/d3-time": "^3.0.0",
-        "@types/d3-timer": "^3.0.0",
-        "d3-array": "^3.1.6",
-        "d3-ease": "^3.0.1",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-shape": "^3.1.0",
-        "d3-time": "^3.0.0",
-        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/@nordlig/styles": {
@@ -4753,16 +4696,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -5117,9 +5050,9 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
     "node_modules/expect-type": {
@@ -5687,7 +5620,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jsdom": {
       "version": "29.0.0",
@@ -6073,24 +6008,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "11.2.7",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
@@ -6289,15 +6206,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -6538,23 +6446,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
     },
     "node_modules/prosemirror-changeset": {
       "version": "2.4.0",
@@ -6937,21 +6828,6 @@
         "react-dom": ">=18"
       }
     },
-    "node_modules/react-smooth": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
-      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-equals": "^5.0.1",
-        "prop-types": "^15.8.1",
-        "react-transition-group": "^4.4.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -6974,59 +6850,35 @@
         }
       }
     },
-    "node_modules/react-transition-group": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0",
-        "react-dom": ">=16.6.0"
-      }
-    },
     "node_modules/recharts": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
-      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
+      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
       "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
       "dependencies": {
-        "clsx": "^2.0.0",
-        "eventemitter3": "^4.0.1",
-        "lodash": "^4.17.21",
-        "react-is": "^18.3.1",
-        "react-smooth": "^4.0.4",
-        "recharts-scale": "^0.4.4",
-        "tiny-invariant": "^1.3.1",
-        "victory-vendor": "^36.6.8"
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
-    },
-    "node_modules/recharts-scale": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
-      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
-      "license": "MIT",
-      "dependencies": {
-        "decimal.js-light": "^2.4.1"
-      }
-    },
-    "node_modules/recharts/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -7643,9 +7495,9 @@
       }
     },
     "node_modules/victory-vendor": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
-      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
       "license": "MIT AND ISC",
       "dependencies": {
         "@types/d3-array": "^3.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,7 @@
     "react-dom": "^19.2.4",
     "react-is": "^19.2.4",
     "react-router-dom": "^7.13.1",
-    "recharts": "^2.10.0",
+    "recharts": "^3.8.0",
     "zod": "^4.3.6",
     "zustand": "^5.0.12"
   },

--- a/frontend/src/components/analysis/CategoryTonnageChart.tsx
+++ b/frontend/src/components/analysis/CategoryTonnageChart.tsx
@@ -101,7 +101,7 @@ function AggregatedView({ data }: { data: CategoryTonnageTrendResponse }) {
           />
           <Tooltip
             contentStyle={TOOLTIP_STYLE}
-            formatter={(value: number) => [formatTonnage(value), 'Tonnage']}
+            formatter={(value) => [formatTonnage(Number(value)), 'Tonnage']}
           />
           <Bar dataKey="tonnage" radius={[0, 4, 4, 0]} isAnimationActive={false}>
             {chartData.map((entry, i) => (
@@ -155,7 +155,7 @@ function TrendView({ data }: { data: CategoryTonnageTrendResponse }) {
           />
           <Tooltip
             contentStyle={TOOLTIP_STYLE}
-            formatter={(value: number, name: string) => [formatTonnage(value), categoryLabel(name)]}
+            formatter={(value, name) => [formatTonnage(Number(value)), categoryLabel(String(name))]}
           />
           <Legend formatter={(value: string) => categoryLabel(value)} />
           {categories.map((cat) => (

--- a/frontend/src/pages/Analyse.tsx
+++ b/frontend/src/pages/Analyse.tsx
@@ -176,8 +176,8 @@ function RunningTrendsContent({ timeRange }: { timeRange: TimeRange }) {
                         borderRadius: 'var(--radius-component-sm)',
                         fontSize: '12px',
                       }}
-                      formatter={(value: number) => [formatPace(value), 'Ø Pace']}
-                      labelFormatter={(label: string) => `KW ${label}`}
+                      formatter={(value) => [formatPace(Number(value)), 'Ø Pace']}
+                      labelFormatter={(label) => `KW ${String(label)}`}
                     />
                     <Line
                       type="monotone"
@@ -223,8 +223,8 @@ function RunningTrendsContent({ timeRange }: { timeRange: TimeRange }) {
                         borderRadius: 'var(--radius-component-sm)',
                         fontSize: '12px',
                       }}
-                      formatter={(value: number) => [`${value} bpm`, 'Ø HF']}
-                      labelFormatter={(label: string) => `KW ${label}`}
+                      formatter={(value) => [`${Number(value)} bpm`, 'Ø HF']}
+                      labelFormatter={(label) => `KW ${String(label)}`}
                     />
                     <Line
                       type="monotone"
@@ -267,12 +267,14 @@ function RunningTrendsContent({ timeRange }: { timeRange: TimeRange }) {
                         borderRadius: 'var(--radius-component-sm)',
                         fontSize: '12px',
                       }}
-                      formatter={(value: number, name: string) => {
-                        if (name === 'total_distance_km') return [`${value} km`, 'Distanz'];
-                        if (name === 'total_duration_sec') return [formatDuration(value), 'Dauer'];
-                        return [value, name];
+                      formatter={(value, name) => {
+                        const v = Number(value);
+                        const n = String(name);
+                        if (n === 'total_distance_km') return [`${v} km`, 'Distanz'];
+                        if (n === 'total_duration_sec') return [formatDuration(v), 'Dauer'];
+                        return [v, n];
                       }}
-                      labelFormatter={(label: string) => `KW ${label}`}
+                      labelFormatter={(label) => `KW ${String(label)}`}
                     />
                     <Bar
                       dataKey="total_distance_km"

--- a/frontend/src/pages/StrengthProgression.tsx
+++ b/frontend/src/pages/StrengthProgression.tsx
@@ -111,7 +111,7 @@ interface ChartConfig {
   dataKey: string;
   secondaryDataKey?: string;
   yFormatter: (v: number) => string;
-  tooltipFormatter: (value: number, name: string) => [string, string];
+  tooltipFormatter: (value: number | string, name: string) => [string, string];
 }
 
 function getChartConfig(setType: string): ChartConfig {
@@ -121,7 +121,7 @@ function getChartConfig(setType: string): ChartConfig {
       icon: <Repeat className="w-4 h-4 text-[var(--color-chart-1)]" />,
       dataKey: 'total_reps',
       yFormatter: (v: number) => `${v}`,
-      tooltipFormatter: (value: number, name: string) => {
+      tooltipFormatter: (value, name) => {
         if (name === 'total_reps') return [`${value}`, 'Gesamt Wdh.'];
         return [`${value}`, name];
       },
@@ -133,8 +133,9 @@ function getChartConfig(setType: string): ChartConfig {
       icon: <Timer className="w-4 h-4 text-[var(--color-chart-1)]" />,
       dataKey: 'total_duration_sec',
       yFormatter: (v: number) => formatDurationShort(v),
-      tooltipFormatter: (value: number, name: string) => {
-        if (name === 'total_duration_sec') return [formatDurationShort(value), 'Gesamt Dauer'];
+      tooltipFormatter: (value, name) => {
+        if (name === 'total_duration_sec')
+          return [formatDurationShort(Number(value)), 'Gesamt Dauer'];
         return [`${value}`, name];
       },
     };
@@ -146,8 +147,9 @@ function getChartConfig(setType: string): ChartConfig {
       dataKey: 'total_distance_m',
       secondaryDataKey: isDurationType(setType) ? 'total_duration_sec' : undefined,
       yFormatter: (v: number) => formatDistanceShort(v),
-      tooltipFormatter: (value: number, name: string) => {
-        if (name === 'total_distance_m') return [formatDistanceShort(value), 'Gesamt Distanz'];
+      tooltipFormatter: (value, name) => {
+        if (name === 'total_distance_m')
+          return [formatDistanceShort(Number(value)), 'Gesamt Distanz'];
         return [`${value}`, name];
       },
     };
@@ -159,7 +161,7 @@ function getChartConfig(setType: string): ChartConfig {
     dataKey: 'max_weight_kg',
     secondaryDataKey: 'tonnage_kg',
     yFormatter: (v: number) => `${v}kg`,
-    tooltipFormatter: (value: number, name: string) => {
+    tooltipFormatter: (value, name) => {
       if (name === 'max_weight_kg') return [`${value} kg`, 'Max. Gewicht'];
       if (name === 'tonnage_kg') return [`${value} kg`, 'Tonnage'];
       return [`${value}`, name];
@@ -446,8 +448,10 @@ export function StrengthProgressionContent({ timeRange }: { timeRange?: TimeRang
                         borderRadius: '8px',
                         fontSize: '12px',
                       }}
-                      formatter={chartConfig.tooltipFormatter}
-                      labelFormatter={(label: string) => label}
+                      formatter={(value, name) =>
+                        chartConfig.tooltipFormatter(Number(value), String(name))
+                      }
+                      labelFormatter={(label) => String(label)}
                     />
                     <Line
                       type="monotone"
@@ -533,11 +537,14 @@ export function StrengthProgressionContent({ timeRange }: { timeRange?: TimeRang
                       borderRadius: '8px',
                       fontSize: '12px',
                     }}
-                    formatter={(value: number) => [
-                      value >= 1000 ? `${(value / 1000).toFixed(1)} t` : `${Math.round(value)} kg`,
-                      'Tonnage',
-                    ]}
-                    labelFormatter={(label: string) => `KW ${label}`}
+                    formatter={(value) => {
+                      const v = Number(value);
+                      return [
+                        v >= 1000 ? `${(v / 1000).toFixed(1)} t` : `${Math.round(v)} kg`,
+                        'Tonnage',
+                      ];
+                    }}
+                    labelFormatter={(label) => `KW ${String(label)}`}
                   />
                   <Bar
                     dataKey="total_tonnage_kg"

--- a/frontend/src/pages/TrainingBalance.tsx
+++ b/frontend/src/pages/TrainingBalance.tsx
@@ -247,8 +247,8 @@ export function TrainingBalanceContent({ days }: { days?: number }) {
                           border: '1px solid var(--color-border-default)',
                           background: 'var(--color-bg-base)',
                         }}
-                        formatter={(value: number) => {
-                          return [`${value.toFixed(1)} km`, 'Distanz'];
+                        formatter={(value) => {
+                          return [`${Number(value).toFixed(1)} km`, 'Distanz'];
                         }}
                       />
                       <Bar dataKey="km" radius={[4, 4, 0, 0]}>


### PR DESCRIPTION
## Summary

- Recharts 2.10→3.8.0 (Major-Upgrade)
- Tooltip Formatter-Signatur angepasst in 4 Dateien: `value` ist jetzt `ValueType | undefined`, `label` ist `ReactNode`
- Betroffene Dateien: `Analyse.tsx`, `CategoryTonnageChart.tsx`, `StrengthProgression.tsx`, `TrainingBalance.tsx`
- Fix-Pattern: `Number(value)` / `String(label)` Casts statt expliziter Typ-Annotationen

## Test plan

- [x] `npx tsc --noEmit` — 0 Fehler (vorher 13)
- [x] `npx eslint src/ --max-warnings 0` — bestanden
- [x] `npx prettier --check` — bestanden
- [x] `npx vitest --run` — 160 Tests grün
- [ ] CI-Pipeline grün

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)