### PR TITLE
feat: KI-Trainingsempfehlungen generieren (E06-S02)

### DIFF
--- a/backend/alembic/versions/c032_add_ai_recommendations.py
+++ b/backend/alembic/versions/c032_add_ai_recommendations.py
@@ -1,0 +1,42 @@
+"""add ai_recommendations table
+
+Revision ID: c032
+Revises: c031
+Create Date: 2026-03-17
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "c032"
+down_revision = "c031"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ai_recommendations",
+        sa.Column("id", sa.Integer, primary_key=True, index=True),
+        sa.Column(
+            "session_id",
+            sa.Integer,
+            sa.ForeignKey("workouts.id", ondelete="CASCADE"),
+            index=True,
+            nullable=False,
+        ),
+        sa.Column("type", sa.String(30), nullable=False),
+        sa.Column("title", sa.String(200), nullable=False),
+        sa.Column("target_session_id", sa.Integer, nullable=True),
+        sa.Column("current_value", sa.String(100), nullable=True),
+        sa.Column("suggested_value", sa.String(100), nullable=True),
+        sa.Column("reasoning", sa.Text, nullable=False),
+        sa.Column("priority", sa.String(10), nullable=False),
+        sa.Column("status", sa.String(20), server_default="pending", nullable=False),
+        sa.Column("provider", sa.String(100), nullable=False),
+        sa.Column("created_at", sa.DateTime, server_default=sa.func.now(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("ai_recommendations")

--- a/backend/app/api/v1/sessions.py
+++ b/backend/app/api/v1/sessions.py
@@ -17,6 +17,11 @@ from app.infrastructure.database.models import (
 )
 from app.infrastructure.database.session import get_db
 from app.models.ai_analysis import AnalyzeRequest, SessionAnalysisResponse
+from app.models.ai_recommendation import (
+    RecommendationResponse,
+    RecommendationsListResponse,
+    RecommendationStatusUpdate,
+)
 from app.models.segment import ComparisonResponse, laps_to_segments
 from app.models.session import (
     DateUpdateRequest,
@@ -834,6 +839,59 @@ async def analyze_session(
         raise HTTPException(status_code=404, detail=str(e)) from e
     except Exception as e:
         raise HTTPException(status_code=502, detail=f"AI-Analyse fehlgeschlagen: {e}") from e
+
+
+# --- KI-Empfehlungen (E06-S02) ---
+
+
+@router.post("/{session_id}/recommendations", response_model=RecommendationsListResponse)
+async def generate_recommendations(
+    session_id: int,
+    body: Optional[AnalyzeRequest] = None,
+    db: AsyncSession = Depends(get_db),
+) -> RecommendationsListResponse:
+    """Generiert KI-gestuetzte Trainingsempfehlungen basierend auf Session-Analyse."""
+    from app.services.recommendation_service import (
+        generate_recommendations as run_recommendations,
+    )
+
+    force = body.force_refresh if body else False
+    try:
+        return await run_recommendations(session_id, db, force_refresh=force)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except Exception as e:
+        raise HTTPException(
+            status_code=502, detail=f"Empfehlungsgenerierung fehlgeschlagen: {e}"
+        ) from e
+
+
+@router.get("/{session_id}/recommendations", response_model=RecommendationsListResponse)
+async def get_session_recommendations(
+    session_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> RecommendationsListResponse:
+    """Laedt gespeicherte Empfehlungen fuer eine Session."""
+    from app.services.recommendation_service import get_recommendations
+
+    return await get_recommendations(session_id, db)
+
+
+@router.patch("/recommendations/{recommendation_id}/status", response_model=RecommendationResponse)
+async def update_recommendation_status(
+    recommendation_id: int,
+    body: RecommendationStatusUpdate,
+    db: AsyncSession = Depends(get_db),
+) -> RecommendationResponse:
+    """Aktualisiert den Status einer Empfehlung (applied/dismissed)."""
+    from app.services.recommendation_service import (
+        update_recommendation_status as update_status,
+    )
+
+    try:
+        return await update_status(recommendation_id, body.status, db)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
 
 
 @router.post("/{session_id}/recalculate-zones")

--- a/backend/app/infrastructure/database/models.py
+++ b/backend/app/infrastructure/database/models.py
@@ -263,3 +263,25 @@ class PlanChangeLogModel(Base):
     reason: Mapped[str | None] = mapped_column(Text, default=None)
     created_by: Mapped[str | None] = mapped_column(String(50), default=None)  # future: user auth
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+class AIRecommendationModel(Base):
+    __tablename__ = "ai_recommendations"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    session_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("workouts.id", ondelete="CASCADE"), index=True
+    )
+    type: Mapped[str] = mapped_column(String(30))  # RecommendationType
+    title: Mapped[str] = mapped_column(String(200))
+    target_session_id: Mapped[int | None] = mapped_column(
+        Integer, default=None
+    )  # FK planned_sessions
+    current_value: Mapped[str | None] = mapped_column(String(100), default=None)
+    suggested_value: Mapped[str | None] = mapped_column(String(100), default=None)
+    reasoning: Mapped[str] = mapped_column(Text)
+    priority: Mapped[str] = mapped_column(String(10))  # high/medium/low
+    status: Mapped[str] = mapped_column(String(20), server_default="pending")
+    provider: Mapped[str] = mapped_column(String(100))
+
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())

--- a/backend/app/models/ai_recommendation.py
+++ b/backend/app/models/ai_recommendation.py
@@ -1,0 +1,66 @@
+"""Pydantic Models für KI-Trainingsempfehlungen (E06-S02)."""
+
+from enum import Enum
+
+from pydantic import BaseModel
+
+
+class RecommendationType(str, Enum):
+    """Typ der Empfehlung — bestimmt welche Aktion vorgeschlagen wird."""
+
+    ADJUST_PACE = "adjust_pace"
+    ADJUST_VOLUME = "adjust_volume"
+    ADD_REST = "add_rest"
+    SKIP_SESSION = "skip_session"
+    INCREASE_VOLUME = "increase_volume"
+    REDUCE_INTENSITY = "reduce_intensity"
+    CHANGE_SESSION_TYPE = "change_session_type"
+    EXTEND_WARMUP_COOLDOWN = "extend_warmup_cooldown"
+    GENERAL = "general"
+
+
+class RecommendationPriority(str, Enum):
+    """Prioritaet der Empfehlung."""
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class RecommendationStatus(str, Enum):
+    """Status einer Empfehlung."""
+
+    PENDING = "pending"
+    APPLIED = "applied"
+    DISMISSED = "dismissed"
+
+
+class RecommendationResponse(BaseModel):
+    """Einzelne Empfehlung — Response."""
+
+    id: int
+    session_id: int
+    type: RecommendationType
+    title: str
+    target_session_id: int | None = None
+    current_value: str | None = None
+    suggested_value: str | None = None
+    reasoning: str
+    priority: RecommendationPriority
+    status: RecommendationStatus = RecommendationStatus.PENDING
+    created_at: str
+
+
+class RecommendationsListResponse(BaseModel):
+    """Liste von Empfehlungen fuer eine Session."""
+
+    recommendations: list[RecommendationResponse]
+    session_id: int
+    provider: str
+    cached: bool = False
+
+
+class RecommendationStatusUpdate(BaseModel):
+    """Request zum Aendern des Empfehlungs-Status."""
+
+    status: RecommendationStatus

--- a/backend/app/services/recommendation_service.py
+++ b/backend/app/services/recommendation_service.py
@@ -1,0 +1,678 @@
+"""KI-Trainingsempfehlungen Service (E06-S02).
+
+Generiert strukturierte Empfehlungen basierend auf der Session-Analyse
+und dem Trainingsplan-Kontext. Nutzt die bereits gecachte Analyse aus
+E06-S01 als Input.
+"""
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.api_key_resolver import resolve_claude_api_key
+from app.infrastructure.ai.ai_service import ai_service
+from app.infrastructure.database.models import (
+    AIRecommendationModel,
+    PlannedSessionModel,
+    RaceGoalModel,
+    TrainingPhaseModel,
+    TrainingPlanModel,
+    WeeklyPlanDayModel,
+    WorkoutModel,
+)
+from app.models.ai_recommendation import (
+    RecommendationPriority,
+    RecommendationResponse,
+    RecommendationsListResponse,
+    RecommendationStatus,
+    RecommendationType,
+)
+from app.services.ai_log_service import AICallData, log_ai_call
+from app.services.session_analysis_service import analyze_session
+
+logger = logging.getLogger(__name__)
+
+VALID_TYPES = {t.value for t in RecommendationType}
+VALID_PRIORITIES = {p.value for p in RecommendationPriority}
+
+
+@dataclass
+class RecommendationContext:
+    """Kontext fuer die Empfehlungsgenerierung."""
+
+    analysis_summary: str
+    intensity_rating: str
+    fatigue_indicators: str | None
+    plan_comparison: str | None
+    analysis_recommendations: list[str]
+    race_goal: dict | None
+    current_phase: dict | None
+    upcoming_sessions: list[dict]
+    weekly_volume: dict
+    recent_recommendations: list[dict]
+
+
+async def generate_recommendations(
+    session_id: int,
+    db: AsyncSession,
+    *,
+    force_refresh: bool = False,
+) -> RecommendationsListResponse:
+    """Generiert KI-Empfehlungen fuer eine Session (Cache-First)."""
+    workout = await _load_workout(session_id, db)
+
+    # Cache: bestehende pending Empfehlungen zurueckgeben
+    if not force_refresh:
+        cached = await _load_cached_recommendations(session_id, db)
+        if cached:
+            return _build_response(cached, session_id, cached[0].provider, is_cached=True)
+
+    # Session-Analyse sicherstellen (Voraussetzung)
+    analysis = await _ensure_analysis(session_id, db)
+
+    # Kontext laden
+    context = await _load_recommendation_context(workout, analysis, db)
+
+    # Prompt bauen und AI aufrufen
+    prompt = _build_recommendation_prompt(context)
+    system_prompt = _build_system_prompt(context)
+    api_key = await resolve_claude_api_key(db)
+
+    t0 = time.monotonic()
+    raw = await ai_service.chat(prompt, {"system_prompt": system_prompt}, api_key)
+    duration_ms = int((time.monotonic() - t0) * 1000)
+    provider = ai_service.get_active_provider() or "unknown"
+
+    # Parsen
+    parsed = _parse_recommendations_json(raw)
+
+    # Alte pending Empfehlungen loeschen, neue speichern
+    await _delete_pending(session_id, db)
+    models = await _save_recommendations(session_id, parsed, provider, db)
+
+    # Log schreiben
+    parsed_ok = len(parsed) > 0
+    await log_ai_call(
+        db,
+        AICallData(
+            use_case="recommendations",
+            provider=provider,
+            system_prompt=system_prompt,
+            user_prompt=prompt,
+            raw_response=raw,
+            parsed_ok=parsed_ok,
+            duration_ms=duration_ms,
+            workout_id=session_id,
+        ),
+    )
+    await db.commit()
+
+    return _build_response(models, session_id, provider, is_cached=False)
+
+
+async def get_recommendations(
+    session_id: int,
+    db: AsyncSession,
+) -> RecommendationsListResponse:
+    """Laedt gespeicherte Empfehlungen fuer eine Session."""
+    models = await _load_all_recommendations(session_id, db)
+    provider = models[0].provider if models else "none"
+    return _build_response(models, session_id, provider, is_cached=True)
+
+
+async def update_recommendation_status(
+    recommendation_id: int,
+    new_status: RecommendationStatus,
+    db: AsyncSession,
+) -> RecommendationResponse:
+    """Aktualisiert den Status einer Empfehlung."""
+    result = await db.execute(
+        select(AIRecommendationModel).where(AIRecommendationModel.id == recommendation_id)
+    )
+    model = result.scalar_one_or_none()
+    if not model:
+        raise ValueError(f"Empfehlung {recommendation_id} nicht gefunden")
+
+    model.status = new_status.value
+    await db.commit()
+    await db.refresh(model)
+    return _model_to_response(model)
+
+
+# ---------------------------------------------------------------------------
+# Interne Hilfsfunktionen
+# ---------------------------------------------------------------------------
+
+
+async def _load_workout(session_id: int, db: AsyncSession) -> WorkoutModel:
+    """Laedt Workout oder wirft ValueError."""
+    result = await db.execute(select(WorkoutModel).where(WorkoutModel.id == session_id))
+    workout = result.scalar_one_or_none()
+    if not workout:
+        raise ValueError(f"Session {session_id} nicht gefunden")
+    return workout
+
+
+async def _ensure_analysis(session_id: int, db: AsyncSession) -> dict:
+    """Stellt sicher, dass eine Session-Analyse existiert."""
+    result = await db.execute(select(WorkoutModel).where(WorkoutModel.id == session_id))
+    workout = result.scalar_one_or_none()
+    if not workout:
+        raise ValueError(f"Session {session_id} nicht gefunden")
+
+    if workout.ai_analysis:
+        try:
+            return json.loads(workout.ai_analysis)
+        except json.JSONDecodeError:
+            pass
+
+    # Analyse noch nicht vorhanden — jetzt ausfuehren
+    analysis_response = await analyze_session(session_id, db)
+    return analysis_response.model_dump()
+
+
+async def _load_cached_recommendations(
+    session_id: int,
+    db: AsyncSession,
+) -> list[AIRecommendationModel]:
+    """Laedt alle pending Empfehlungen fuer eine Session."""
+    result = await db.execute(
+        select(AIRecommendationModel)
+        .where(
+            AIRecommendationModel.session_id == session_id,
+            AIRecommendationModel.status == "pending",
+        )
+        .order_by(AIRecommendationModel.priority.desc(), AIRecommendationModel.id)
+    )
+    return list(result.scalars().all())
+
+
+async def _load_all_recommendations(
+    session_id: int,
+    db: AsyncSession,
+) -> list[AIRecommendationModel]:
+    """Laedt alle Empfehlungen fuer eine Session (alle Status)."""
+    result = await db.execute(
+        select(AIRecommendationModel)
+        .where(AIRecommendationModel.session_id == session_id)
+        .order_by(AIRecommendationModel.created_at.desc())
+    )
+    return list(result.scalars().all())
+
+
+async def _delete_pending(session_id: int, db: AsyncSession) -> None:
+    """Loescht alle pending Empfehlungen fuer eine Session."""
+    await db.execute(
+        delete(AIRecommendationModel).where(
+            AIRecommendationModel.session_id == session_id,
+            AIRecommendationModel.status == "pending",
+        )
+    )
+
+
+async def _save_recommendations(
+    session_id: int,
+    parsed: list[dict],
+    provider: str,
+    db: AsyncSession,
+) -> list[AIRecommendationModel]:
+    """Speichert geparste Empfehlungen in der DB."""
+    models = []
+    for rec in parsed:
+        model = AIRecommendationModel(
+            session_id=session_id,
+            type=rec["type"],
+            title=rec["title"][:200],
+            target_session_id=rec.get("target_session_id"),
+            current_value=rec.get("current_value"),
+            suggested_value=rec.get("suggested_value"),
+            reasoning=rec["reasoning"],
+            priority=rec["priority"],
+            status="pending",
+            provider=provider,
+        )
+        db.add(model)
+        models.append(model)
+
+    await db.flush()
+    for m in models:
+        await db.refresh(m)
+    return models
+
+
+async def _load_recommendation_context(
+    workout: WorkoutModel,
+    analysis: dict,
+    db: AsyncSession,
+) -> RecommendationContext:
+    """Laedt den vollstaendigen Kontext fuer die Empfehlungsgenerierung."""
+    workout_date = workout.date.date() if isinstance(workout.date, datetime) else workout.date
+
+    # Aktives Wettkampfziel
+    goal_result = await db.execute(
+        select(RaceGoalModel).where(RaceGoalModel.is_active.is_(True)).limit(1)
+    )
+    goal_model = goal_result.scalar_one_or_none()
+    race_goal = _goal_to_dict(goal_model) if goal_model else None
+
+    # Aktuelle Trainingsphase
+    current_phase = await _load_current_phase(workout_date, db)
+
+    # Naechste 7 Tage geplante Sessions
+    upcoming = await _load_upcoming_sessions(workout_date, db)
+
+    # Wochenvolumen
+    weekly_volume = await _load_weekly_volume(workout_date, db)
+
+    # Letzte 10 Empfehlungen (Duplikat-Vermeidung)
+    recent = await _load_recent_recommendations(db)
+
+    return RecommendationContext(
+        analysis_summary=analysis.get("summary", ""),
+        intensity_rating=analysis.get("intensity_rating", "moderat"),
+        fatigue_indicators=analysis.get("fatigue_indicators"),
+        plan_comparison=analysis.get("plan_comparison"),
+        analysis_recommendations=analysis.get("recommendations", []),
+        race_goal=race_goal,
+        current_phase=current_phase,
+        upcoming_sessions=upcoming,
+        weekly_volume=weekly_volume,
+        recent_recommendations=recent,
+    )
+
+
+def _goal_to_dict(g: RaceGoalModel) -> dict:
+    """RaceGoal in Dict."""
+    target_pace = None
+    if g.target_time_seconds and g.distance_km and g.distance_km > 0:
+        pace_min = (g.target_time_seconds / 60) / g.distance_km
+        m = int(pace_min)
+        s = int((pace_min - m) * 60)
+        target_pace = f"{m}:{s:02d}"
+
+    return {
+        "title": g.title,
+        "date": str(g.race_date.date() if isinstance(g.race_date, datetime) else g.race_date),
+        "distance_km": g.distance_km,
+        "target_pace": target_pace,
+    }
+
+
+async def _load_current_phase(
+    ref_date: object,
+    db: AsyncSession,
+) -> dict | None:
+    """Laedt die aktuelle Trainingsphase basierend auf dem Datum."""
+    # Aktiven Plan finden
+    plan_result = await db.execute(
+        select(TrainingPlanModel)
+        .where(TrainingPlanModel.status == "active")
+        .order_by(TrainingPlanModel.start_date.desc())
+        .limit(1)
+    )
+    plan = plan_result.scalar_one_or_none()
+    if not plan:
+        return None
+
+    # Aktuelle Woche im Plan berechnen
+    days_since_start = (ref_date - plan.start_date).days  # type: ignore[operator]
+    current_week = (days_since_start // 7) + 1
+
+    # Phase finden
+    phase_result = await db.execute(
+        select(TrainingPhaseModel)
+        .where(
+            TrainingPhaseModel.training_plan_id == plan.id,
+            TrainingPhaseModel.start_week <= current_week,
+            TrainingPhaseModel.end_week >= current_week,
+        )
+        .limit(1)
+    )
+    phase = phase_result.scalar_one_or_none()
+    if not phase:
+        return {"plan_name": plan.name, "week": current_week}
+
+    return {
+        "plan_name": plan.name,
+        "phase_name": phase.name,
+        "phase_type": phase.phase_type,
+        "week": current_week,
+    }
+
+
+async def _load_upcoming_sessions(
+    ref_date: date,
+    db: AsyncSession,
+) -> list[dict]:
+    """Laedt geplante Sessions der naechsten 7 Tage."""
+    next_week = ref_date + timedelta(days=7)
+
+    day_result = await db.execute(
+        select(WeeklyPlanDayModel)
+        .where(
+            WeeklyPlanDayModel.week_start >= ref_date,
+            WeeklyPlanDayModel.week_start <= next_week,
+        )
+        .order_by(WeeklyPlanDayModel.week_start, WeeklyPlanDayModel.day_of_week)
+    )
+    days = day_result.scalars().all()
+
+    upcoming = []
+    for day in days:
+        session_date = day.week_start + timedelta(days=day.day_of_week)
+
+        if day.is_rest_day:
+            upcoming.append({"date": str(session_date), "type": "Ruhetag"})
+            continue
+
+        # Geplante Sessions fuer diesen Tag laden
+        ps_result = await db.execute(
+            select(PlannedSessionModel)
+            .where(PlannedSessionModel.day_id == day.id)
+            .order_by(PlannedSessionModel.position)
+        )
+        for ps in ps_result.scalars().all():
+            entry: dict = {
+                "date": str(session_date),
+                "id": ps.id,
+                "type": ps.training_type,
+            }
+            if ps.run_details_json:
+                try:
+                    rd = json.loads(str(ps.run_details_json))
+                    entry["run_type"] = rd.get("run_type")
+                    entry["target_duration_min"] = rd.get("target_duration_minutes")
+                    entry["target_pace"] = rd.get("target_pace_min")
+                except json.JSONDecodeError:
+                    pass
+            upcoming.append(entry)
+
+    return upcoming[:10]
+
+
+async def _load_weekly_volume(ref_date: date, db: AsyncSession) -> dict:
+    """Berechnet das Wochenvolumen (aktuelle Woche)."""
+    # Montag der aktuellen Woche
+    weekday = ref_date.weekday()
+    week_start = ref_date - timedelta(days=weekday)
+    week_end = week_start + timedelta(days=6)
+
+    result = await db.execute(
+        select(WorkoutModel).where(
+            WorkoutModel.date >= datetime.combine(week_start, datetime.min.time()),
+            WorkoutModel.date <= datetime.combine(week_end, datetime.max.time()),
+        )
+    )
+    workouts = result.scalars().all()
+
+    total_km = sum(w.distance_km or 0 for w in workouts)
+    total_min = sum((w.duration_sec or 0) / 60 for w in workouts)
+    run_count = sum(1 for w in workouts if w.workout_type == "running")
+    strength_count = sum(1 for w in workouts if w.workout_type == "strength")
+
+    return {
+        "total_km": round(total_km, 1),
+        "total_hours": round(total_min / 60, 1),
+        "session_count": len(workouts),
+        "run_count": run_count,
+        "strength_count": strength_count,
+    }
+
+
+async def _load_recent_recommendations(db: AsyncSession) -> list[dict]:
+    """Laedt die letzten 10 Empfehlungen (alle Sessions)."""
+    result = await db.execute(
+        select(AIRecommendationModel).order_by(AIRecommendationModel.created_at.desc()).limit(10)
+    )
+    return [{"type": r.type, "title": r.title, "status": r.status} for r in result.scalars().all()]
+
+
+# ---------------------------------------------------------------------------
+# Prompt-Builder
+# ---------------------------------------------------------------------------
+
+
+def _build_system_prompt(ctx: RecommendationContext) -> str:
+    """System-Prompt fuer Empfehlungsgenerierung."""
+    parts = [
+        "Du bist ein erfahrener Lauf- und Krafttrainer.",
+        "Deine Aufgabe: Generiere konkrete, umsetzbare Trainingsempfehlungen.",
+        "",
+        "Regeln:",
+        "- Priorisiere Gesundheit vor Performance",
+        "- Achte auf Uebertraining-Signale",
+        "- Empfehlungen muessen spezifisch und actionable sein",
+        "- Beruecksichtige die Trainingsphase und das Wettkampfziel",
+        "- Vermeide generische Ratschlaege",
+    ]
+
+    if ctx.race_goal:
+        g = ctx.race_goal
+        parts.append("")
+        parts.append(f"Wettkampfziel: {g['title']} ({g['distance_km']} km)")
+        if g.get("target_pace"):
+            parts.append(f"Zielpace: {g['target_pace']} min/km")
+        if g.get("date"):
+            parts.append(f"Wettkampf am: {g['date']}")
+
+    if ctx.current_phase:
+        p = ctx.current_phase
+        parts.append("")
+        parts.append(f"Trainingsplan: {p.get('plan_name', '?')}")
+        if p.get("phase_name"):
+            parts.append(f"Phase: {p['phase_name']} ({p.get('phase_type', '?')})")
+        parts.append(f"Woche: {p.get('week', '?')}")
+
+    return "\n".join(parts)
+
+
+def _build_recommendation_prompt(ctx: RecommendationContext) -> str:
+    """User-Prompt fuer Empfehlungsgenerierung."""
+    parts: list[str] = []
+
+    # Session-Analyse (bereits durchgefuehrt)
+    parts.append("## Session-Analyse (bereits durchgefuehrt)")
+    parts.append(f"- Zusammenfassung: {ctx.analysis_summary}")
+    parts.append(f"- Intensitaet: {ctx.intensity_rating}")
+    if ctx.fatigue_indicators:
+        parts.append(f"- Ermuedungssignale: {ctx.fatigue_indicators}")
+    if ctx.plan_comparison:
+        parts.append(f"- Soll/Ist: {ctx.plan_comparison}")
+    if ctx.analysis_recommendations:
+        parts.append("- Bisherige Kurzempfehlungen:")
+        for rec in ctx.analysis_recommendations:
+            parts.append(f"  - {rec}")
+
+    # Wochenvolumen
+    parts.append("")
+    parts.append("## Wochenvolumen (aktuelle Woche)")
+    wv = ctx.weekly_volume
+    parts.append(
+        f"- Sessions: {wv['session_count']} ({wv['run_count']} Lauf, {wv['strength_count']} Kraft)"
+    )
+    parts.append(f"- Distanz: {wv['total_km']} km")
+    parts.append(f"- Dauer: {wv['total_hours']} Stunden")
+
+    # Geplante Sessions
+    if ctx.upcoming_sessions:
+        parts.append("")
+        parts.append("## Geplante Sessions (naechste 7 Tage)")
+        for s in ctx.upcoming_sessions:
+            label = s.get("run_type") or s["type"]
+            dur = f", {s['target_duration_min']}min" if s.get("target_duration_min") else ""
+            pace = f", Pace {s['target_pace']}" if s.get("target_pace") else ""
+            parts.append(f"- {s['date']}: {label}{dur}{pace}")
+
+    # Bereits gegebene Empfehlungen (Duplikat-Vermeidung)
+    if ctx.recent_recommendations:
+        parts.append("")
+        parts.append("## Bereits gegebene Empfehlungen (nicht wiederholen)")
+        for r in ctx.recent_recommendations:
+            parts.append(f"- [{r['type']}] {r['title']} (Status: {r['status']})")
+
+    # Anweisungen
+    parts.append("")
+    parts.append(_build_instructions())
+
+    return "\n".join(parts)
+
+
+def _build_instructions() -> str:
+    """Anweisungen fuer die KI."""
+    valid_types = ", ".join(sorted(VALID_TYPES))
+    return f"""## Anweisungen
+Generiere 2-5 konkrete Trainingsempfehlungen. Antworte NUR mit einem JSON-Array (ohne Markdown-Codeblock):
+
+[
+  {{
+    "type": "EMPFEHLUNG_TYP",
+    "title": "Kurzer Titel (max 60 Zeichen)",
+    "current_value": "Aktueller Wert oder null",
+    "suggested_value": "Vorgeschlagener Wert oder null",
+    "reasoning": "1-3 Saetze Begruendung warum diese Aenderung sinnvoll ist",
+    "priority": "high|medium|low"
+  }}
+]
+
+Gueltige Typen: {valid_types}
+
+Regeln:
+- Auf Deutsch antworten
+- 2-5 Empfehlungen, sortiert nach Prioritaet (high zuerst)
+- Jede Empfehlung muss spezifisch und umsetzbar sein
+- current_value/suggested_value: konkrete Werte wenn moeglich (z.B. "5:20 min/km" -> "5:40 min/km")
+- Bei add_rest: current_value = geplante Session, suggested_value = "Ruhetag"
+- Bei skip_session: current_value = geplante Session, suggested_value = "Ueberspringen"
+- Keine generischen Empfehlungen wie "Hoer auf deinen Koerper"
+- NICHT die bereits gegebenen Empfehlungen wiederholen"""
+
+
+# ---------------------------------------------------------------------------
+# JSON-Parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_recommendations_json(raw: str) -> list[dict]:
+    """Parst die AI-Antwort als JSON-Array von Empfehlungen."""
+    text = raw.strip()
+
+    # Provider-Prefix entfernen
+    if text.startswith("[") and "]" in text and not text.startswith("[["):
+        # Koennte ein JSON-Array sein, versuche direkt zu parsen
+        pass
+    elif text.startswith("[") and "]" in text:
+        bracket_idx = text.index("]")
+        remaining = text[bracket_idx + 1 :].strip()
+        if remaining.startswith("["):
+            text = remaining
+
+    # Provider-Tag am Anfang: "[Claude (...)] [...]"
+    if text.startswith("[") and not text.startswith("[["):
+        try:
+            json.loads(text)
+        except json.JSONDecodeError:
+            # Wahrscheinlich Provider-Tag
+            close_bracket = text.index("]")
+            text = text[close_bracket + 1 :].strip()
+
+    # Markdown-Codeblock entfernen
+    if text.startswith("```"):
+        lines = text.split("\n")
+        text = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        logger.warning("Empfehlungen konnten nicht geparst werden: %s", text[:200])
+        return [_fallback_recommendation()]
+
+    if not isinstance(data, list):
+        data = [data]
+
+    results = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        results.append(_normalize_recommendation(item))
+
+    return results if results else [_fallback_recommendation()]
+
+
+def _normalize_recommendation(item: dict) -> dict:
+    """Normalisiert eine einzelne Empfehlung."""
+    rec_type = str(item.get("type", "general")).lower()
+    if rec_type not in VALID_TYPES:
+        rec_type = "general"
+
+    priority = str(item.get("priority", "medium")).lower()
+    if priority not in VALID_PRIORITIES:
+        priority = "medium"
+
+    return {
+        "type": rec_type,
+        "title": str(item.get("title", "Trainingsempfehlung"))[:200],
+        "current_value": item.get("current_value"),
+        "suggested_value": item.get("suggested_value"),
+        "reasoning": str(item.get("reasoning", "Keine Begruendung verfuegbar.")),
+        "priority": priority,
+    }
+
+
+def _fallback_recommendation() -> dict:
+    """Erstellt eine Fallback-Empfehlung bei Parse-Fehler."""
+    return {
+        "type": "general",
+        "title": "Analyse erneut durchfuehren",
+        "current_value": None,
+        "suggested_value": None,
+        "reasoning": "Die KI-Antwort konnte nicht strukturiert verarbeitet werden. "
+        "Bitte versuche es erneut.",
+        "priority": "low",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Response-Builder
+# ---------------------------------------------------------------------------
+
+
+def _model_to_response(m: AIRecommendationModel) -> RecommendationResponse:
+    """Konvertiert DB-Model in Response."""
+    return RecommendationResponse(
+        id=m.id,
+        session_id=m.session_id,
+        type=RecommendationType(m.type),
+        title=m.title,
+        target_session_id=m.target_session_id,
+        current_value=m.current_value,
+        suggested_value=m.suggested_value,
+        reasoning=m.reasoning,
+        priority=RecommendationPriority(m.priority),
+        status=RecommendationStatus(m.status),
+        created_at=m.created_at.isoformat() if m.created_at else "",
+    )
+
+
+def _build_response(
+    models: list[AIRecommendationModel],
+    session_id: int,
+    provider: str,
+    *,
+    is_cached: bool,
+) -> RecommendationsListResponse:
+    """Baut die API-Response."""
+    # Sortierung: high > medium > low
+    priority_order = {"high": 0, "medium": 1, "low": 2}
+    sorted_models = sorted(models, key=lambda m: priority_order.get(m.priority, 9))
+
+    return RecommendationsListResponse(
+        recommendations=[_model_to_response(m) for m in sorted_models],
+        session_id=session_id,
+        provider=provider,
+        cached=is_cached,
+    )

--- a/backend/app/tests/test_recommendations.py
+++ b/backend/app/tests/test_recommendations.py
@@ -1,0 +1,366 @@
+"""Tests fuer KI-Trainingsempfehlungen (E06-S02, Issue #33)."""
+
+import json
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.infrastructure.database.models import WorkoutModel
+from app.services.recommendation_service import (
+    RecommendationContext,
+    _build_recommendation_prompt,
+    _normalize_recommendation,
+    _parse_recommendations_json,
+)
+
+MOCK_ANALYSIS = {
+    "summary": "Gutes moderates Lauftraining im GA1-Bereich.",
+    "intensity_rating": "moderat",
+    "intensity_text": "HF und Pace passen zum Easy Run.",
+    "hr_zone_assessment": "80% in Zone 2.",
+    "plan_comparison": None,
+    "fatigue_indicators": None,
+    "recommendations": ["Pace beibehalten", "Long Run einplanen"],
+    "cached": True,
+    "session_id": 1,
+    "provider": "Claude (test)",
+}
+
+MOCK_RECOMMENDATIONS_RESPONSE = json.dumps(
+    [
+        {
+            "type": "adjust_pace",
+            "title": "Long Run Tempo reduzieren",
+            "current_value": "5:20 min/km",
+            "suggested_value": "5:40 min/km",
+            "reasoning": "Die HF war im oberen Zone-2-Bereich. "
+            "Fuer den Long Run sollte das Tempo etwas langsamer sein.",
+            "priority": "high",
+        },
+        {
+            "type": "add_rest",
+            "title": "Ruhetag nach intensiver Woche",
+            "current_value": "Tempo-Lauf geplant",
+            "suggested_value": "Ruhetag",
+            "reasoning": "Die Woche hat bereits 5 Sessions. "
+            "Ein Ruhetag hilft bei der Regeneration.",
+            "priority": "medium",
+        },
+        {
+            "type": "general",
+            "title": "Dehnroutine nach dem Lauf",
+            "current_value": None,
+            "suggested_value": "10min Dehnen",
+            "reasoning": "Regelmaessiges Dehnen verbessert die Beweglichkeit.",
+            "priority": "low",
+        },
+    ]
+)
+
+
+async def _create_test_workout(
+    db: AsyncSession,
+    *,
+    with_analysis: bool = False,
+) -> WorkoutModel:
+    """Erstellt ein Test-Workout in der DB."""
+    workout = WorkoutModel(
+        date=datetime(2026, 3, 10, 8, 0),
+        workout_type="running",
+        duration_sec=3600,
+        distance_km=10.5,
+        pace="5:43",
+        hr_avg=145,
+        hr_max=162,
+        hr_min=120,
+    )
+    if with_analysis:
+        workout.ai_analysis = json.dumps(MOCK_ANALYSIS)
+    db.add(workout)
+    await db.commit()
+    await db.refresh(workout)
+    return workout
+
+
+class TestRecommendationsAPI:
+    """Integration-Tests fuer POST/GET /sessions/{id}/recommendations."""
+
+    @patch("app.services.recommendation_service.ai_service")
+    @patch("app.services.session_analysis_service.ai_service")
+    async def test_generate_returns_structured_recommendations(
+        self,
+        mock_analysis_ai: AsyncMock,
+        mock_rec_ai: AsyncMock,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        """POST liefert strukturierte Empfehlungen."""
+        workout = await _create_test_workout(db_session, with_analysis=True)
+        mock_rec_ai.chat = AsyncMock(return_value=MOCK_RECOMMENDATIONS_RESPONSE)
+        mock_rec_ai.get_active_provider.return_value = "Claude (test)"
+
+        response = await client.post(f"/api/v1/sessions/{workout.id}/recommendations")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["session_id"] == workout.id
+        assert data["cached"] is False
+        assert len(data["recommendations"]) == 3
+
+        # Erste Empfehlung (high priority)
+        rec = data["recommendations"][0]
+        assert rec["type"] == "adjust_pace"
+        assert rec["priority"] == "high"
+        assert rec["status"] == "pending"
+        assert rec["current_value"] == "5:20 min/km"
+        assert rec["suggested_value"] == "5:40 min/km"
+        assert rec["id"] > 0
+
+    @patch("app.services.recommendation_service.ai_service")
+    @patch("app.services.session_analysis_service.ai_service")
+    async def test_cached_recommendations_no_ai_call(
+        self,
+        mock_analysis_ai: AsyncMock,
+        mock_rec_ai: AsyncMock,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        """Zweiter Aufruf liefert gecachte Empfehlungen ohne AI-Call."""
+        workout = await _create_test_workout(db_session, with_analysis=True)
+        mock_rec_ai.chat = AsyncMock(return_value=MOCK_RECOMMENDATIONS_RESPONSE)
+        mock_rec_ai.get_active_provider.return_value = "Claude (test)"
+
+        # Erster Aufruf — AI wird gerufen
+        await client.post(f"/api/v1/sessions/{workout.id}/recommendations")
+        assert mock_rec_ai.chat.call_count == 1
+
+        # Zweiter Aufruf — Cache
+        response = await client.post(f"/api/v1/sessions/{workout.id}/recommendations")
+        assert response.status_code == 200
+        assert response.json()["cached"] is True
+        assert mock_rec_ai.chat.call_count == 1  # Kein erneuter Aufruf
+
+    @patch("app.services.recommendation_service.ai_service")
+    @patch("app.services.session_analysis_service.ai_service")
+    async def test_force_refresh_regenerates(
+        self,
+        mock_analysis_ai: AsyncMock,
+        mock_rec_ai: AsyncMock,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        """force_refresh=True generiert neue Empfehlungen."""
+        workout = await _create_test_workout(db_session, with_analysis=True)
+        mock_rec_ai.chat = AsyncMock(return_value=MOCK_RECOMMENDATIONS_RESPONSE)
+        mock_rec_ai.get_active_provider.return_value = "Claude (test)"
+
+        await client.post(f"/api/v1/sessions/{workout.id}/recommendations")
+
+        response = await client.post(
+            f"/api/v1/sessions/{workout.id}/recommendations",
+            json={"force_refresh": True},
+        )
+        assert response.status_code == 200
+        assert response.json()["cached"] is False
+        assert mock_rec_ai.chat.call_count == 2
+
+    async def test_recommendations_not_found(self, client: AsyncClient) -> None:
+        """404 bei ungueltiger Session-ID."""
+        response = await client.post("/api/v1/sessions/99999/recommendations")
+        assert response.status_code == 404
+
+    @patch("app.services.recommendation_service.ai_service")
+    @patch("app.services.session_analysis_service.ai_service")
+    async def test_get_recommendations(
+        self,
+        mock_analysis_ai: AsyncMock,
+        mock_rec_ai: AsyncMock,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        """GET liefert gespeicherte Empfehlungen."""
+        workout = await _create_test_workout(db_session, with_analysis=True)
+        mock_rec_ai.chat = AsyncMock(return_value=MOCK_RECOMMENDATIONS_RESPONSE)
+        mock_rec_ai.get_active_provider.return_value = "Claude (test)"
+
+        # Erst generieren
+        await client.post(f"/api/v1/sessions/{workout.id}/recommendations")
+
+        # Dann abrufen
+        response = await client.get(f"/api/v1/sessions/{workout.id}/recommendations")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["recommendations"]) == 3
+        assert data["cached"] is True
+
+
+class TestRecommendationStatusUpdate:
+    """Tests fuer PATCH /recommendations/{id}/status."""
+
+    @patch("app.services.recommendation_service.ai_service")
+    @patch("app.services.session_analysis_service.ai_service")
+    async def test_dismiss_recommendation(
+        self,
+        mock_analysis_ai: AsyncMock,
+        mock_rec_ai: AsyncMock,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        """Empfehlung kann als 'dismissed' markiert werden."""
+        workout = await _create_test_workout(db_session, with_analysis=True)
+        mock_rec_ai.chat = AsyncMock(return_value=MOCK_RECOMMENDATIONS_RESPONSE)
+        mock_rec_ai.get_active_provider.return_value = "Claude (test)"
+
+        gen_resp = await client.post(f"/api/v1/sessions/{workout.id}/recommendations")
+        rec_id = gen_resp.json()["recommendations"][0]["id"]
+
+        response = await client.patch(
+            f"/api/v1/sessions/recommendations/{rec_id}/status",
+            json={"status": "dismissed"},
+        )
+        assert response.status_code == 200
+        assert response.json()["status"] == "dismissed"
+
+    async def test_update_not_found(self, client: AsyncClient) -> None:
+        """404 bei ungueltiger Empfehlungs-ID."""
+        response = await client.patch(
+            "/api/v1/sessions/recommendations/99999/status",
+            json={"status": "dismissed"},
+        )
+        assert response.status_code == 404
+
+
+class TestRecommendationPromptBuilding:
+    """Unit-Tests fuer Prompt-Aufbau."""
+
+    def test_prompt_includes_analysis_context(self) -> None:
+        """Prompt enthaelt Session-Analyse."""
+        ctx = RecommendationContext(
+            analysis_summary="Gutes Training",
+            intensity_rating="moderat",
+            fatigue_indicators=None,
+            plan_comparison=None,
+            analysis_recommendations=["Pace beibehalten"],
+            race_goal=None,
+            current_phase=None,
+            upcoming_sessions=[],
+            weekly_volume={
+                "total_km": 30.0,
+                "total_hours": 4.5,
+                "session_count": 4,
+                "run_count": 3,
+                "strength_count": 1,
+            },
+            recent_recommendations=[],
+        )
+        prompt = _build_recommendation_prompt(ctx)
+
+        assert "Gutes Training" in prompt
+        assert "moderat" in prompt
+        assert "Pace beibehalten" in prompt
+
+    def test_prompt_includes_weekly_volume(self) -> None:
+        """Prompt enthaelt Wochenvolumen."""
+        ctx = RecommendationContext(
+            analysis_summary="OK",
+            intensity_rating="moderat",
+            fatigue_indicators=None,
+            plan_comparison=None,
+            analysis_recommendations=[],
+            race_goal=None,
+            current_phase=None,
+            upcoming_sessions=[],
+            weekly_volume={
+                "total_km": 42.0,
+                "total_hours": 5.0,
+                "session_count": 5,
+                "run_count": 4,
+                "strength_count": 1,
+            },
+            recent_recommendations=[],
+        )
+        prompt = _build_recommendation_prompt(ctx)
+
+        assert "42.0 km" in prompt
+        assert "5.0 Stunden" in prompt
+
+    def test_prompt_includes_upcoming_sessions(self) -> None:
+        """Prompt enthaelt geplante Sessions."""
+        ctx = RecommendationContext(
+            analysis_summary="OK",
+            intensity_rating="moderat",
+            fatigue_indicators=None,
+            plan_comparison=None,
+            analysis_recommendations=[],
+            race_goal=None,
+            current_phase=None,
+            upcoming_sessions=[
+                {
+                    "date": "2026-03-12",
+                    "type": "running",
+                    "run_type": "long_run",
+                    "target_duration_min": 90,
+                },
+            ],
+            weekly_volume={
+                "total_km": 0,
+                "total_hours": 0,
+                "session_count": 0,
+                "run_count": 0,
+                "strength_count": 0,
+            },
+            recent_recommendations=[],
+        )
+        prompt = _build_recommendation_prompt(ctx)
+
+        assert "long_run" in prompt
+        assert "90min" in prompt
+
+
+class TestRecommendationJsonParsing:
+    """Unit-Tests fuer JSON-Parsing."""
+
+    def test_valid_json_array(self) -> None:
+        """Gueltiges JSON-Array wird korrekt geparst."""
+        result = _parse_recommendations_json(MOCK_RECOMMENDATIONS_RESPONSE)
+        assert len(result) == 3
+        assert result[0]["type"] == "adjust_pace"
+        assert result[0]["priority"] == "high"
+
+    def test_json_with_markdown_codeblock(self) -> None:
+        """JSON in Markdown-Codeblock wird geparst."""
+        raw = f"```json\n{MOCK_RECOMMENDATIONS_RESPONSE}\n```"
+        result = _parse_recommendations_json(raw)
+        assert len(result) == 3
+
+    def test_invalid_json_fallback(self) -> None:
+        """Ungueltiges JSON ergibt Fallback-Empfehlung."""
+        result = _parse_recommendations_json("Das ist kein JSON.")
+        assert len(result) == 1
+        assert result[0]["type"] == "general"
+
+    def test_invalid_type_normalized_to_general(self) -> None:
+        """Unbekannter Typ wird zu 'general' normalisiert."""
+        rec = _normalize_recommendation({"type": "unknown_type", "title": "Test"})
+        assert rec["type"] == "general"
+
+    def test_invalid_priority_normalized_to_medium(self) -> None:
+        """Ungueltige Prioritaet wird zu 'medium' normalisiert."""
+        rec = _normalize_recommendation({"priority": "critical", "title": "Test"})
+        assert rec["priority"] == "medium"
+
+    def test_single_object_wrapped_in_list(self) -> None:
+        """Einzelnes JSON-Objekt (statt Array) wird gewrapped."""
+        raw = json.dumps(
+            {
+                "type": "add_rest",
+                "title": "Ruhetag einlegen",
+                "reasoning": "Erholung noetig",
+                "priority": "high",
+            }
+        )
+        result = _parse_recommendations_json(raw)
+        assert len(result) == 1
+        assert result[0]["type"] == "add_rest"

--- a/frontend/src/api/training.ts
+++ b/frontend/src/api/training.ts
@@ -445,6 +445,72 @@ export async function analyzeSession(
   return response.data;
 }
 
+// --- KI-Empfehlungen (E06-S02, #33) ---
+
+export type RecommendationType =
+  | 'adjust_pace'
+  | 'adjust_volume'
+  | 'add_rest'
+  | 'skip_session'
+  | 'increase_volume'
+  | 'reduce_intensity'
+  | 'change_session_type'
+  | 'extend_warmup_cooldown'
+  | 'general';
+
+export type RecommendationPriority = 'high' | 'medium' | 'low';
+export type RecommendationStatusValue = 'pending' | 'applied' | 'dismissed';
+
+export interface AIRecommendation {
+  id: number;
+  session_id: number;
+  type: RecommendationType;
+  title: string;
+  target_session_id: number | null;
+  current_value: string | null;
+  suggested_value: string | null;
+  reasoning: string;
+  priority: RecommendationPriority;
+  status: RecommendationStatusValue;
+  created_at: string;
+}
+
+export interface RecommendationsList {
+  recommendations: AIRecommendation[];
+  session_id: number;
+  provider: string;
+  cached: boolean;
+}
+
+export async function generateRecommendations(
+  sessionId: number,
+  forceRefresh = false,
+): Promise<RecommendationsList> {
+  const response = await apiClient.post<RecommendationsList>(
+    `/api/v1/sessions/${sessionId}/recommendations`,
+    { force_refresh: forceRefresh },
+  );
+  return response.data;
+}
+
+export async function getRecommendations(sessionId: number): Promise<RecommendationsList> {
+  const response = await apiClient.get<RecommendationsList>(
+    `/api/v1/sessions/${sessionId}/recommendations`,
+  );
+  return response.data;
+}
+
+export async function updateRecommendationStatus(
+  recommendationId: number,
+  status: RecommendationStatusValue,
+): Promise<AIRecommendation> {
+  const response = await apiClient.patch<AIRecommendation>(
+    `/api/v1/sessions/recommendations/${recommendationId}/status`,
+    { status },
+  );
+  return response.data;
+}
+
 // --- Soll/Ist-Vergleich (#138) ---
 
 export interface SegmentDelta {


### PR DESCRIPTION
## Summary
- **Backend**: RecommendationService mit Kontextaufbau (Session-Analyse, Wettkampfziel, Trainingsphase, Wochenvolumen, geplante Sessions), Prompt-Engineering und robustem JSON-Parsing
- **API**: 3 neue Endpunkte — `POST/GET /{id}/recommendations` + `PATCH /recommendations/{id}/status`
- **DB**: `ai_recommendations` Tabelle mit Status-Tracking (pending/applied/dismissed), Alembic Migration c032
- **Frontend**: TypeScript-Typen und API-Funktionen für Empfehlungen
- **Tests**: 16 neue Tests (Integration + Unit) — 622 gesamt, alle grün

## Details
- Caching: Vorhandene pending Empfehlungen werden wiederverwendet, `force_refresh` zum Neugenerieren
- 9 Empfehlungstypen: adjust_pace, adjust_volume, add_rest, skip_session, increase_volume, reduce_intensity, change_session_type, extend_warmup_cooldown, general
- Automatische Session-Analyse falls noch nicht vorhanden
- Fallback bei ungültigem AI-JSON → General-Empfehlung

Closes #33

## Test plan
- [x] Mypy: Success (112 files)
- [x] Ruff: All checks passed
- [x] Pytest: 622 passed
- [x] TSC: No errors
- [x] ESLint: 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)