### PR TITLE
fix: Empfehlungskarten-Hintergrund aufhellen

### DIFF
--- a/frontend/src/components/session-detail/SessionRecommendations.tsx
+++ b/frontend/src/components/session-detail/SessionRecommendations.tsx
@@ -80,8 +80,8 @@ function RecommendationCard({
     <div
       className={`rounded-[var(--radius-md)] border p-3 sm:p-4 space-y-2 transition-opacity ${
         isPending
-          ? 'border-[var(--color-border-default)] bg-[var(--color-bg-base)]'
-          : 'border-[var(--color-border-muted)] bg-[var(--color-bg-muted)] opacity-70'
+          ? 'border-[var(--color-border-default)] bg-[var(--color-bg-surface)]'
+          : 'border-[var(--color-border-muted)] bg-[var(--color-bg-surface)] opacity-60'
       }`}
     >
       {/* Header: Icon + Titel + Badges */}


### PR DESCRIPTION
## Summary
- `bg-base` (neutral-200) → `bg-surface` (neutral-100) für helleren Kartenhintergrund
- bg-base ist für App-Shell (Sidebar/Navbar), nicht für Content-Karten

## Test plan
- [x] Vitest: 176 passed
- [x] ESLint + TSC: bestanden

🤖 Generated with [Claude Code](https://claude.com/claude-code)