### PR TITLE
fix: SPA Warmup Retry-Logik für Deploy-Verifikation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,31 +265,46 @@ jobs:
           PROD_URL: http://training.89.167.78.223.sslip.io
         run: |
           echo "Lade SPA-Routen vor um JS-Bundle-Caching sicherzustellen..."
-          FAILED=false
 
-          # Lade index.html und prüfe ob JS-Bundles referenziert werden
-          HTML=$(curl -s "$PROD_URL/" --max-time 15)
-          JS_ASSETS=$(echo "$HTML" | grep -oE 'src="/assets/[^"]+\.js"' | head -5)
-          if [ -z "$JS_ASSETS" ]; then
-            echo "::warning::Keine JS-Assets in index.html gefunden"
-          else
-            echo "JS-Assets gefunden:"
-            echo "$JS_ASSETS"
+          # Retry-Logik: JS-Bundles können nach Deploy kurz verzögert sein
+          BUNDLES_OK=false
+          for attempt in 1 2 3 4 5; do
+            echo ""
+            echo "--- Versuch $attempt/5 ---"
+            FAILED=false
 
-            # Prüfe ob die JS-Bundles tatsächlich ladbar sind
-            for asset in $(echo "$HTML" | grep -oE '/assets/[^"]+\.js' | head -5); do
-              HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$PROD_URL$asset" --max-time 10 2>/dev/null || echo "000")
-              if [ "$HTTP_CODE" = "200" ]; then
-                echo "  ✓ $asset"
-              else
-                echo "  ✗ $asset (HTTP $HTTP_CODE)"
-                FAILED=true
-              fi
-            done
-          fi
+            HTML=$(curl -s "$PROD_URL/" --max-time 15)
+            JS_ASSETS=$(echo "$HTML" | grep -oE '/assets/[^"]+\.js' | head -5)
 
-          if [ "$FAILED" = "true" ]; then
-            echo "::error::Nicht alle JS-Bundles erreichbar — Frontend noch nicht bereit"
+            if [ -z "$JS_ASSETS" ]; then
+              echo "Keine JS-Assets in index.html gefunden"
+              FAILED=true
+            else
+              for asset in $JS_ASSETS; do
+                HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$PROD_URL$asset" --max-time 10 2>/dev/null || echo "000")
+                if [ "$HTTP_CODE" = "200" ]; then
+                  echo "  ✓ $asset"
+                else
+                  echo "  ✗ $asset (HTTP $HTTP_CODE)"
+                  FAILED=true
+                fi
+              done
+            fi
+
+            if [ "$FAILED" = "false" ]; then
+              BUNDLES_OK=true
+              echo "Alle JS-Bundles erreichbar"
+              break
+            fi
+
+            if [ "$attempt" -lt 5 ]; then
+              echo "Warte 15s vor nächstem Versuch..."
+              sleep 15
+            fi
+          done
+
+          if [ "$BUNDLES_OK" = "false" ]; then
+            echo "::error::JS-Bundles nach 5 Versuchen nicht erreichbar"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- Frontend SPA Warmup im CI mit Retry-Logik (5 Versuche, je 15s Pause) statt sofortigem Fail
- JS-Bundles können nach Coolify-Deploy kurz verzögert verfügbar sein

Fixes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)