### PR TITLE
fix: Wettkampfnähe im KI-Review berücksichtigen

### DIFF
--- a/backend/app/services/weekly_review_service.py
+++ b/backend/app/services/weekly_review_service.py
@@ -119,6 +119,18 @@ async def get_weekly_review(
 # ---------------------------------------------------------------------------
 
 
+def _weeks_until_race(week_start: date, race_date_str: str) -> int | None:
+    """Berechnet die Wochen zwischen Wochenstart und Wettkampfdatum."""
+    try:
+        race_date = date.fromisoformat(race_date_str)
+    except (ValueError, TypeError):
+        return None
+    delta_days = (race_date - week_start).days
+    if delta_days < 0:
+        return 0
+    return delta_days // 7
+
+
 def _validate_week_start(week_start: date) -> None:
     """Stellt sicher, dass week_start ein Montag ist."""
     if week_start.weekday() != 0:
@@ -377,6 +389,19 @@ def _build_system_prompt(ctx: WeeklyContext) -> str:
             parts.append(f"Zielpace: {g['target_pace']} min/km")
         if g.get("date"):
             parts.append(f"Wettkampf am: {g['date']}")
+            weeks_until = _weeks_until_race(ctx.week_start, g["date"])
+            if weeks_until is not None:
+                parts.append(f"Wochen bis Wettkampf: {weeks_until}")
+                if weeks_until <= 3:
+                    parts.append(
+                        "WICHTIG: Tapering-Phase! Umfang reduzieren, keine neuen Reize, "
+                        "Erholung priorisieren. Keine langen Läufe (>10 km) mehr empfehlen."
+                    )
+                elif weeks_until <= 6:
+                    parts.append(
+                        "Wettkampf-spezifische Phase: Intensität beibehalten, "
+                        "aber Umfang langsam reduzieren. Long Runs verkürzen."
+                    )
 
     if ctx.current_phase:
         p = ctx.current_phase
@@ -477,7 +502,10 @@ Regeln:
 - fatigue_assessment: "low", "moderate", "high", oder "critical"
 - volume_comparison.actual_km/actual_sessions/actual_hours: Echte Werte aus den Daten
 - Auf Deutsch antworten
-- Keine generischen Ratschlaege"""
+- Keine generischen Ratschlaege
+- Empfehlungen MUESSEN zur aktuellen Trainingsphase und Wettkampfnaehe passen
+- Bei Tapering (<=3 Wochen vor Wettkampf): KEINE langen Laeufe, Umfang reduzieren, Erholung betonen
+- Bei wettkampfspezifischer Phase (<=6 Wochen): Intensitaet halten, Umfang moderat reduzieren"""
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/tests/test_weekly_review.py
+++ b/backend/app/tests/test_weekly_review.py
@@ -14,12 +14,14 @@ from app.models.weekly_review import (
 from app.services.weekly_review_service import (
     WeeklyContext,
     _build_review_prompt,
+    _build_system_prompt,
     _calculate_volume,
     _ensure_str_list,
     _fallback_review,
     _normalize_review,
     _parse_review_json,
     _validate_week_start,
+    _weeks_until_race,
 )
 
 # ---------------------------------------------------------------------------
@@ -33,6 +35,8 @@ TUESDAY = date(2026, 3, 17)  # Dienstag
 def _make_context(
     sessions: list[dict] | None = None,
     volume: dict | None = None,
+    race_goal: dict | None = None,
+    current_phase: dict | None = None,
 ) -> WeeklyContext:
     return WeeklyContext(
         week_start=MONDAY,
@@ -45,8 +49,8 @@ def _make_context(
             "run_count": 3,
             "strength_count": 1,
         },
-        race_goal=None,
-        current_phase=None,
+        race_goal=race_goal,
+        current_phase=current_phase,
         session_analyses=[],
     )
 
@@ -286,3 +290,53 @@ class TestModels:
     def test_fatigue_level_enum(self) -> None:
         assert FatigueLevel.LOW.value == "low"
         assert FatigueLevel.CRITICAL.value == "critical"
+
+
+# ---------------------------------------------------------------------------
+# Wettkampf-Kontext
+# ---------------------------------------------------------------------------
+
+
+class TestWeeksUntilRace:
+    def test_weeks_calculation(self) -> None:
+        assert _weeks_until_race(date(2026, 3, 16), "2026-03-30") == 2
+
+    def test_same_day(self) -> None:
+        assert _weeks_until_race(date(2026, 3, 16), "2026-03-16") == 0
+
+    def test_past_race(self) -> None:
+        assert _weeks_until_race(date(2026, 3, 16), "2026-03-10") == 0
+
+    def test_invalid_date(self) -> None:
+        assert _weeks_until_race(date(2026, 3, 16), "invalid") is None
+
+    def test_none_date(self) -> None:
+        assert _weeks_until_race(date(2026, 3, 16), None) is None  # type: ignore[arg-type]
+
+
+class TestSystemPromptRaceContext:
+    def test_tapering_warning(self) -> None:
+        ctx = _make_context(
+            race_goal={
+                "title": "HM",
+                "date": "2026-03-30",
+                "distance_km": 21.1,
+                "target_pace": "5:41",
+            }
+        )
+        prompt = _build_system_prompt(ctx)
+        assert "Tapering" in prompt
+        assert "Wochen bis Wettkampf: 2" in prompt
+
+    def test_no_tapering_far_out(self) -> None:
+        ctx = _make_context(
+            race_goal={
+                "title": "HM",
+                "date": "2026-06-01",
+                "distance_km": 21.1,
+                "target_pace": "5:41",
+            }
+        )
+        prompt = _build_system_prompt(ctx)
+        assert "Tapering" not in prompt
+        assert "Wochen bis Wettkampf:" in prompt


### PR DESCRIPTION
## Summary
- System-Prompt berechnet jetzt "Wochen bis Wettkampf" und gibt Tapering-Anweisungen
- ≤3 Wochen: Keine langen Läufe (>10 km), Umfang reduzieren, Erholung priorisieren
- ≤6 Wochen: Intensität halten, Umfang moderat reduzieren
- Verhindert unpassende Empfehlungen wie "15km Long Run" kurz vor dem Wettkampf
- 7 neue Tests für `_weeks_until_race` und System-Prompt-Kontext

## Test plan
- [ ] Review mit "Neu" regenerieren → keine Long-Run-Empfehlungen bei ≤3 Wochen vor Wettkampf
- [ ] System-Prompt im KI-Log enthält "Wochen bis Wettkampf" und "Tapering"
- [ ] Backend-Tests grün (31 Tests in test_weekly_review.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)