### PR TITLE
feat: Wöchentliches KI-Trainingsreview (E06-S06)

### DIFF
--- a/backend/alembic/versions/c033_add_weekly_reviews.py
+++ b/backend/alembic/versions/c033_add_weekly_reviews.py
@@ -1,0 +1,41 @@
+"""Add weekly_reviews table for KI-Trainingsreview (E06-S06).
+
+Revision ID: c033
+Revises: c032
+Create Date: 2026-03-17
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "c033"
+down_revision = "c032"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "weekly_reviews",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("week_start", sa.Date(), nullable=False, unique=True, index=True),
+        sa.Column("summary", sa.Text(), nullable=False),
+        sa.Column("volume_comparison_json", sa.Text(), nullable=False),
+        sa.Column("highlights_json", sa.Text(), nullable=False),
+        sa.Column("improvements_json", sa.Text(), nullable=False),
+        sa.Column("next_week_recommendations_json", sa.Text(), nullable=False),
+        sa.Column("overall_rating", sa.String(20), nullable=False),
+        sa.Column("fatigue_assessment", sa.String(20), nullable=False),
+        sa.Column("session_count", sa.Integer(), nullable=False),
+        sa.Column("provider", sa.String(100), nullable=False),
+        sa.Column(
+            "review_created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("weekly_reviews")

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -16,6 +16,7 @@ from app.api.v1 import (
     trends,
     user_settings,
     weekly_plan,
+    weekly_review,
     workouts,
 )
 
@@ -37,3 +38,4 @@ api_router.include_router(weekly_plan.router, tags=["weekly-plan"])
 api_router.include_router(training_balance.router, tags=["analytics"])
 api_router.include_router(streak.router, tags=["analytics"])
 api_router.include_router(user_settings.router, tags=["user-settings"])
+api_router.include_router(weekly_review.router, tags=["weekly-review"])

--- a/backend/app/api/v1/weekly_review.py
+++ b/backend/app/api/v1/weekly_review.py
@@ -1,0 +1,75 @@
+"""Wöchentliches KI-Trainingsreview API (E06-S06)."""
+
+from datetime import date
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.infrastructure.database.session import get_db
+from app.models.weekly_review import WeeklyReviewGenerateRequest, WeeklyReviewResponse
+from app.services.weekly_review_service import generate_weekly_review, get_weekly_review
+
+router = APIRouter()
+
+
+@router.post("/weekly-review/generate", response_model=WeeklyReviewResponse)
+async def generate_review(
+    request: WeeklyReviewGenerateRequest,
+    db: AsyncSession = Depends(get_db),
+) -> WeeklyReviewResponse:
+    """Generiert ein wöchentliches KI-Trainingsreview.
+
+    **Parameters:**
+    - week_start: ISO-Datum des Montags der Woche (z.B. "2026-03-10")
+    - force_refresh: true um ein bestehendes Review zu überschreiben
+    """
+    try:
+        week_start_date = date.fromisoformat(request.week_start)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Ungültiges Datum: {request.week_start}",
+        ) from e
+
+    try:
+        return await generate_weekly_review(
+            week_start_date, db, force_refresh=request.force_refresh
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Review konnte nicht generiert werden: {e}",
+        ) from e
+
+
+@router.get("/weekly-review/{week_start}", response_model=WeeklyReviewResponse)
+async def get_review(
+    week_start: str,
+    db: AsyncSession = Depends(get_db),
+) -> WeeklyReviewResponse:
+    """Lädt ein gespeichertes Wochen-Review.
+
+    **Parameters:**
+    - week_start: ISO-Datum des Montags der Woche (z.B. "2026-03-10")
+    """
+    try:
+        week_start_date = date.fromisoformat(week_start)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Ungültiges Datum: {week_start}",
+        ) from e
+
+    try:
+        review = await get_weekly_review(week_start_date, db)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    if not review:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Kein Review für Woche {week_start} gefunden",
+        )
+    return review

--- a/backend/app/infrastructure/database/models.py
+++ b/backend/app/infrastructure/database/models.py
@@ -285,3 +285,21 @@ class AIRecommendationModel(Base):
     provider: Mapped[str] = mapped_column(String(100))
 
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+
+
+class WeeklyReviewModel(Base):
+    __tablename__ = "weekly_reviews"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    week_start: Mapped[date] = mapped_column(Date, unique=True, index=True)
+    summary: Mapped[str] = mapped_column(Text)
+    volume_comparison_json: Mapped[str] = mapped_column(Text)  # JSON
+    highlights_json: Mapped[str] = mapped_column(Text)  # JSON array
+    improvements_json: Mapped[str] = mapped_column(Text)  # JSON array
+    next_week_recommendations_json: Mapped[str] = mapped_column(Text)  # JSON array
+    overall_rating: Mapped[str] = mapped_column(String(20))
+    fatigue_assessment: Mapped[str] = mapped_column(String(20))
+    session_count: Mapped[int] = mapped_column(Integer)
+    provider: Mapped[str] = mapped_column(String(100))
+
+    review_created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())

--- a/backend/app/models/weekly_review.py
+++ b/backend/app/models/weekly_review.py
@@ -1,0 +1,59 @@
+"""Pydantic Models für wöchentliches KI-Trainingsreview (E06-S06)."""
+
+from enum import Enum
+
+from pydantic import BaseModel
+
+
+class OverallRating(str, Enum):
+    """Gesamtbewertung der Trainingswoche."""
+
+    EXCELLENT = "excellent"
+    GOOD = "good"
+    MODERATE = "moderate"
+    POOR = "poor"
+
+
+class FatigueLevel(str, Enum):
+    """Ermüdungseinschätzung."""
+
+    LOW = "low"
+    MODERATE = "moderate"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class VolumeComparison(BaseModel):
+    """Soll/Ist-Vergleich des Wochenvolumens."""
+
+    planned_km: float | None = None
+    actual_km: float
+    planned_sessions: int | None = None
+    actual_sessions: int
+    planned_hours: float | None = None
+    actual_hours: float
+
+
+class WeeklyReviewResponse(BaseModel):
+    """Wöchentliches KI-Trainingsreview — Response."""
+
+    id: int
+    week_start: str
+    summary: str
+    volume_comparison: VolumeComparison
+    highlights: list[str]
+    improvements: list[str]
+    next_week_recommendations: list[str]
+    overall_rating: OverallRating
+    fatigue_assessment: FatigueLevel
+    session_count: int
+    provider: str
+    cached: bool = False
+    created_at: str
+
+
+class WeeklyReviewGenerateRequest(BaseModel):
+    """Request zum Generieren eines Wochen-Reviews."""
+
+    week_start: str  # ISO-Datum (Montag), z.B. "2026-03-10"
+    force_refresh: bool = False

--- a/backend/app/services/weekly_review_service.py
+++ b/backend/app/services/weekly_review_service.py
@@ -1,0 +1,598 @@
+"""Wöchentliches KI-Trainingsreview Service (E06-S06).
+
+Aggregiert alle Sessions einer Woche und generiert ein strukturiertes
+Review mit Zusammenfassung, Highlights, Verbesserungspotenzial und
+Empfehlungen für die nächste Woche.
+"""
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.api_key_resolver import resolve_claude_api_key
+from app.infrastructure.ai.ai_service import ai_service
+from app.infrastructure.database.models import (
+    RaceGoalModel,
+    TrainingPhaseModel,
+    TrainingPlanModel,
+    WeeklyReviewModel,
+    WorkoutModel,
+)
+from app.models.weekly_review import (
+    FatigueLevel,
+    OverallRating,
+    VolumeComparison,
+    WeeklyReviewResponse,
+)
+from app.services.ai_log_service import AICallData, log_ai_call
+
+logger = logging.getLogger(__name__)
+
+VALID_RATINGS = {r.value for r in OverallRating}
+VALID_FATIGUE = {f.value for f in FatigueLevel}
+
+
+@dataclass
+class WeeklyContext:
+    """Kontext für die Wochen-Review-Generierung."""
+
+    week_start: date
+    sessions: list[dict]
+    volume: dict
+    race_goal: dict | None
+    current_phase: dict | None
+    session_analyses: list[dict]
+
+
+async def generate_weekly_review(
+    week_start: date,
+    db: AsyncSession,
+    *,
+    force_refresh: bool = False,
+) -> WeeklyReviewResponse:
+    """Generiert ein wöchentliches KI-Trainingsreview."""
+    _validate_week_start(week_start)
+
+    # Cache prüfen
+    if not force_refresh:
+        cached = await _load_cached_review(week_start, db)
+        if cached:
+            return _model_to_response(cached, is_cached=True)
+
+    # Kontext laden
+    context = await _load_weekly_context(week_start, db)
+
+    # Prompt bauen und AI aufrufen
+    prompt = _build_review_prompt(context)
+    system_prompt = _build_system_prompt(context)
+    api_key = await resolve_claude_api_key(db)
+
+    t0 = time.monotonic()
+    raw = await ai_service.chat(prompt, {"system_prompt": system_prompt}, api_key)
+    duration_ms = int((time.monotonic() - t0) * 1000)
+    provider = ai_service.get_active_provider() or "unknown"
+
+    # Parsen
+    parsed = _parse_review_json(raw, context)
+
+    # Altes Review löschen, neues speichern
+    await _delete_existing_review(week_start, db)
+    model = await _save_review(week_start, parsed, provider, context, db)
+
+    # Log
+    await log_ai_call(
+        db,
+        AICallData(
+            use_case="weekly_review",
+            provider=provider,
+            system_prompt=system_prompt,
+            user_prompt=prompt,
+            raw_response=raw,
+            parsed_ok=True,
+            duration_ms=duration_ms,
+        ),
+    )
+    await db.commit()
+
+    return _model_to_response(model, is_cached=False)
+
+
+async def get_weekly_review(
+    week_start: date,
+    db: AsyncSession,
+) -> WeeklyReviewResponse | None:
+    """Lädt ein gespeichertes Wochen-Review."""
+    _validate_week_start(week_start)
+    model = await _load_cached_review(week_start, db)
+    if not model:
+        return None
+    return _model_to_response(model, is_cached=True)
+
+
+# ---------------------------------------------------------------------------
+# Validierung
+# ---------------------------------------------------------------------------
+
+
+def _validate_week_start(week_start: date) -> None:
+    """Stellt sicher, dass week_start ein Montag ist."""
+    if week_start.weekday() != 0:
+        raise ValueError(
+            f"week_start muss ein Montag sein, ist aber {week_start.strftime('%A')} ({week_start})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Kontext laden
+# ---------------------------------------------------------------------------
+
+
+async def _load_weekly_context(week_start: date, db: AsyncSession) -> WeeklyContext:
+    """Lädt den vollständigen Kontext für eine Trainingswoche."""
+    week_end = week_start + timedelta(days=6)
+
+    # Alle Sessions der Woche
+    sessions = await _load_week_sessions(week_start, week_end, db)
+
+    # Volumen berechnen
+    volume = _calculate_volume(sessions)
+
+    # Wettkampfziel
+    race_goal = await _load_race_goal(db)
+
+    # Trainingsphase
+    current_phase = await _load_current_phase(week_start, db)
+
+    # Session-Analysen (sofern vorhanden)
+    analyses = _extract_analyses(sessions)
+
+    return WeeklyContext(
+        week_start=week_start,
+        sessions=[_session_to_dict(s) for s in sessions],
+        volume=volume,
+        race_goal=race_goal,
+        current_phase=current_phase,
+        session_analyses=analyses,
+    )
+
+
+async def _load_week_sessions(
+    week_start: date,
+    week_end: date,
+    db: AsyncSession,
+) -> list[WorkoutModel]:
+    """Lädt alle Sessions einer Woche."""
+    result = await db.execute(
+        select(WorkoutModel)
+        .where(
+            WorkoutModel.date >= datetime.combine(week_start, datetime.min.time()),
+            WorkoutModel.date <= datetime.combine(week_end, datetime.max.time()),
+        )
+        .order_by(WorkoutModel.date)
+    )
+    return list(result.scalars().all())
+
+
+def _calculate_volume(sessions: list[WorkoutModel]) -> dict:
+    """Berechnet Wochenvolumen aus Sessions."""
+    total_km = sum(s.distance_km or 0 for s in sessions)
+    total_min = sum((s.duration_sec or 0) / 60 for s in sessions)
+    run_count = sum(1 for s in sessions if s.workout_type == "running")
+    strength_count = sum(1 for s in sessions if s.workout_type == "strength")
+
+    return {
+        "total_km": round(total_km, 1),
+        "total_hours": round(total_min / 60, 1),
+        "session_count": len(sessions),
+        "run_count": run_count,
+        "strength_count": strength_count,
+    }
+
+
+def _session_to_dict(s: WorkoutModel) -> dict:
+    """Konvertiert WorkoutModel in kompaktes Dict für den Prompt."""
+    d: dict = {
+        "date": s.date.strftime("%Y-%m-%d"),
+        "type": s.workout_type,
+        "subtype": s.subtype,
+    }
+    if s.distance_km:
+        d["distance_km"] = round(s.distance_km, 1)
+    if s.duration_sec:
+        d["duration_min"] = round(s.duration_sec / 60, 1)
+    if s.pace:
+        d["pace"] = s.pace
+    if s.hr_avg:
+        d["hr_avg"] = s.hr_avg
+    if s.hr_max:
+        d["hr_max"] = s.hr_max
+    if s.rpe:
+        d["rpe"] = s.rpe
+    if s.notes:
+        d["notes"] = s.notes[:200]
+    return d
+
+
+def _extract_analyses(sessions: list[WorkoutModel]) -> list[dict]:
+    """Extrahiert vorhandene KI-Analysen aus Sessions."""
+    analyses = []
+    for s in sessions:
+        if not s.ai_analysis:
+            continue
+        try:
+            analysis = json.loads(s.ai_analysis)
+            analyses.append(
+                {
+                    "date": s.date.strftime("%Y-%m-%d"),
+                    "type": s.subtype or s.workout_type,
+                    "summary": analysis.get("summary", ""),
+                    "intensity_rating": analysis.get("intensity_rating", ""),
+                }
+            )
+        except json.JSONDecodeError:
+            continue
+    return analyses
+
+
+async def _load_race_goal(db: AsyncSession) -> dict | None:
+    """Lädt das aktive Wettkampfziel."""
+    result = await db.execute(
+        select(RaceGoalModel).where(RaceGoalModel.is_active.is_(True)).limit(1)
+    )
+    goal = result.scalar_one_or_none()
+    if not goal:
+        return None
+
+    target_pace = None
+    if goal.target_time_seconds and goal.distance_km and goal.distance_km > 0:
+        pace_min = (goal.target_time_seconds / 60) / goal.distance_km
+        m = int(pace_min)
+        s = int((pace_min - m) * 60)
+        target_pace = f"{m}:{s:02d}"
+
+    return {
+        "title": goal.title,
+        "date": str(
+            goal.race_date.date() if isinstance(goal.race_date, datetime) else goal.race_date
+        ),
+        "distance_km": goal.distance_km,
+        "target_pace": target_pace,
+    }
+
+
+async def _load_current_phase(ref_date: date, db: AsyncSession) -> dict | None:
+    """Lädt die aktuelle Trainingsphase."""
+    plan_result = await db.execute(
+        select(TrainingPlanModel)
+        .where(TrainingPlanModel.status == "active")
+        .order_by(TrainingPlanModel.start_date.desc())
+        .limit(1)
+    )
+    plan = plan_result.scalar_one_or_none()
+    if not plan:
+        return None
+
+    days_since_start = (ref_date - plan.start_date).days  # type: ignore[operator]
+    current_week = (days_since_start // 7) + 1
+
+    phase_result = await db.execute(
+        select(TrainingPhaseModel)
+        .where(
+            TrainingPhaseModel.training_plan_id == plan.id,
+            TrainingPhaseModel.start_week <= current_week,
+            TrainingPhaseModel.end_week >= current_week,
+        )
+        .limit(1)
+    )
+    phase = phase_result.scalar_one_or_none()
+    if not phase:
+        return {"plan_name": plan.name, "week": current_week}
+
+    return {
+        "plan_name": plan.name,
+        "phase_name": phase.name,
+        "phase_type": phase.phase_type,
+        "week": current_week,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Cache / DB
+# ---------------------------------------------------------------------------
+
+
+async def _load_cached_review(
+    week_start: date,
+    db: AsyncSession,
+) -> WeeklyReviewModel | None:
+    """Lädt ein gecachtes Review für eine Woche."""
+    result = await db.execute(
+        select(WeeklyReviewModel).where(WeeklyReviewModel.week_start == week_start)
+    )
+    return result.scalar_one_or_none()
+
+
+async def _delete_existing_review(week_start: date, db: AsyncSession) -> None:
+    """Löscht ein bestehendes Review für eine Woche."""
+    from sqlalchemy import delete
+
+    await db.execute(delete(WeeklyReviewModel).where(WeeklyReviewModel.week_start == week_start))
+
+
+async def _save_review(
+    week_start: date,
+    parsed: dict,
+    provider: str,
+    context: WeeklyContext,
+    db: AsyncSession,
+) -> WeeklyReviewModel:
+    """Speichert ein geparstes Review in der DB."""
+    model = WeeklyReviewModel(
+        week_start=week_start,
+        summary=parsed["summary"],
+        volume_comparison_json=json.dumps(parsed["volume_comparison"]),
+        highlights_json=json.dumps(parsed["highlights"]),
+        improvements_json=json.dumps(parsed["improvements"]),
+        next_week_recommendations_json=json.dumps(parsed["next_week_recommendations"]),
+        overall_rating=parsed["overall_rating"],
+        fatigue_assessment=parsed["fatigue_assessment"],
+        session_count=context.volume["session_count"],
+        provider=provider,
+    )
+    db.add(model)
+    await db.flush()
+    await db.refresh(model)
+    return model
+
+
+# ---------------------------------------------------------------------------
+# Prompt-Builder
+# ---------------------------------------------------------------------------
+
+
+def _build_system_prompt(ctx: WeeklyContext) -> str:
+    """System-Prompt für Wochen-Review."""
+    parts = [
+        "Du bist ein erfahrener Lauf- und Krafttrainer.",
+        "Deine Aufgabe: Erstelle ein umfassendes Wochen-Review des Trainings.",
+        "",
+        "Regeln:",
+        "- Analysiere die gesamte Trainingswoche holistisch",
+        "- Bewerte Balance zwischen Belastung und Erholung",
+        "- Erkenne Muster (z.B. zu viel Intensitaet, fehlende Variation)",
+        "- Empfehlungen muessen spezifisch und fuer die naechste Woche umsetzbar sein",
+        "- Auf Deutsch antworten",
+    ]
+
+    if ctx.race_goal:
+        g = ctx.race_goal
+        parts.append("")
+        parts.append(f"Wettkampfziel: {g['title']} ({g['distance_km']} km)")
+        if g.get("target_pace"):
+            parts.append(f"Zielpace: {g['target_pace']} min/km")
+        if g.get("date"):
+            parts.append(f"Wettkampf am: {g['date']}")
+
+    if ctx.current_phase:
+        p = ctx.current_phase
+        parts.append("")
+        parts.append(f"Trainingsplan: {p.get('plan_name', '?')}")
+        if p.get("phase_name"):
+            parts.append(f"Phase: {p['phase_name']} ({p.get('phase_type', '?')})")
+        parts.append(f"Woche: {p.get('week', '?')}")
+
+    return "\n".join(parts)
+
+
+def _build_review_prompt(ctx: WeeklyContext) -> str:
+    """User-Prompt für Wochen-Review."""
+    parts: list[str] = []
+
+    parts.append(
+        f"## Trainingswoche {ctx.week_start.strftime('%d.%m.%Y')} "
+        f"– {(ctx.week_start + timedelta(days=6)).strftime('%d.%m.%Y')}"
+    )
+
+    # Sessions auflisten
+    parts.append("")
+    parts.append("## Durchgeführte Sessions")
+    if not ctx.sessions:
+        parts.append("Keine Sessions in dieser Woche.")
+    else:
+        for s in ctx.sessions:
+            label = s.get("subtype") or s["type"]
+            details = []
+            if s.get("distance_km"):
+                details.append(f"{s['distance_km']} km")
+            if s.get("duration_min"):
+                details.append(f"{s['duration_min']} min")
+            if s.get("pace"):
+                details.append(f"Pace {s['pace']}")
+            if s.get("hr_avg"):
+                details.append(f"HF Ø{s['hr_avg']}")
+            if s.get("rpe"):
+                details.append(f"RPE {s['rpe']}")
+            detail_str = ", ".join(details) if details else ""
+            parts.append(f"- {s['date']}: {label} ({detail_str})")
+            if s.get("notes"):
+                parts.append(f"  Notizen: {s['notes']}")
+
+    # Wochenvolumen
+    parts.append("")
+    parts.append("## Wochenvolumen")
+    v = ctx.volume
+    parts.append(
+        f"- Sessions: {v['session_count']} ({v['run_count']} Lauf, {v['strength_count']} Kraft)"
+    )
+    parts.append(f"- Distanz: {v['total_km']} km")
+    parts.append(f"- Dauer: {v['total_hours']} Stunden")
+
+    # Session-Analysen
+    if ctx.session_analyses:
+        parts.append("")
+        parts.append("## Bisherige KI-Analysen der einzelnen Sessions")
+        for a in ctx.session_analyses:
+            parts.append(
+                f"- {a['date']} ({a['type']}): {a['summary'][:150]} "
+                f"[Intensitaet: {a['intensity_rating']}]"
+            )
+
+    # Anweisungen
+    parts.append("")
+    parts.append(_build_review_instructions())
+
+    return "\n".join(parts)
+
+
+def _build_review_instructions() -> str:
+    """Anweisungen für die KI."""
+    return """## Anweisungen
+Erstelle ein Wochen-Review. Antworte NUR mit einem JSON-Objekt (ohne Markdown-Codeblock):
+
+{
+  "summary": "2-4 Saetze Zusammenfassung der Trainingswoche",
+  "volume_comparison": {
+    "actual_km": 42.0,
+    "actual_sessions": 4,
+    "actual_hours": 5.5
+  },
+  "highlights": ["Positiv-Punkt 1", "Positiv-Punkt 2"],
+  "improvements": ["Verbesserung 1", "Verbesserung 2"],
+  "next_week_recommendations": ["Konkrete Empfehlung 1", "Konkrete Empfehlung 2"],
+  "overall_rating": "good",
+  "fatigue_assessment": "moderate"
+}
+
+Regeln:
+- summary: 2-4 Saetze, nicht laenger
+- highlights: 2-4 positive Aspekte der Woche
+- improvements: 1-3 Verbesserungsvorschlaege
+- next_week_recommendations: 2-4 konkrete Empfehlungen fuer die naechste Woche
+- overall_rating: "excellent", "good", "moderate", oder "poor"
+- fatigue_assessment: "low", "moderate", "high", oder "critical"
+- volume_comparison.actual_km/actual_sessions/actual_hours: Echte Werte aus den Daten
+- Auf Deutsch antworten
+- Keine generischen Ratschlaege"""
+
+
+# ---------------------------------------------------------------------------
+# JSON-Parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_review_json(raw: str, context: WeeklyContext) -> dict:
+    """Parst die AI-Antwort als JSON-Objekt."""
+    text = raw.strip()
+
+    # Markdown-Codeblock entfernen
+    if text.startswith("```"):
+        lines = text.split("\n")
+        text = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
+
+    # Provider-Tag entfernen: "[Claude ...] {...}"
+    if text.startswith("[") and "{" in text:
+        brace_idx = text.index("{")
+        text = text[brace_idx:]
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        logger.warning("Wochen-Review konnte nicht geparst werden: %s", text[:200])
+        return _fallback_review(context)
+
+    if not isinstance(data, dict):
+        return _fallback_review(context)
+
+    return _normalize_review(data, context)
+
+
+def _normalize_review(data: dict, context: WeeklyContext) -> dict:
+    """Normalisiert ein geparstes Review."""
+    rating = str(data.get("overall_rating", "moderate")).lower()
+    if rating not in VALID_RATINGS:
+        rating = "moderate"
+
+    fatigue = str(data.get("fatigue_assessment", "moderate")).lower()
+    if fatigue not in VALID_FATIGUE:
+        fatigue = "moderate"
+
+    vol = data.get("volume_comparison", {})
+    if not isinstance(vol, dict):
+        vol = {}
+
+    return {
+        "summary": str(data.get("summary", "Keine Zusammenfassung verfügbar.")),
+        "volume_comparison": {
+            "actual_km": float(vol.get("actual_km", context.volume["total_km"])),
+            "actual_sessions": int(vol.get("actual_sessions", context.volume["session_count"])),
+            "actual_hours": float(vol.get("actual_hours", context.volume["total_hours"])),
+        },
+        "highlights": _ensure_str_list(data.get("highlights", [])),
+        "improvements": _ensure_str_list(data.get("improvements", [])),
+        "next_week_recommendations": _ensure_str_list(data.get("next_week_recommendations", [])),
+        "overall_rating": rating,
+        "fatigue_assessment": fatigue,
+    }
+
+
+def _ensure_str_list(value: object) -> list[str]:
+    """Stellt sicher, dass der Wert eine Liste von Strings ist."""
+    if not isinstance(value, list):
+        return [str(value)] if value else []
+    return [str(v) for v in value if v]
+
+
+def _fallback_review(context: WeeklyContext) -> dict:
+    """Fallback bei Parse-Fehler."""
+    return {
+        "summary": "Das Wochen-Review konnte nicht generiert werden. Bitte erneut versuchen.",
+        "volume_comparison": {
+            "actual_km": context.volume["total_km"],
+            "actual_sessions": context.volume["session_count"],
+            "actual_hours": context.volume["total_hours"],
+        },
+        "highlights": [],
+        "improvements": [],
+        "next_week_recommendations": [],
+        "overall_rating": "moderate",
+        "fatigue_assessment": "moderate",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Response-Builder
+# ---------------------------------------------------------------------------
+
+
+def _model_to_response(
+    model: WeeklyReviewModel,
+    *,
+    is_cached: bool,
+) -> WeeklyReviewResponse:
+    """Konvertiert DB-Model in Response."""
+    vol_data = json.loads(model.volume_comparison_json)
+
+    return WeeklyReviewResponse(
+        id=model.id,
+        week_start=str(model.week_start),
+        summary=model.summary,
+        volume_comparison=VolumeComparison(
+            actual_km=vol_data.get("actual_km", 0),
+            actual_sessions=vol_data.get("actual_sessions", 0),
+            actual_hours=vol_data.get("actual_hours", 0),
+        ),
+        highlights=json.loads(model.highlights_json),
+        improvements=json.loads(model.improvements_json),
+        next_week_recommendations=json.loads(model.next_week_recommendations_json),
+        overall_rating=OverallRating(model.overall_rating),
+        fatigue_assessment=FatigueLevel(model.fatigue_assessment),
+        session_count=model.session_count,
+        provider=model.provider,
+        cached=is_cached,
+        created_at=model.review_created_at.isoformat() if model.review_created_at else "",
+    )

--- a/backend/app/tests/test_weekly_review.py
+++ b/backend/app/tests/test_weekly_review.py
@@ -1,0 +1,288 @@
+"""Tests für wöchentliches KI-Trainingsreview (E06-S06)."""
+
+import json
+from datetime import date
+
+import pytest
+
+from app.models.weekly_review import (
+    FatigueLevel,
+    OverallRating,
+    VolumeComparison,
+    WeeklyReviewResponse,
+)
+from app.services.weekly_review_service import (
+    WeeklyContext,
+    _build_review_prompt,
+    _calculate_volume,
+    _ensure_str_list,
+    _fallback_review,
+    _normalize_review,
+    _parse_review_json,
+    _validate_week_start,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+MONDAY = date(2026, 3, 16)  # Montag
+TUESDAY = date(2026, 3, 17)  # Dienstag
+
+
+def _make_context(
+    sessions: list[dict] | None = None,
+    volume: dict | None = None,
+) -> WeeklyContext:
+    return WeeklyContext(
+        week_start=MONDAY,
+        sessions=sessions or [],
+        volume=volume
+        or {
+            "total_km": 42.0,
+            "total_hours": 5.5,
+            "session_count": 4,
+            "run_count": 3,
+            "strength_count": 1,
+        },
+        race_goal=None,
+        current_phase=None,
+        session_analyses=[],
+    )
+
+
+VALID_AI_RESPONSE = json.dumps(
+    {
+        "summary": "Gute Trainingswoche mit solider Grundlage.",
+        "volume_comparison": {
+            "actual_km": 42.0,
+            "actual_sessions": 4,
+            "actual_hours": 5.5,
+        },
+        "highlights": ["Guter Long Run", "Konstante Paces"],
+        "improvements": ["Mehr Stretching"],
+        "next_week_recommendations": [
+            "Tempolauf am Dienstag einfuegen",
+            "Ruhetag am Freitag",
+        ],
+        "overall_rating": "good",
+        "fatigue_assessment": "moderate",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_valid_monday(self) -> None:
+        _validate_week_start(MONDAY)  # Sollte keine Exception werfen
+
+    def test_invalid_tuesday(self) -> None:
+        with pytest.raises(ValueError, match="Montag"):
+            _validate_week_start(TUESDAY)
+
+    def test_invalid_sunday(self) -> None:
+        with pytest.raises(ValueError, match="Montag"):
+            _validate_week_start(date(2026, 3, 22))
+
+
+# ---------------------------------------------------------------------------
+# Volume Calculation
+# ---------------------------------------------------------------------------
+
+
+class TestCalculateVolume:
+    def test_empty_sessions(self) -> None:
+        vol = _calculate_volume([])
+        assert vol["total_km"] == 0
+        assert vol["session_count"] == 0
+
+    def test_mixed_sessions(self) -> None:
+        class FakeSession:
+            def __init__(
+                self, distance_km: float | None, duration_sec: int | None, workout_type: str
+            ) -> None:
+                self.distance_km = distance_km
+                self.duration_sec = duration_sec
+                self.workout_type = workout_type
+
+        sessions = [
+            FakeSession(10.0, 3600, "running"),
+            FakeSession(8.0, 2400, "running"),
+            FakeSession(None, 3600, "strength"),
+        ]
+        vol = _calculate_volume(sessions)  # type: ignore[arg-type]
+        assert vol["total_km"] == 18.0
+        assert vol["run_count"] == 2
+        assert vol["strength_count"] == 1
+        assert vol["session_count"] == 3
+
+
+# ---------------------------------------------------------------------------
+# JSON Parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseReviewJson:
+    def test_valid_json(self) -> None:
+        ctx = _make_context()
+        result = _parse_review_json(VALID_AI_RESPONSE, ctx)
+        assert result["summary"] == "Gute Trainingswoche mit solider Grundlage."
+        assert result["overall_rating"] == "good"
+        assert len(result["highlights"]) == 2
+
+    def test_markdown_codeblock(self) -> None:
+        ctx = _make_context()
+        wrapped = f"```json\n{VALID_AI_RESPONSE}\n```"
+        result = _parse_review_json(wrapped, ctx)
+        assert result["overall_rating"] == "good"
+
+    def test_provider_tag(self) -> None:
+        ctx = _make_context()
+        tagged = f"[Claude (3.5 Sonnet)] {VALID_AI_RESPONSE}"
+        result = _parse_review_json(tagged, ctx)
+        assert result["overall_rating"] == "good"
+
+    def test_invalid_json_fallback(self) -> None:
+        ctx = _make_context()
+        result = _parse_review_json("This is not JSON", ctx)
+        assert "erneut versuchen" in result["summary"]
+        assert result["overall_rating"] == "moderate"
+
+    def test_invalid_rating_normalized(self) -> None:
+        ctx = _make_context()
+        data = json.loads(VALID_AI_RESPONSE)
+        data["overall_rating"] = "super_duper"
+        result = _normalize_review(data, ctx)
+        assert result["overall_rating"] == "moderate"
+
+    def test_invalid_fatigue_normalized(self) -> None:
+        ctx = _make_context()
+        data = json.loads(VALID_AI_RESPONSE)
+        data["fatigue_assessment"] = "extreme"
+        result = _normalize_review(data, ctx)
+        assert result["fatigue_assessment"] == "moderate"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureStrList:
+    def test_list(self) -> None:
+        assert _ensure_str_list(["a", "b"]) == ["a", "b"]
+
+    def test_string(self) -> None:
+        assert _ensure_str_list("hello") == ["hello"]
+
+    def test_empty_list(self) -> None:
+        assert _ensure_str_list([]) == []
+
+    def test_none(self) -> None:
+        assert _ensure_str_list(None) == []
+
+    def test_filters_empty(self) -> None:
+        assert _ensure_str_list(["a", "", "b"]) == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# Prompt Builder
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPrompt:
+    def test_includes_week_dates(self) -> None:
+        ctx = _make_context()
+        prompt = _build_review_prompt(ctx)
+        assert "16.03.2026" in prompt
+        assert "22.03.2026" in prompt
+
+    def test_includes_sessions(self) -> None:
+        ctx = _make_context(
+            sessions=[
+                {
+                    "date": "2026-03-16",
+                    "type": "running",
+                    "subtype": "easy",
+                    "distance_km": 10.0,
+                    "pace": "5:30",
+                }
+            ]
+        )
+        prompt = _build_review_prompt(ctx)
+        assert "easy" in prompt
+        assert "10.0 km" in prompt
+
+    def test_empty_sessions(self) -> None:
+        ctx = _make_context()
+        prompt = _build_review_prompt(ctx)
+        assert "Keine Sessions" in prompt
+
+    def test_includes_volume(self) -> None:
+        ctx = _make_context()
+        prompt = _build_review_prompt(ctx)
+        assert "42.0 km" in prompt
+        assert "5.5 Stunden" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Fallback
+# ---------------------------------------------------------------------------
+
+
+class TestFallback:
+    def test_fallback_uses_context_volume(self) -> None:
+        ctx = _make_context(
+            volume={
+                "total_km": 30.0,
+                "total_hours": 4.0,
+                "session_count": 3,
+                "run_count": 2,
+                "strength_count": 1,
+            }
+        )
+        result = _fallback_review(ctx)
+        assert result["volume_comparison"]["actual_km"] == 30.0
+        assert result["volume_comparison"]["actual_sessions"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Pydantic Models
+# ---------------------------------------------------------------------------
+
+
+class TestModels:
+    def test_weekly_review_response(self) -> None:
+        response = WeeklyReviewResponse(
+            id=1,
+            week_start="2026-03-16",
+            summary="Gute Woche",
+            volume_comparison=VolumeComparison(
+                actual_km=42.0,
+                actual_sessions=4,
+                actual_hours=5.5,
+            ),
+            highlights=["A"],
+            improvements=["B"],
+            next_week_recommendations=["C"],
+            overall_rating=OverallRating.GOOD,
+            fatigue_assessment=FatigueLevel.MODERATE,
+            session_count=4,
+            provider="Claude",
+            cached=False,
+            created_at="2026-03-17T10:00:00",
+        )
+        assert response.overall_rating == OverallRating.GOOD
+        assert response.volume_comparison.actual_km == 42.0
+
+    def test_overall_rating_enum(self) -> None:
+        assert OverallRating.EXCELLENT.value == "excellent"
+        assert OverallRating.POOR.value == "poor"
+
+    def test_fatigue_level_enum(self) -> None:
+        assert FatigueLevel.LOW.value == "low"
+        assert FatigueLevel.CRITICAL.value == "critical"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -106,6 +106,9 @@ const AthleteProfilePage = lazy(() =>
   import('./pages/AthleteProfile').then((m) => ({ default: m.AthleteProfilePage })),
 );
 const KiLogPage = lazy(() => import('./pages/KiLog').then((m) => ({ default: m.KiLogPage })));
+const WeeklyReviewPage = lazy(() =>
+  import('./pages/WeeklyReview').then((m) => ({ default: m.WeeklyReviewPage })),
+);
 const NotFoundPage = lazy(() =>
   import('./pages/NotFound').then((m) => ({ default: m.NotFoundPage })),
 );
@@ -157,6 +160,7 @@ function App() {
 
                   {/* Profil (formerly Einstellungen > Athletenprofil) */}
                   <Route path="/profile" element={<AthleteProfilePage />} />
+                  <Route path="/weekly-review" element={<WeeklyReviewPage />} />
                   <Route path="/ki-log" element={<KiLogPage />} />
 
                   {/* Redirects for old /settings paths */}

--- a/frontend/src/api/training.ts
+++ b/frontend/src/api/training.ts
@@ -588,3 +588,49 @@ export async function healthCheck(): Promise<{ status: string }> {
   const response = await apiClient.get<{ status: string }>('/health');
   return response.data;
 }
+
+// --- Wöchentliches KI-Review (E06-S06, #323) ---
+
+export type OverallRating = 'excellent' | 'good' | 'moderate' | 'poor';
+export type FatigueLevel = 'low' | 'moderate' | 'high' | 'critical';
+
+export interface VolumeComparison {
+  planned_km: number | null;
+  actual_km: number;
+  planned_sessions: number | null;
+  actual_sessions: number;
+  planned_hours: number | null;
+  actual_hours: number;
+}
+
+export interface WeeklyReview {
+  id: number;
+  week_start: string;
+  summary: string;
+  volume_comparison: VolumeComparison;
+  highlights: string[];
+  improvements: string[];
+  next_week_recommendations: string[];
+  overall_rating: OverallRating;
+  fatigue_assessment: FatigueLevel;
+  session_count: number;
+  provider: string;
+  cached: boolean;
+  created_at: string;
+}
+
+export async function generateWeeklyReview(
+  weekStart: string,
+  forceRefresh = false,
+): Promise<WeeklyReview> {
+  const response = await apiClient.post<WeeklyReview>('/api/v1/weekly-review/generate', {
+    week_start: weekStart,
+    force_refresh: forceRefresh,
+  });
+  return response.data;
+}
+
+export async function getWeeklyReview(weekStart: string): Promise<WeeklyReview> {
+  const response = await apiClient.get<WeeklyReview>(`/api/v1/weekly-review/${weekStart}`);
+  return response.data;
+}

--- a/frontend/src/hooks/useWeeklyReview.test.ts
+++ b/frontend/src/hooks/useWeeklyReview.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useWeeklyReview } from './useWeeklyReview';
+import type { WeeklyReview } from '@/api/training';
+
+const MOCK_REVIEW: WeeklyReview = {
+  id: 1,
+  week_start: '2026-03-16',
+  summary: 'Gute Trainingswoche mit solidem Volumen.',
+  volume_comparison: {
+    planned_km: null,
+    actual_km: 42.0,
+    planned_sessions: null,
+    actual_sessions: 4,
+    planned_hours: null,
+    actual_hours: 5.5,
+  },
+  highlights: ['Guter Long Run', 'Konstante Paces'],
+  improvements: ['Mehr Stretching'],
+  next_week_recommendations: ['Tempolauf einfügen'],
+  overall_rating: 'good',
+  fatigue_assessment: 'moderate',
+  session_count: 4,
+  provider: 'Claude (test)',
+  cached: false,
+  created_at: '2026-03-17T10:00:00',
+};
+
+const mockGenerateWeeklyReview = vi.fn();
+const mockGetWeeklyReview = vi.fn();
+
+vi.mock('@/api/training', () => ({
+  generateWeeklyReview: (...args: unknown[]) => mockGenerateWeeklyReview(...args),
+  getWeeklyReview: (...args: unknown[]) => mockGetWeeklyReview(...args),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useWeeklyReview', () => {
+  it('starts with empty state', () => {
+    const { result } = renderHook(() => useWeeklyReview());
+    expect(result.current.review).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('generate() calls API and sets review', async () => {
+    mockGenerateWeeklyReview.mockResolvedValue(MOCK_REVIEW);
+    const { result } = renderHook(() => useWeeklyReview());
+
+    await act(async () => {
+      await result.current.generate('2026-03-16');
+    });
+
+    expect(mockGenerateWeeklyReview).toHaveBeenCalledWith('2026-03-16', false);
+    expect(result.current.review).not.toBeNull();
+    expect(result.current.review?.summary).toBe('Gute Trainingswoche mit solidem Volumen.');
+  });
+
+  it('generate(weekStart, true) passes forceRefresh', async () => {
+    mockGenerateWeeklyReview.mockResolvedValue(MOCK_REVIEW);
+    const { result } = renderHook(() => useWeeklyReview());
+
+    await act(async () => {
+      await result.current.generate('2026-03-16', true);
+    });
+
+    expect(mockGenerateWeeklyReview).toHaveBeenCalledWith('2026-03-16', true);
+  });
+
+  it('generate() sets error on failure', async () => {
+    mockGenerateWeeklyReview.mockRejectedValue(new Error('API Error'));
+    const { result } = renderHook(() => useWeeklyReview());
+
+    await act(async () => {
+      await result.current.generate('2026-03-16');
+    });
+
+    expect(result.current.error).toBe('Wochen-Review konnte nicht generiert werden.');
+    expect(result.current.review).toBeNull();
+  });
+
+  it('fetch() loads stored review', async () => {
+    mockGetWeeklyReview.mockResolvedValue({ ...MOCK_REVIEW, cached: true });
+    const { result } = renderHook(() => useWeeklyReview());
+
+    await act(async () => {
+      await result.current.fetch('2026-03-16');
+    });
+
+    expect(mockGetWeeklyReview).toHaveBeenCalledWith('2026-03-16');
+    expect(result.current.review).not.toBeNull();
+    expect(result.current.cached).toBe(true);
+  });
+
+  it('fetch() silently handles missing review', async () => {
+    mockGetWeeklyReview.mockRejectedValue(new Error('404'));
+    const { result } = renderHook(() => useWeeklyReview());
+
+    await act(async () => {
+      await result.current.fetch('2026-03-16');
+    });
+
+    expect(result.current.review).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useWeeklyReview.ts
+++ b/frontend/src/hooks/useWeeklyReview.ts
@@ -1,0 +1,57 @@
+import { useState, useCallback } from 'react';
+import type { WeeklyReview } from '@/api/training';
+import { generateWeeklyReview, getWeeklyReview } from '@/api/training';
+
+interface UseWeeklyReviewReturn {
+  review: WeeklyReview | null;
+  loading: boolean;
+  error: string | null;
+  cached: boolean;
+  generate: (weekStart: string, forceRefresh?: boolean) => Promise<void>;
+  fetch: (weekStart: string) => Promise<void>;
+}
+
+export function useWeeklyReview(): UseWeeklyReviewReturn {
+  const [review, setReview] = useState<WeeklyReview | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [cached, setCached] = useState(false);
+
+  const generate = useCallback(async (weekStart: string, forceRefresh = false) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await generateWeeklyReview(weekStart, forceRefresh);
+      setReview(result);
+      setCached(result.cached);
+    } catch {
+      setError('Wochen-Review konnte nicht generiert werden.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const fetch = useCallback(async (weekStart: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await getWeeklyReview(weekStart);
+      setReview(result);
+      setCached(result.cached);
+    } catch {
+      // Kein gespeichertes Review — kein Fehler
+      setReview(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return {
+    review,
+    loading,
+    error,
+    cached,
+    generate,
+    fetch,
+  };
+}

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -6,6 +6,7 @@ import {
   LayoutDashboard,
   Dumbbell,
   TrendingUp,
+  Sparkles,
   User,
   ChevronDown,
   Calendar,
@@ -27,6 +28,7 @@ const navItems: NavItem[] = [
   { to: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
   { to: '/sessions', label: 'Sessions', icon: Dumbbell },
   { to: '/analyse', label: 'Analyse', icon: TrendingUp },
+  { to: '/weekly-review', label: 'KI-Review', icon: Sparkles },
   {
     to: '/plan',
     label: 'Plan',

--- a/frontend/src/pages/WeeklyReview.tsx
+++ b/frontend/src/pages/WeeklyReview.tsx
@@ -1,0 +1,353 @@
+import { useEffect, useState, useCallback } from 'react';
+import {
+  Card,
+  CardHeader,
+  CardBody,
+  Button,
+  Badge,
+  Spinner,
+  Breadcrumbs,
+  BreadcrumbItem,
+} from '@nordlig/components';
+import {
+  Sparkles,
+  RefreshCw,
+  ChevronLeft,
+  ChevronRight,
+  TrendingUp,
+  TrendingDown,
+  AlertTriangle,
+  CheckCircle2,
+  Lightbulb,
+  Activity,
+  Gauge,
+  Calendar,
+} from 'lucide-react';
+import { Link } from 'react-router-dom';
+import type { WeeklyReview, OverallRating, FatigueLevel } from '@/api/training';
+import { useWeeklyReview } from '@/hooks/useWeeklyReview';
+
+// --- Hilfsfunktionen ---
+
+function getMonday(d: Date): Date {
+  const day = d.getDay();
+  const diff = d.getDate() - day + (day === 0 ? -6 : 1);
+  return new Date(d.getFullYear(), d.getMonth(), diff);
+}
+
+function formatWeekStart(d: Date): string {
+  return d.toISOString().split('T')[0];
+}
+
+function formatDateRange(weekStart: Date): string {
+  const end = new Date(weekStart);
+  end.setDate(end.getDate() + 6);
+  const opts: Intl.DateTimeFormatOptions = { day: 'numeric', month: 'short' };
+  return `${weekStart.toLocaleDateString('de-DE', opts)} – ${end.toLocaleDateString('de-DE', opts)}`;
+}
+
+function shiftWeek(weekStart: Date, delta: number): Date {
+  const d = new Date(weekStart);
+  d.setDate(d.getDate() + delta * 7);
+  return d;
+}
+
+// --- Config ---
+
+const ratingConfig: Record<
+  OverallRating,
+  { label: string; variant: string; icon: typeof CheckCircle2 }
+> = {
+  excellent: { label: 'Ausgezeichnet', variant: 'success', icon: CheckCircle2 },
+  good: { label: 'Gut', variant: 'primary', icon: TrendingUp },
+  moderate: { label: 'Mäßig', variant: 'warning', icon: Activity },
+  poor: { label: 'Schwach', variant: 'error', icon: TrendingDown },
+};
+
+const fatigueConfig: Record<FatigueLevel, { label: string; variant: string }> = {
+  low: { label: 'Niedrig', variant: 'success' },
+  moderate: { label: 'Moderat', variant: 'primary' },
+  high: { label: 'Hoch', variant: 'warning' },
+  critical: { label: 'Kritisch', variant: 'error' },
+};
+
+// --- Sub-Komponenten ---
+
+function WeekNavigator({
+  weekStart,
+  onNavigate,
+}: {
+  weekStart: Date;
+  onNavigate: (d: Date) => void;
+}) {
+  const today = getMonday(new Date());
+  const isCurrentWeek = formatWeekStart(weekStart) === formatWeekStart(today);
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button variant="ghost" size="sm" onClick={() => onNavigate(shiftWeek(weekStart, -1))}>
+        <ChevronLeft className="w-4 h-4" />
+      </Button>
+      <div className="text-center min-w-[140px]">
+        <span className="text-sm font-medium text-[var(--color-text-default)]">
+          {formatDateRange(weekStart)}
+        </span>
+        {isCurrentWeek && (
+          <span className="block text-xs text-[var(--color-text-muted)]">Aktuelle Woche</span>
+        )}
+      </div>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => onNavigate(shiftWeek(weekStart, 1))}
+        disabled={isCurrentWeek}
+      >
+        <ChevronRight className="w-4 h-4" />
+      </Button>
+    </div>
+  );
+}
+
+function EmptyState({
+  onGenerate,
+  loading,
+  error,
+}: {
+  onGenerate: () => void;
+  loading: boolean;
+  error: string | null;
+}) {
+  return (
+    <Card elevation="raised">
+      <CardBody>
+        <div className="flex flex-col items-center gap-3 py-6">
+          <Sparkles className="w-8 h-8 text-[var(--color-text-primary)]" />
+          <p className="text-sm text-[var(--color-text-muted)] text-center max-w-xs">
+            Lass dir ein KI-Review deiner Trainingswoche generieren — mit Zusammenfassung,
+            Highlights und Empfehlungen.
+          </p>
+          {error && <p className="text-sm text-[var(--color-text-error)]">{error}</p>}
+          <Button onClick={onGenerate} disabled={loading}>
+            {loading ? (
+              <Spinner size="sm" className="mr-1.5" />
+            ) : (
+              <Sparkles className="w-4 h-4 mr-1.5" />
+            )}
+            Review generieren
+          </Button>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}
+
+function LoadingState() {
+  return (
+    <Card elevation="raised">
+      <CardBody>
+        <div className="flex flex-col items-center gap-3 py-8">
+          <Spinner size="md" />
+          <p className="text-sm text-[var(--color-text-muted)]">Review wird generiert…</p>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}
+
+function VolumeSection({ review }: { review: WeeklyReview }) {
+  const vol = review.volume_comparison;
+  return (
+    <div className="grid grid-cols-3 gap-3">
+      <div className="rounded-[var(--radius-md)] bg-[var(--color-bg-surface)] p-3 text-center">
+        <span className="text-lg font-semibold text-[var(--color-text-default)]">
+          {vol.actual_km}
+        </span>
+        <span className="block text-xs text-[var(--color-text-muted)]">km</span>
+      </div>
+      <div className="rounded-[var(--radius-md)] bg-[var(--color-bg-surface)] p-3 text-center">
+        <span className="text-lg font-semibold text-[var(--color-text-default)]">
+          {vol.actual_sessions}
+        </span>
+        <span className="block text-xs text-[var(--color-text-muted)]">Sessions</span>
+      </div>
+      <div className="rounded-[var(--radius-md)] bg-[var(--color-bg-surface)] p-3 text-center">
+        <span className="text-lg font-semibold text-[var(--color-text-default)]">
+          {vol.actual_hours}
+        </span>
+        <span className="block text-xs text-[var(--color-text-muted)]">Stunden</span>
+      </div>
+    </div>
+  );
+}
+
+function ListSection({
+  title,
+  items,
+  icon: Icon,
+}: {
+  title: string;
+  items: string[];
+  icon: typeof Lightbulb;
+}) {
+  if (items.length === 0) return null;
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-1.5">
+        <Icon className="w-4 h-4 text-[var(--color-text-primary)]" />
+        <span className="text-sm font-medium text-[var(--color-text-default)]">{title}</span>
+      </div>
+      <ul className="space-y-1.5 pl-5.5">
+        {items.map((item, i) => (
+          <li key={i} className="text-sm text-[var(--color-text-muted)] list-disc">
+            {item}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ReviewContent({
+  review,
+  loading,
+  error,
+  onRefresh,
+}: {
+  review: WeeklyReview;
+  loading: boolean;
+  error: string | null;
+  onRefresh: () => void;
+}) {
+  const rating = ratingConfig[review.overall_rating] ?? ratingConfig.moderate;
+  const fatigue = fatigueConfig[review.fatigue_assessment] ?? fatigueConfig.moderate;
+  const RatingIcon = rating.icon;
+
+  return (
+    <Card elevation="raised">
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Calendar className="w-4 h-4 text-[var(--color-text-primary)]" />
+            <span className="text-sm font-semibold text-[var(--color-text-default)]">
+              Wochen-Review
+            </span>
+          </div>
+          <Button variant="ghost" size="sm" onClick={onRefresh} disabled={loading}>
+            <RefreshCw className={`w-3.5 h-3.5 mr-1 ${loading ? 'animate-spin' : ''}`} />
+            Neu
+          </Button>
+        </div>
+      </CardHeader>
+      <CardBody>
+        <div className="space-y-4">
+          {error && <p className="text-sm text-[var(--color-text-error)]">{error}</p>}
+
+          {/* Bewertung + Ermüdung */}
+          <div className="flex flex-wrap gap-2">
+            <Badge
+              variant={rating.variant as 'success' | 'warning' | 'error' | 'primary'}
+              size="xs"
+            >
+              <RatingIcon className="w-3 h-3 mr-1" />
+              {rating.label}
+            </Badge>
+            <Badge
+              variant={fatigue.variant as 'success' | 'warning' | 'error' | 'primary'}
+              size="xs"
+            >
+              <Gauge className="w-3 h-3 mr-1" />
+              Ermüdung: {fatigue.label}
+            </Badge>
+          </div>
+
+          {/* Zusammenfassung */}
+          <p className="text-sm text-[var(--color-text-default)]">{review.summary}</p>
+
+          {/* Volumen */}
+          <VolumeSection review={review} />
+
+          {/* Highlights */}
+          <ListSection title="Highlights" items={review.highlights} icon={CheckCircle2} />
+
+          {/* Verbesserungspotenzial */}
+          <ListSection
+            title="Verbesserungspotenzial"
+            items={review.improvements}
+            icon={AlertTriangle}
+          />
+
+          {/* Empfehlungen für nächste Woche */}
+          <ListSection
+            title="Empfehlungen für nächste Woche"
+            items={review.next_week_recommendations}
+            icon={Lightbulb}
+          />
+        </div>
+      </CardBody>
+    </Card>
+  );
+}
+
+// --- Hauptkomponente ---
+
+export function WeeklyReviewPage() {
+  const [weekStart, setWeekStart] = useState(() => getMonday(new Date()));
+  const { review, loading, error, generate, fetch } = useWeeklyReview();
+  const [initialized, setInitialized] = useState(false);
+
+  const weekKey = formatWeekStart(weekStart);
+
+  const handleFetch = useCallback(
+    async (ws: Date) => {
+      setInitialized(true);
+      await fetch(formatWeekStart(ws));
+    },
+    [fetch],
+  );
+
+  useEffect(() => {
+    handleFetch(weekStart);
+  }, [weekKey]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleNavigate = useCallback((d: Date) => {
+    setWeekStart(d);
+    setInitialized(false);
+  }, []);
+
+  const handleGenerate = useCallback(() => {
+    generate(weekKey, false);
+  }, [generate, weekKey]);
+
+  const handleRefresh = useCallback(() => {
+    generate(weekKey, true);
+  }, [generate, weekKey]);
+
+  return (
+    <div className="p-4 pt-6 md:p-6 md:pt-8 max-w-5xl mx-auto space-y-6">
+      <header className="space-y-2 pb-2">
+        <Breadcrumbs>
+          <BreadcrumbItem>
+            <Link to="/dashboard">Dashboard</Link>
+          </BreadcrumbItem>
+          <BreadcrumbItem>Wochen-Review</BreadcrumbItem>
+        </Breadcrumbs>
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <h1 className="text-xl font-bold text-[var(--color-text-default)]">
+            Wöchentliches KI-Review
+          </h1>
+          <WeekNavigator weekStart={weekStart} onNavigate={handleNavigate} />
+        </div>
+      </header>
+
+      {loading && !review && <LoadingState />}
+
+      {!loading && !review && initialized && (
+        <EmptyState onGenerate={handleGenerate} loading={loading} error={error} />
+      )}
+
+      {review && (
+        <ReviewContent review={review} loading={loading} error={error} onRefresh={handleRefresh} />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Neues Feature: Wöchentliches KI-Trainingsreview, das alle Sessions einer Woche aggregiert und ein strukturiertes Review generiert
- Backend: `WeeklyReviewModel` + Migration, Service mit Kontext-Aggregation und Prompt-Builder, 2 API-Endpoints
- Frontend: Eigene Seite `/weekly-review` mit Wochennavigation, Review-Card (Bewertung, Volumen, Highlights, Empfehlungen), Sidebar-Link

## Test plan
- [x] Backend: 24 Tests (Validierung, Volumen-Berechnung, JSON-Parsing, Prompt-Builder, Fallback, Models)
- [x] Frontend: 6 Hook-Tests (generate, fetch, error handling)
- [x] TSC, ESLint, Prettier, Ruff, Mypy — alle bestanden
- [x] 182 Frontend Tests, 646 Backend Tests grün
- [ ] Manuell: Weekly Review generieren und UI prüfen

Resolves #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)