### PR TITLE
feat: KI-Review-Empfehlungen in Wochenplan übernehmen

### DIFF
--- a/backend/app/api/v1/weekly_plan.py
+++ b/backend/app/api/v1/weekly_plan.py
@@ -26,6 +26,8 @@ from app.models.training_plan import (
 )
 from app.models.weekly_plan import (
     ActualSession,
+    ApplyRecommendationsRequest,
+    ApplyRecommendationsResponse,
     CategoryTonnage,
     ComplianceDayEntry,
     ComplianceResponse,
@@ -960,3 +962,24 @@ async def sync_to_plan(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refactoring
         apply_to_all_weeks=data.apply_to_all_weeks,
         synced_days=synced_days,
     )
+
+
+@router.post("/apply-recommendations", response_model=ApplyRecommendationsResponse)
+async def apply_recommendations(
+    data: ApplyRecommendationsRequest,
+    db: AsyncSession = Depends(get_db),
+) -> ApplyRecommendationsResponse:
+    """Konvertiert KI-Review-Empfehlungen in Plan-Sessions für die Folgewoche."""
+    from app.services.recommendation_to_plan_service import (
+        apply_recommendations as do_apply,
+    )
+
+    week_start = _monday_of_week(data.week_start)
+
+    result = await do_apply(
+        review_week_start=week_start,
+        recommendations=data.recommendations,
+        db=db,
+    )
+
+    return ApplyRecommendationsResponse(**result)

--- a/backend/app/models/weekly_plan.py
+++ b/backend/app/models/weekly_plan.py
@@ -262,6 +262,23 @@ class ComplianceResponse(BaseModel):
     strength_summary: Optional[WeeklyStrengthSummary] = None  # #149
 
 
+class ApplyRecommendationsRequest(BaseModel):
+    """Request: apply KI-Review recommendations to next week's plan."""
+
+    week_start: date = Field(..., description="Montag der Review-Woche")
+    recommendations: list[str] = Field(
+        ..., min_length=1, max_length=20, description="Empfehlungen aus dem Wochen-Review"
+    )
+
+
+class ApplyRecommendationsResponse(BaseModel):
+    """Response: result of applying recommendations to the plan."""
+
+    target_week_start: str
+    entries: list[WeeklyPlanEntry]
+    applied_count: int
+
+
 class SyncToPlanRequest(BaseModel):
     """Request: sync weekly plan entries back to training plan phase template."""
 

--- a/backend/app/services/recommendation_to_plan_service.py
+++ b/backend/app/services/recommendation_to_plan_service.py
@@ -1,0 +1,393 @@
+"""Service: Konvertiert KI-Review-Empfehlungen in strukturierte Plan-Sessions.
+
+Nimmt Freitext-Empfehlungen aus dem Wochen-Review und konvertiert sie via
+KI-Call in strukturierte WeeklyPlanEntry-Objekte, die in den Wochenplan
+der Folgewoche eingefügt werden können.
+"""
+
+import contextlib
+import json
+import logging
+import time
+from datetime import date, timedelta
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.api_key_resolver import resolve_claude_api_key
+from app.infrastructure.ai.ai_service import ai_service
+from app.infrastructure.database.models import (
+    RaceGoalModel,
+    SessionTemplateModel,
+    WeeklyPlanDayModel,
+)
+from app.models.taxonomy import SESSION_TYPES
+from app.models.weekly_plan import PlannedSession, RunDetails, WeeklyPlanEntry
+from app.services.ai_log_service import AICallData, log_ai_call
+
+logger = logging.getLogger(__name__)
+
+VALID_RUN_TYPES = sorted(SESSION_TYPES)
+DAY_NAMES = ["Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag", "Sonntag"]
+
+
+async def apply_recommendations(
+    review_week_start: date,
+    recommendations: list[str],
+    db: AsyncSession,
+) -> dict:
+    """Konvertiert Empfehlungen in Plan-Sessions für die Folgewoche.
+
+    Returns dict with: target_week_start, entries (list[WeeklyPlanEntry]), applied_count.
+    """
+    target_week = review_week_start + timedelta(days=7)
+
+    # Bestehenden Plan laden
+    existing = await _load_existing_entries(target_week, db)
+
+    # Kontext laden
+    templates = await _load_strength_templates(db)
+    race_goal = await _load_race_goal(db)
+
+    # Prompt bauen und KI aufrufen
+    system_prompt = _build_system_prompt(race_goal, target_week)
+    user_prompt = _build_user_prompt(recommendations, existing, templates)
+    api_key = await resolve_claude_api_key(db)
+
+    t0 = time.monotonic()
+    raw = await ai_service.chat(user_prompt, {"system_prompt": system_prompt}, api_key)
+    duration_ms = int((time.monotonic() - t0) * 1000)
+    provider = ai_service.get_active_provider() or "unknown"
+
+    # Parsen und mergen
+    new_sessions = _parse_sessions(raw)
+    merged = _merge_into_plan(existing, new_sessions)
+
+    # Log
+    await log_ai_call(
+        db,
+        AICallData(
+            use_case="apply_recommendations",
+            provider=provider,
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            raw_response=raw,
+            parsed_ok=len(new_sessions) > 0,
+            duration_ms=duration_ms,
+        ),
+    )
+    await db.commit()
+
+    return {
+        "target_week_start": str(target_week),
+        "entries": [e.model_dump() for e in merged],
+        "applied_count": len(new_sessions),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Kontext laden
+# ---------------------------------------------------------------------------
+
+
+async def _load_existing_entries(week_start: date, db: AsyncSession) -> list[dict]:
+    """Lädt bestehende Plan-Tage als kompakte Dicts."""
+    result = await db.execute(
+        select(WeeklyPlanDayModel)
+        .where(WeeklyPlanDayModel.week_start == week_start)
+        .order_by(WeeklyPlanDayModel.day_of_week)
+    )
+    days = result.scalars().all()
+    entries = []
+    for d in days:
+        entries.append(
+            {
+                "day_of_week": int(d.day_of_week),
+                "is_rest_day": bool(d.is_rest_day),
+                "has_sessions": True,  # Vereinfachung — Tag existiert = hat Inhalt
+            }
+        )
+    return entries
+
+
+async def _load_strength_templates(db: AsyncSession) -> list[dict]:
+    """Lädt verfügbare Kraft-Templates (Name + ID)."""
+    result = await db.execute(select(SessionTemplateModel.id, SessionTemplateModel.name).limit(20))
+    return [{"id": row.id, "name": str(row.name)} for row in result.all()]
+
+
+async def _load_race_goal(db: AsyncSession) -> dict | None:
+    """Lädt das aktive Wettkampfziel."""
+    result = await db.execute(
+        select(RaceGoalModel).where(RaceGoalModel.is_active.is_(True)).limit(1)
+    )
+    goal = result.scalar_one_or_none()
+    if not goal:
+        return None
+    return {
+        "title": goal.title,
+        "date": str(goal.race_date.date() if hasattr(goal.race_date, "date") else goal.race_date),
+        "distance_km": goal.distance_km,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Prompt-Builder
+# ---------------------------------------------------------------------------
+
+
+def _build_system_prompt(race_goal: dict | None, target_week: date) -> str:
+    """System-Prompt für Empfehlungs-Konvertierung."""
+    parts = [
+        "Du bist ein Trainingsplaner.",
+        "Deine Aufgabe: Konvertiere natürlichsprachige Trainingsempfehlungen in "
+        "strukturierte Plan-Sessions (JSON).",
+        "",
+        "Gültige Lauf-Typen (run_type):",
+        ", ".join(VALID_RUN_TYPES),
+        "",
+        "Trainingstypen (training_type): 'running' oder 'strength'",
+        "",
+        f"Zielwoche: {target_week.strftime('%d.%m.%Y')} – "
+        f"{(target_week + timedelta(days=6)).strftime('%d.%m.%Y')}",
+    ]
+
+    if race_goal:
+        parts.append("")
+        parts.append(f"Wettkampfziel: {race_goal['title']} ({race_goal['distance_km']} km)")
+        parts.append(f"Wettkampfdatum: {race_goal['date']}")
+
+    return "\n".join(parts)
+
+
+def _build_user_prompt(
+    recommendations: list[str],
+    existing: list[dict],
+    templates: list[dict],
+) -> str:
+    """User-Prompt mit Empfehlungen und Kontext."""
+    parts: list[str] = []
+
+    parts.append("## Empfehlungen zum Konvertieren")
+    for i, rec in enumerate(recommendations, 1):
+        parts.append(f"{i}. {rec}")
+
+    # Belegte Tage
+    if existing:
+        parts.append("")
+        parts.append("## Bereits belegte Tage (NICHT belegen)")
+        for e in existing:
+            day_name = DAY_NAMES[e["day_of_week"]]
+            status = "Ruhetag" if e["is_rest_day"] else "hat Sessions"
+            parts.append(f"- {day_name} ({status})")
+
+    # Freie Tage
+    occupied = {e["day_of_week"] for e in existing}
+    free_days = [DAY_NAMES[d] for d in range(7) if d not in occupied]
+    if free_days:
+        parts.append("")
+        parts.append(f"## Freie Tage: {', '.join(free_days)}")
+
+    # Kraft-Templates
+    if templates:
+        parts.append("")
+        parts.append("## Verfügbare Kraft-Templates")
+        for t in templates:
+            parts.append(f"- ID {t['id']}: {t['name']}")
+
+    parts.append("")
+    parts.append(_build_instructions())
+
+    return "\n".join(parts)
+
+
+def _build_instructions() -> str:
+    """JSON-Anweisungen."""
+    return """## Anweisungen
+Konvertiere die Empfehlungen in Plan-Sessions. Antworte NUR mit einem JSON-Array (ohne Markdown-Codeblock):
+
+[
+  {
+    "day_of_week": 0,
+    "training_type": "running",
+    "run_details": {
+      "run_type": "easy",
+      "target_duration_minutes": 45,
+      "target_pace_min": "6:30",
+      "target_pace_max": "7:00"
+    },
+    "notes": "Lockerer Lauf zur Erholung"
+  }
+]
+
+Regeln:
+- day_of_week: 0=Montag bis 6=Sonntag — NUR freie Tage verwenden
+- training_type: "running" oder "strength"
+- Bei Lauf: run_details mit run_type (aus der gültigen Liste), Dauer, Pace
+- Bei Kraft: template_id setzen falls passend, sonst weglassen
+- notes: Kurze Erklärung der Empfehlung
+- Pace im Format "M:SS" (z.B. "5:30")
+- target_pace_min = schnellere Pace, target_pace_max = langsamere Pace
+- Ignoriere Empfehlungen die keine konkreten Sessions sind (z.B. "mehr schlafen")
+- Maximal eine Session pro Tag"""
+
+
+# ---------------------------------------------------------------------------
+# JSON-Parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_sessions(raw: str) -> list[dict]:
+    """Parst KI-Antwort als JSON-Array von Sessions."""
+    text = raw.strip()
+
+    # Markdown-Codeblock entfernen
+    if text.startswith("```"):
+        lines = text.split("\n")
+        text = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        logger.warning("Apply-Recommendations JSON konnte nicht geparst werden: %s", text[:200])
+        return []
+
+    if not isinstance(data, list):
+        return []
+
+    valid: list[dict] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        session = _normalize_session(item)
+        if session:
+            valid.append(session)
+
+    return valid
+
+
+def _parse_run_details_from_ai(rd_raw: object) -> dict:
+    """Parst run_details aus der KI-Antwort."""
+    if not isinstance(rd_raw, dict):
+        return {"run_type": "easy"}
+
+    run_type = str(rd_raw.get("run_type", "easy")).lower()
+    if run_type not in SESSION_TYPES:
+        run_type = "easy"
+
+    details: dict = {"run_type": run_type}
+    if rd_raw.get("target_duration_minutes"):
+        dur = int(rd_raw["target_duration_minutes"])
+        if 5 <= dur <= 360:
+            details["target_duration_minutes"] = dur
+    if rd_raw.get("target_pace_min"):
+        details["target_pace_min"] = str(rd_raw["target_pace_min"])
+    if rd_raw.get("target_pace_max"):
+        details["target_pace_max"] = str(rd_raw["target_pace_max"])
+
+    return details
+
+
+def _normalize_session(item: dict) -> dict | None:
+    """Normalisiert und validiert eine einzelne Session."""
+    day = item.get("day_of_week")
+    if not isinstance(day, int) or day < 0 or day > 6:
+        return None
+
+    training_type = str(item.get("training_type", "")).lower()
+    if training_type not in ("running", "strength"):
+        return None
+
+    result: dict = {
+        "day_of_week": day,
+        "training_type": training_type,
+    }
+
+    if item.get("notes"):
+        result["notes"] = str(item["notes"])[:500]
+
+    if training_type == "running":
+        result["run_details"] = _parse_run_details_from_ai(item.get("run_details", {}))
+
+    if training_type == "strength" and item.get("template_id"):
+        with contextlib.suppress(ValueError, TypeError):
+            result["template_id"] = int(item["template_id"])
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Merge
+# ---------------------------------------------------------------------------
+
+
+def _merge_into_plan(
+    existing: list[dict],
+    new_sessions: list[dict],
+) -> list[WeeklyPlanEntry]:
+    """Merged neue Sessions in den bestehenden 7-Tage-Plan."""
+    occupied = {e["day_of_week"] for e in existing}
+
+    # Bestehende Tage als Entries (mit is_rest_day)
+    existing_map: dict[int, dict] = {e["day_of_week"]: e for e in existing}
+
+    # Neue Sessions einfügen (nur auf freie Tage)
+    new_by_day: dict[int, dict] = {}
+    for s in new_sessions:
+        day = s["day_of_week"]
+        if day in occupied:
+            # Freien Tag suchen
+            day = _find_free_day(occupied | set(new_by_day.keys()), day)
+            if day is None:
+                continue
+        new_by_day[day] = s
+
+    # 7-Tage-Plan bauen
+    entries: list[WeeklyPlanEntry] = []
+    for dow in range(7):
+        if dow in existing_map:
+            # Bestehender Tag — unverändert lassen (leerer Platzhalter)
+            e = existing_map[dow]
+            entries.append(
+                WeeklyPlanEntry(
+                    day_of_week=dow,
+                    is_rest_day=e.get("is_rest_day", False),
+                )
+            )
+        elif dow in new_by_day:
+            s = new_by_day[dow]
+            sessions = [_dict_to_planned_session(s, position=0)]
+            entries.append(
+                WeeklyPlanEntry(
+                    day_of_week=dow,
+                    sessions=sessions,
+                )
+            )
+        else:
+            entries.append(WeeklyPlanEntry(day_of_week=dow))
+
+    return entries
+
+
+def _find_free_day(occupied: set[int], preferred: int) -> int | None:
+    """Sucht den nächsten freien Tag ab preferred."""
+    for offset in range(1, 7):
+        candidate = (preferred + offset) % 7
+        if candidate not in occupied:
+            return candidate
+    return None
+
+
+def _dict_to_planned_session(s: dict, position: int) -> PlannedSession:
+    """Konvertiert ein normalisiertes Dict in ein PlannedSession-Objekt."""
+    rd = None
+    if s.get("run_details"):
+        rd = RunDetails(**s["run_details"])
+
+    return PlannedSession(
+        position=position,
+        training_type=s["training_type"],
+        template_id=s.get("template_id"),
+        notes=s.get("notes"),
+        run_details=rd,
+    )

--- a/backend/app/tests/test_recommendation_to_plan.py
+++ b/backend/app/tests/test_recommendation_to_plan.py
@@ -1,0 +1,249 @@
+"""Tests für recommendation_to_plan_service."""
+
+import json
+from datetime import date
+
+from app.services.recommendation_to_plan_service import (
+    _build_instructions,
+    _build_system_prompt,
+    _build_user_prompt,
+    _find_free_day,
+    _merge_into_plan,
+    _normalize_session,
+    _parse_run_details_from_ai,
+    _parse_sessions,
+)
+
+# ---------------------------------------------------------------------------
+# _parse_run_details_from_ai
+# ---------------------------------------------------------------------------
+
+
+class TestParseRunDetailsFromAI:
+    def test_valid_details(self) -> None:
+        rd = _parse_run_details_from_ai(
+            {
+                "run_type": "easy",
+                "target_duration_minutes": 45,
+                "target_pace_min": "6:30",
+                "target_pace_max": "7:00",
+            }
+        )
+        assert rd["run_type"] == "easy"
+        assert rd["target_duration_minutes"] == 45
+        assert rd["target_pace_min"] == "6:30"
+
+    def test_invalid_run_type_falls_back_to_easy(self) -> None:
+        rd = _parse_run_details_from_ai({"run_type": "sprint"})
+        assert rd["run_type"] == "easy"
+
+    def test_non_dict_returns_default(self) -> None:
+        rd = _parse_run_details_from_ai("not a dict")
+        assert rd == {"run_type": "easy"}
+
+    def test_duration_out_of_range_ignored(self) -> None:
+        rd = _parse_run_details_from_ai({"run_type": "easy", "target_duration_minutes": 500})
+        assert "target_duration_minutes" not in rd
+
+
+# ---------------------------------------------------------------------------
+# _normalize_session
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeSession:
+    def test_valid_running_session(self) -> None:
+        result = _normalize_session(
+            {
+                "day_of_week": 1,
+                "training_type": "running",
+                "run_details": {"run_type": "tempo", "target_duration_minutes": 40},
+                "notes": "Tempo-Lauf",
+            }
+        )
+        assert result is not None
+        assert result["day_of_week"] == 1
+        assert result["training_type"] == "running"
+        assert result["run_details"]["run_type"] == "tempo"
+        assert result["notes"] == "Tempo-Lauf"
+
+    def test_valid_strength_session(self) -> None:
+        result = _normalize_session(
+            {
+                "day_of_week": 3,
+                "training_type": "strength",
+                "template_id": 5,
+            }
+        )
+        assert result is not None
+        assert result["training_type"] == "strength"
+        assert result["template_id"] == 5
+
+    def test_invalid_day_returns_none(self) -> None:
+        assert _normalize_session({"day_of_week": 7, "training_type": "running"}) is None
+        assert _normalize_session({"day_of_week": -1, "training_type": "running"}) is None
+        assert _normalize_session({"day_of_week": "Mon", "training_type": "running"}) is None
+
+    def test_invalid_training_type_returns_none(self) -> None:
+        assert _normalize_session({"day_of_week": 0, "training_type": "yoga"}) is None
+
+    def test_notes_truncated(self) -> None:
+        result = _normalize_session(
+            {
+                "day_of_week": 0,
+                "training_type": "running",
+                "notes": "x" * 600,
+            }
+        )
+        assert result is not None
+        assert len(result["notes"]) == 500
+
+    def test_invalid_template_id_ignored(self) -> None:
+        result = _normalize_session(
+            {
+                "day_of_week": 0,
+                "training_type": "strength",
+                "template_id": "abc",
+            }
+        )
+        assert result is not None
+        assert "template_id" not in result
+
+
+# ---------------------------------------------------------------------------
+# _parse_sessions
+# ---------------------------------------------------------------------------
+
+
+class TestParseSessions:
+    def test_valid_json_array(self) -> None:
+        raw = json.dumps(
+            [
+                {"day_of_week": 0, "training_type": "running", "run_details": {"run_type": "easy"}},
+                {"day_of_week": 2, "training_type": "strength"},
+            ]
+        )
+        sessions = _parse_sessions(raw)
+        assert len(sessions) == 2
+
+    def test_markdown_codeblock_stripped(self) -> None:
+        raw = '```json\n[{"day_of_week": 0, "training_type": "running"}]\n```'
+        sessions = _parse_sessions(raw)
+        assert len(sessions) == 1
+
+    def test_invalid_json_returns_empty(self) -> None:
+        assert _parse_sessions("not json") == []
+
+    def test_non_array_returns_empty(self) -> None:
+        assert _parse_sessions('{"key": "value"}') == []
+
+    def test_invalid_items_filtered(self) -> None:
+        raw = json.dumps(
+            [
+                {"day_of_week": 0, "training_type": "running"},
+                {"day_of_week": 99, "training_type": "running"},  # ungültig
+                "not a dict",
+            ]
+        )
+        sessions = _parse_sessions(raw)
+        assert len(sessions) == 1
+
+
+# ---------------------------------------------------------------------------
+# _find_free_day
+# ---------------------------------------------------------------------------
+
+
+class TestFindFreeDay:
+    def test_finds_next_free_day(self) -> None:
+        assert _find_free_day({0, 1, 2}, 0) == 3
+
+    def test_wraps_around(self) -> None:
+        assert _find_free_day({4, 5, 6}, 5) == 0
+
+    def test_no_free_day_returns_none(self) -> None:
+        assert _find_free_day({0, 1, 2, 3, 4, 5, 6}, 0) is None
+
+
+# ---------------------------------------------------------------------------
+# _merge_into_plan
+# ---------------------------------------------------------------------------
+
+
+class TestMergeIntoPlan:
+    def test_new_sessions_on_free_days(self) -> None:
+        existing = [{"day_of_week": 0, "is_rest_day": False}]
+        new_sessions = [
+            {"day_of_week": 1, "training_type": "running", "run_details": {"run_type": "easy"}}
+        ]
+        merged = _merge_into_plan(existing, new_sessions)
+        assert len(merged) == 7
+        assert len(merged[1].sessions) == 1
+
+    def test_occupied_day_redirected(self) -> None:
+        existing = [{"day_of_week": 0, "is_rest_day": False}]
+        new_sessions = [
+            {"day_of_week": 0, "training_type": "running", "run_details": {"run_type": "easy"}}
+        ]
+        merged = _merge_into_plan(existing, new_sessions)
+        # Tag 0 ist belegt → Session wird auf nächsten freien Tag verschoben
+        assert len(merged[0].sessions) == 0
+        # Irgendein anderer Tag hat die Session
+        placed = [e for e in merged if len(e.sessions) > 0]
+        assert len(placed) == 1
+
+    def test_all_days_occupied_skips_session(self) -> None:
+        existing = [{"day_of_week": d, "is_rest_day": False} for d in range(7)]
+        new_sessions = [
+            {"day_of_week": 0, "training_type": "running", "run_details": {"run_type": "easy"}}
+        ]
+        merged = _merge_into_plan(existing, new_sessions)
+        placed = [e for e in merged if len(e.sessions) > 0]
+        assert len(placed) == 0
+
+    def test_empty_days_stay_empty(self) -> None:
+        merged = _merge_into_plan([], [])
+        assert len(merged) == 7
+        for entry in merged:
+            assert len(entry.sessions) == 0
+
+
+# ---------------------------------------------------------------------------
+# Prompt-Builder
+# ---------------------------------------------------------------------------
+
+
+class TestPromptBuilders:
+    def test_system_prompt_includes_valid_run_types(self) -> None:
+        prompt = _build_system_prompt(None, date(2026, 3, 23))
+        assert "easy" in prompt
+        assert "intervals" in prompt
+        assert "Trainingsplaner" in prompt
+
+    def test_system_prompt_with_race_goal(self) -> None:
+        goal = {"title": "Halbmarathon", "distance_km": 21.1, "date": "2026-03-29"}
+        prompt = _build_system_prompt(goal, date(2026, 3, 23))
+        assert "Halbmarathon" in prompt
+        assert "21.1" in prompt
+
+    def test_user_prompt_includes_recommendations(self) -> None:
+        recs = ["Mehr Tempo-Läufe einbauen", "Kraft-Training 2x pro Woche"]
+        prompt = _build_user_prompt(recs, [], [])
+        assert "Mehr Tempo-Läufe" in prompt
+        assert "Kraft-Training" in prompt
+
+    def test_user_prompt_shows_occupied_days(self) -> None:
+        existing = [{"day_of_week": 0, "is_rest_day": False}]
+        prompt = _build_user_prompt(["Test"], existing, [])
+        assert "Montag" in prompt
+        assert "NICHT belegen" in prompt
+
+    def test_user_prompt_shows_templates(self) -> None:
+        templates = [{"id": 1, "name": "Oberkörper"}]
+        prompt = _build_user_prompt(["Test"], [], templates)
+        assert "Oberkörper" in prompt
+
+    def test_instructions_format(self) -> None:
+        instructions = _build_instructions()
+        assert "JSON-Array" in instructions
+        assert "day_of_week" in instructions

--- a/frontend/src/api/weekly-plan.ts
+++ b/frontend/src/api/weekly-plan.ts
@@ -148,6 +148,19 @@ export interface SyncToPlanResponse {
   synced_days: number;
 }
 
+// --- Apply Recommendations Types ---
+
+export interface ApplyRecommendationsRequest {
+  week_start: string;
+  recommendations: string[];
+}
+
+export interface ApplyRecommendationsResponse {
+  target_week_start: string;
+  entries: WeeklyPlanEntry[];
+  applied_count: number;
+}
+
 // --- Planned Session Option (for upload linking) ---
 
 export interface PlannedSessionOption {
@@ -206,6 +219,16 @@ export async function getCompliance(weekStart?: string): Promise<ComplianceRespo
     : '/api/v1/weekly-plan/compliance';
 
   const response = await apiClient.get<ComplianceResponse>(url);
+  return response.data;
+}
+
+export async function applyRecommendations(
+  data: ApplyRecommendationsRequest,
+): Promise<ApplyRecommendationsResponse> {
+  const response = await apiClient.post<ApplyRecommendationsResponse>(
+    '/api/v1/weekly-plan/apply-recommendations',
+    data,
+  );
   return response.data;
 }
 

--- a/frontend/src/components/WeeklyReviewSection.tsx
+++ b/frontend/src/components/WeeklyReviewSection.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useCallback, useState } from 'react';
-import { Card, CardBody, Button, Badge, Spinner } from '@nordlig/components';
+import {
+  Card,
+  CardBody,
+  Button,
+  Badge,
+  Spinner,
+  Alert,
+  AlertDescription,
+} from '@nordlig/components';
 import {
   Sparkles,
   RefreshCw,
@@ -11,8 +19,10 @@ import {
   Activity,
   Gauge,
   Calendar,
+  CalendarPlus,
 } from 'lucide-react';
 import type { WeeklyReview, OverallRating, FatigueLevel } from '@/api/training';
+import { applyRecommendations } from '@/api/weekly-plan';
 import { useWeeklyReview } from '@/hooks/useWeeklyReview';
 
 // --- Config ---
@@ -118,20 +128,75 @@ function ListItems({
   );
 }
 
+function ApplySection({
+  applying,
+  applyError,
+  appliedCount,
+  onApply,
+}: {
+  applying: boolean;
+  applyError: string | null;
+  appliedCount: number | null;
+  onApply: () => void;
+}) {
+  return (
+    <div className="pt-2 border-t border-[var(--color-border-muted)] space-y-2">
+      {applyError && (
+        <Alert variant="error">
+          <AlertDescription>{applyError}</AlertDescription>
+        </Alert>
+      )}
+      {appliedCount !== null && appliedCount > 0 && (
+        <Alert variant="success">
+          <AlertDescription>
+            {appliedCount} {appliedCount === 1 ? 'Empfehlung' : 'Empfehlungen'} in den Plan der
+            nächsten Woche übernommen.
+          </AlertDescription>
+        </Alert>
+      )}
+      {appliedCount === null && (
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={onApply}
+          disabled={applying}
+          className="w-full"
+        >
+          {applying ? (
+            <Spinner size="sm" className="mr-1.5" />
+          ) : (
+            <CalendarPlus className="w-4 h-4 mr-1.5" />
+          )}
+          {applying ? 'Wird übernommen…' : 'In Wochenplan übernehmen'}
+        </Button>
+      )}
+    </div>
+  );
+}
+
 function ReviewBody({
   review,
   loading,
   error,
+  applying,
+  applyError,
+  appliedCount,
   onRefresh,
+  onApply,
 }: {
   review: WeeklyReview;
   loading: boolean;
   error: string | null;
+  applying: boolean;
+  applyError: string | null;
+  appliedCount: number | null;
   onRefresh: () => void;
+  onApply: () => void;
 }) {
   const rating = ratingConfig[review.overall_rating] ?? ratingConfig.moderate;
   const fatigue = fatigueConfig[review.fatigue_assessment] ?? fatigueConfig.moderate;
   const RatingIcon = rating.icon;
+  const hasRecommendations = review.next_week_recommendations.length > 0;
 
   return (
     <>
@@ -183,6 +248,16 @@ function ReviewBody({
           items={review.next_week_recommendations}
           icon={Lightbulb}
         />
+
+        {/* In Plan übernehmen */}
+        {hasRecommendations && (
+          <ApplySection
+            applying={applying}
+            applyError={applyError}
+            appliedCount={appliedCount}
+            onApply={onApply}
+          />
+        )}
       </div>
     </>
   );
@@ -190,13 +265,26 @@ function ReviewBody({
 
 // --- Hauptkomponente ---
 
-export function WeeklyReviewSection({ weekStart }: { weekStart: string }) {
+interface WeeklyReviewSectionProps {
+  weekStart: string;
+  onRecommendationsApplied?: () => void;
+}
+
+export function WeeklyReviewSection({
+  weekStart,
+  onRecommendationsApplied,
+}: WeeklyReviewSectionProps) {
   const { review, loading, error, generate, fetch: fetchReview } = useWeeklyReview();
   const [initialized, setInitialized] = useState(false);
+  const [applying, setApplying] = useState(false);
+  const [applyError, setApplyError] = useState<string | null>(null);
+  const [appliedCount, setAppliedCount] = useState<number | null>(null);
 
   const handleFetch = useCallback(
     async (ws: string) => {
       setInitialized(true);
+      setAppliedCount(null);
+      setApplyError(null);
       await fetchReview(ws);
     },
     [fetchReview],
@@ -207,12 +295,35 @@ export function WeeklyReviewSection({ weekStart }: { weekStart: string }) {
   }, [weekStart]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleGenerate = useCallback(() => {
+    setAppliedCount(null);
+    setApplyError(null);
     generate(weekStart, false);
   }, [generate, weekStart]);
 
   const handleRefresh = useCallback(() => {
+    setAppliedCount(null);
+    setApplyError(null);
     generate(weekStart, true);
   }, [generate, weekStart]);
+
+  const handleApply = useCallback(async () => {
+    if (!review?.next_week_recommendations.length) return;
+
+    setApplying(true);
+    setApplyError(null);
+    try {
+      const result = await applyRecommendations({
+        week_start: weekStart,
+        recommendations: review.next_week_recommendations,
+      });
+      setAppliedCount(result.applied_count);
+      onRecommendationsApplied?.();
+    } catch {
+      setApplyError('Empfehlungen konnten nicht übernommen werden.');
+    } finally {
+      setApplying(false);
+    }
+  }, [review, weekStart, onRecommendationsApplied]);
 
   return (
     <Card elevation="raised">
@@ -229,7 +340,16 @@ export function WeeklyReviewSection({ weekStart }: { weekStart: string }) {
         )}
 
         {review && (
-          <ReviewBody review={review} loading={loading} error={error} onRefresh={handleRefresh} />
+          <ReviewBody
+            review={review}
+            loading={loading}
+            error={error}
+            applying={applying}
+            applyError={applyError}
+            appliedCount={appliedCount}
+            onRefresh={handleRefresh}
+            onApply={handleApply}
+          />
         )}
       </CardBody>
     </Card>

--- a/frontend/src/pages/WeeklyPlan.tsx
+++ b/frontend/src/pages/WeeklyPlan.tsx
@@ -324,7 +324,10 @@ export function WeeklyPlanPage() {
       </Card>
 
       {/* KI-Review */}
-      <WeeklyReviewSection weekStart={plan.weekStart} />
+      <WeeklyReviewSection
+        weekStart={plan.weekStart}
+        onRecommendationsApplied={() => plan.loadWeek(plan.weekStart)}
+      />
 
       {/* Delete Dialog */}
       <AlertDialog open={plan.showDeleteDialog} onOpenChange={plan.setShowDeleteDialog}>


### PR DESCRIPTION
## Summary
- Neuer Backend-Service `recommendation_to_plan_service.py` konvertiert Freitext-Empfehlungen aus dem Wochen-Review via KI-Call in strukturierte `PlannedSession`-Objekte
- API-Endpoint `POST /api/v1/weekly-plan/apply-recommendations` mit Pydantic Request/Response Models
- Frontend: „In Wochenplan übernehmen"-Button in der WeeklyReviewSection mit Lade-/Erfolgs-/Fehlerzuständen
- Nach Apply wird der Wochenplan automatisch neu geladen
- 28 Backend-Tests für Parsing, Normalisierung, Merge-Logik, Prompt-Builder

## Test plan
- [ ] Review generieren und „In Wochenplan übernehmen" klicken
- [ ] Prüfen, dass Sessions in der Folgewoche auf freien Tagen erscheinen
- [ ] Prüfen, dass belegte Tage nicht überschrieben werden
- [ ] Prüfen, dass Erfolgs-Alert nach Apply angezeigt wird
- [ ] Fehlerfall testen (z.B. API-Key fehlt)

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)