### PR TITLE
fix: Apply-Recommendations passt bestehenden Plan an (#328)

### DIFF
--- a/backend/app/services/recommendation_to_plan_service.py
+++ b/backend/app/services/recommendation_to_plan_service.py
@@ -1,8 +1,8 @@
-"""Service: Konvertiert KI-Review-Empfehlungen in strukturierte Plan-Sessions.
+"""Service: Passt den bestehenden Wochenplan anhand von KI-Review-Empfehlungen an.
 
-Nimmt Freitext-Empfehlungen aus dem Wochen-Review und konvertiert sie via
-KI-Call in strukturierte WeeklyPlanEntry-Objekte, die in den Wochenplan
-der Folgewoche eingefügt werden können.
+Nimmt Freitext-Empfehlungen aus dem Wochen-Review und lässt die KI den
+bestehenden Plan der Folgewoche entsprechend anpassen — Sessions werden
+modifiziert, hinzugefügt oder entfernt.
 """
 
 import contextlib
@@ -37,14 +37,14 @@ async def apply_recommendations(
     recommendations: list[str],
     db: AsyncSession,
 ) -> dict:
-    """Konvertiert Empfehlungen in Plan-Sessions für die Folgewoche.
+    """Passt den Plan der Folgewoche anhand von Empfehlungen an.
 
     Returns dict with: target_week_start, entries (list[WeeklyPlanEntry]), applied_count.
     """
     target_week = review_week_start + timedelta(days=7)
 
-    # Bestehenden Plan laden
-    existing = await _load_existing_entries(target_week, db)
+    # Bestehenden Plan mit vollen Details laden
+    existing_plan = await _load_full_plan(target_week, db)
 
     # Kontext laden
     templates = await _load_strength_templates(db)
@@ -52,7 +52,7 @@ async def apply_recommendations(
 
     # Prompt bauen und KI aufrufen
     system_prompt = _build_system_prompt(race_goal, target_week)
-    user_prompt = _build_user_prompt(recommendations, existing, templates)
+    user_prompt = _build_user_prompt(recommendations, existing_plan, templates)
     api_key = await resolve_claude_api_key(db)
 
     t0 = time.monotonic()
@@ -60,12 +60,13 @@ async def apply_recommendations(
     duration_ms = int((time.monotonic() - t0) * 1000)
     provider = ai_service.get_active_provider() or "unknown"
 
-    # Parsen und mergen
-    new_sessions = _parse_sessions(raw)
-    merged = _merge_into_plan(existing, new_sessions)
+    # KI-Antwort parsen → vollständiger 7-Tage-Plan
+    ai_days = _parse_plan(raw)
+    entries = _build_entries(ai_days)
 
-    # Neue Sessions in DB persistieren
-    await _persist_new_sessions(target_week, existing, new_sessions, db)
+    # Bestehende Einträge löschen und neue persistieren
+    if ai_days:
+        await _replace_plan(target_week, existing_plan, ai_days, db)
 
     # Log
     await log_ai_call(
@@ -76,7 +77,7 @@ async def apply_recommendations(
             system_prompt=system_prompt,
             user_prompt=user_prompt,
             raw_response=raw,
-            parsed_ok=len(new_sessions) > 0,
+            parsed_ok=len(ai_days) > 0,
             duration_ms=duration_ms,
         ),
     )
@@ -84,34 +85,61 @@ async def apply_recommendations(
 
     return {
         "target_week_start": str(target_week),
-        "entries": [e.model_dump() for e in merged],
-        "applied_count": len(new_sessions),
+        "entries": [e.model_dump() for e in entries],
+        "applied_count": len([d for d in ai_days if not d.get("is_rest_day", False)]),
     }
 
 
 # ---------------------------------------------------------------------------
-# Kontext laden
+# Plan laden (mit vollen Session-Details)
 # ---------------------------------------------------------------------------
 
 
-async def _load_existing_entries(week_start: date, db: AsyncSession) -> list[dict]:
-    """Lädt bestehende Plan-Tage als kompakte Dicts."""
-    result = await db.execute(
+async def _load_full_plan(week_start: date, db: AsyncSession) -> list[dict]:
+    """Lädt den bestehenden Plan mit vollen Session-Details für den KI-Prompt."""
+    day_result = await db.execute(
         select(WeeklyPlanDayModel)
         .where(WeeklyPlanDayModel.week_start == week_start)
         .order_by(WeeklyPlanDayModel.day_of_week)
     )
-    days = result.scalars().all()
-    entries = []
+    days = day_result.scalars().all()
+    if not days:
+        return []
+
+    day_ids = [d.id for d in days]
+    session_result = await db.execute(
+        select(PlannedSessionModel)
+        .where(PlannedSessionModel.day_id.in_(day_ids))
+        .order_by(PlannedSessionModel.day_id, PlannedSessionModel.position)
+    )
+    sessions_by_day: dict[int, list[PlannedSessionModel]] = {}
+    for s in session_result.scalars().all():
+        sessions_by_day.setdefault(s.day_id, []).append(s)
+
+    plan: list[dict] = []
     for d in days:
-        entries.append(
-            {
-                "day_of_week": int(d.day_of_week),
-                "is_rest_day": bool(d.is_rest_day),
-                "has_sessions": True,  # Vereinfachung — Tag existiert = hat Inhalt
+        day_sessions = sessions_by_day.get(d.id, [])
+        entry: dict = {
+            "day_of_week": int(d.day_of_week),
+            "is_rest_day": bool(d.is_rest_day),
+            "notes": d.notes,
+            "plan_id": d.plan_id,
+            "sessions": [],
+        }
+        for s in day_sessions:
+            sess: dict = {
+                "training_type": s.training_type,
+                "notes": s.notes,
             }
-        )
-    return entries
+            if s.run_details_json:
+                with contextlib.suppress(json.JSONDecodeError):
+                    sess["run_details"] = json.loads(s.run_details_json)
+            if s.template_id:
+                sess["template_id"] = s.template_id
+            entry["sessions"].append(sess)
+        plan.append(entry)
+
+    return plan
 
 
 async def _load_strength_templates(db: AsyncSession) -> list[dict]:
@@ -141,11 +169,11 @@ async def _load_race_goal(db: AsyncSession) -> dict | None:
 
 
 def _build_system_prompt(race_goal: dict | None, target_week: date) -> str:
-    """System-Prompt für Empfehlungs-Konvertierung."""
+    """System-Prompt für Plan-Anpassung."""
     parts = [
-        "Du bist ein Trainingsplaner.",
-        "Deine Aufgabe: Konvertiere natürlichsprachige Trainingsempfehlungen in "
-        "strukturierte Plan-Sessions (JSON).",
+        "Du bist ein erfahrener Trainingsplaner.",
+        "Deine Aufgabe: Passe einen bestehenden Wochenplan anhand von Empfehlungen an.",
+        "Du gibst den KOMPLETTEN angepassten 7-Tage-Plan als JSON zurück.",
         "",
         "Gültige Lauf-Typen (run_type):",
         ", ".join(VALID_RUN_TYPES),
@@ -166,31 +194,26 @@ def _build_system_prompt(race_goal: dict | None, target_week: date) -> str:
 
 def _build_user_prompt(
     recommendations: list[str],
-    existing: list[dict],
+    existing_plan: list[dict],
     templates: list[dict],
 ) -> str:
-    """User-Prompt mit Empfehlungen und Kontext."""
+    """User-Prompt mit bestehendem Plan und Empfehlungen."""
     parts: list[str] = []
 
-    parts.append("## Empfehlungen zum Konvertieren")
+    # Bestehender Plan
+    parts.append("## Aktueller Plan der Zielwoche")
+    if existing_plan:
+        for e in existing_plan:
+            day_name = DAY_NAMES[e["day_of_week"]]
+            parts.append(_format_plan_day(day_name, e))
+    else:
+        parts.append("Kein bestehender Plan vorhanden.")
+
+    # Empfehlungen
+    parts.append("")
+    parts.append("## Empfehlungen zur Anpassung")
     for i, rec in enumerate(recommendations, 1):
         parts.append(f"{i}. {rec}")
-
-    # Belegte Tage
-    if existing:
-        parts.append("")
-        parts.append("## Bereits belegte Tage (NICHT belegen)")
-        for e in existing:
-            day_name = DAY_NAMES[e["day_of_week"]]
-            status = "Ruhetag" if e["is_rest_day"] else "hat Sessions"
-            parts.append(f"- {day_name} ({status})")
-
-    # Freie Tage
-    occupied = {e["day_of_week"] for e in existing}
-    free_days = [DAY_NAMES[d] for d in range(7) if d not in occupied]
-    if free_days:
-        parts.append("")
-        parts.append(f"## Freie Tage: {', '.join(free_days)}")
 
     # Kraft-Templates
     if templates:
@@ -205,14 +228,51 @@ def _build_user_prompt(
     return "\n".join(parts)
 
 
+def _format_plan_day(day_name: str, entry: dict) -> str:
+    """Formatiert einen Plan-Tag für den Prompt."""
+    if entry["is_rest_day"]:
+        return f"- {day_name}: Ruhetag"
+
+    sessions = entry.get("sessions", [])
+    if not sessions:
+        return f"- {day_name}: (leer)"
+
+    session_parts: list[str] = []
+    for s in sessions:
+        tt = s.get("training_type", "?")
+        rd = s.get("run_details", {})
+        rt = rd.get("run_type", "") if rd else ""
+        dur = rd.get("target_duration_minutes", "") if rd else ""
+        notes = s.get("notes", "") or ""
+        desc = f"{tt}"
+        if rt:
+            desc += f" ({rt})"
+        if dur:
+            desc += f" {dur}min"
+        if notes:
+            desc += f" — {notes[:80]}"
+        session_parts.append(desc)
+
+    day_notes = entry.get("notes", "") or ""
+    line = f"- {day_name}: {'; '.join(session_parts)}"
+    if day_notes:
+        line += f" | Notiz: {day_notes[:80]}"
+    return line
+
+
 def _build_instructions() -> str:
-    """JSON-Anweisungen."""
+    """JSON-Anweisungen für die Plan-Anpassung."""
     return """## Anweisungen
-Konvertiere die Empfehlungen in Plan-Sessions. Antworte NUR mit einem JSON-Array (ohne Markdown-Codeblock):
+Passe den bestehenden Plan gemäß den Empfehlungen an. Antworte NUR mit einem JSON-Array \
+(ohne Markdown-Codeblock) für alle 7 Tage (0=Montag bis 6=Sonntag):
 
 [
   {
     "day_of_week": 0,
+    "is_rest_day": true
+  },
+  {
+    "day_of_week": 1,
     "training_type": "running",
     "run_details": {
       "run_type": "easy",
@@ -225,14 +285,16 @@ Konvertiere die Empfehlungen in Plan-Sessions. Antworte NUR mit einem JSON-Array
 ]
 
 Regeln:
-- day_of_week: 0=Montag bis 6=Sonntag — NUR freie Tage verwenden
-- training_type: "running" oder "strength"
+- Gib ALLE 7 Tage zurück (day_of_week 0-6), auch Ruhetage
+- Ruhetage: nur day_of_week + is_rest_day: true
+- Trainingstage: training_type + run_details/template_id + notes
+- Passe bestehende Sessions an (Umfang, Pace, Dauer, Typ), entferne oder füge hinzu
+- Behalte die Grundstruktur bei, wenn die Empfehlungen keine Änderung erfordern
 - Bei Lauf: run_details mit run_type (aus der gültigen Liste), Dauer, Pace
 - Bei Kraft: template_id setzen falls passend, sonst weglassen
-- notes: Kurze Erklärung der Empfehlung
+- notes: Kurze Erklärung was geändert wurde und warum
 - Pace im Format "M:SS" (z.B. "5:30")
 - target_pace_min = schnellere Pace, target_pace_max = langsamere Pace
-- Ignoriere Empfehlungen die keine konkreten Sessions sind (z.B. "mehr schlafen")
 - Maximal eine Session pro Tag"""
 
 
@@ -241,8 +303,8 @@ Regeln:
 # ---------------------------------------------------------------------------
 
 
-def _parse_sessions(raw: str) -> list[dict]:
-    """Parst KI-Antwort als JSON-Array von Sessions."""
+def _parse_plan(raw: str) -> list[dict]:
+    """Parst KI-Antwort als JSON-Array des kompletten 7-Tage-Plans."""
     text = raw.strip()
 
     # Markdown-Codeblock entfernen
@@ -263,14 +325,48 @@ def _parse_sessions(raw: str) -> list[dict]:
     for item in data:
         if not isinstance(item, dict):
             continue
-        session = _normalize_session(item)
-        if session:
-            valid.append(session)
+        day = _normalize_day(item)
+        if day:
+            valid.append(day)
 
     return valid
 
 
-def _parse_run_details_from_ai(rd_raw: object) -> dict:
+def _normalize_day(item: dict) -> dict | None:
+    """Normalisiert und validiert einen einzelnen Tag aus der KI-Antwort."""
+    day = item.get("day_of_week")
+    if not isinstance(day, int) or day < 0 or day > 6:
+        return None
+
+    # Ruhetag
+    if item.get("is_rest_day"):
+        return {"day_of_week": day, "is_rest_day": True}
+
+    training_type = str(item.get("training_type", "")).lower()
+    if training_type not in ("running", "strength"):
+        # Wenn kein gültiger training_type → als Ruhetag behandeln
+        return {"day_of_week": day, "is_rest_day": True}
+
+    result: dict = {
+        "day_of_week": day,
+        "is_rest_day": False,
+        "training_type": training_type,
+    }
+
+    if item.get("notes"):
+        result["notes"] = str(item["notes"])[:500]
+
+    if training_type == "running":
+        result["run_details"] = _parse_run_details(item.get("run_details", {}))
+
+    if training_type == "strength" and item.get("template_id"):
+        with contextlib.suppress(ValueError, TypeError):
+            result["template_id"] = int(item["template_id"])
+
+    return result
+
+
+def _parse_run_details(rd_raw: object) -> dict:
     """Parst run_details aus der KI-Antwort."""
     if not isinstance(rd_raw, dict):
         return {"run_type": "easy"}
@@ -292,137 +388,104 @@ def _parse_run_details_from_ai(rd_raw: object) -> dict:
     return details
 
 
-def _normalize_session(item: dict) -> dict | None:
-    """Normalisiert und validiert eine einzelne Session."""
-    day = item.get("day_of_week")
-    if not isinstance(day, int) or day < 0 or day > 6:
-        return None
-
-    training_type = str(item.get("training_type", "")).lower()
-    if training_type not in ("running", "strength"):
-        return None
-
-    result: dict = {
-        "day_of_week": day,
-        "training_type": training_type,
-    }
-
-    if item.get("notes"):
-        result["notes"] = str(item["notes"])[:500]
-
-    if training_type == "running":
-        result["run_details"] = _parse_run_details_from_ai(item.get("run_details", {}))
-
-    if training_type == "strength" and item.get("template_id"):
-        with contextlib.suppress(ValueError, TypeError):
-            result["template_id"] = int(item["template_id"])
-
-    return result
-
-
 # ---------------------------------------------------------------------------
-# Merge
+# Entries bauen + DB-Persistierung
 # ---------------------------------------------------------------------------
 
 
-def _merge_into_plan(
-    existing: list[dict],
-    new_sessions: list[dict],
-) -> list[WeeklyPlanEntry]:
-    """Merged neue Sessions in den bestehenden 7-Tage-Plan."""
-    occupied = {e["day_of_week"] for e in existing}
+def _build_entries(ai_days: list[dict]) -> list[WeeklyPlanEntry]:
+    """Baut WeeklyPlanEntry-Objekte aus den KI-Tagen."""
+    day_map = {d["day_of_week"]: d for d in ai_days}
 
-    # Bestehende Tage als Entries (mit is_rest_day)
-    existing_map: dict[int, dict] = {e["day_of_week"]: e for e in existing}
-
-    # Neue Sessions einfügen (nur auf freie Tage)
-    new_by_day: dict[int, dict] = {}
-    for s in new_sessions:
-        day = s["day_of_week"]
-        if day in occupied:
-            # Freien Tag suchen
-            day = _find_free_day(occupied | set(new_by_day.keys()), day)
-            if day is None:
-                continue
-        new_by_day[day] = s
-
-    # 7-Tage-Plan bauen
     entries: list[WeeklyPlanEntry] = []
     for dow in range(7):
-        if dow in existing_map:
-            # Bestehender Tag — unverändert lassen (leerer Platzhalter)
-            e = existing_map[dow]
-            entries.append(
-                WeeklyPlanEntry(
-                    day_of_week=dow,
-                    is_rest_day=e.get("is_rest_day", False),
-                )
-            )
-        elif dow in new_by_day:
-            s = new_by_day[dow]
-            sessions = [_dict_to_planned_session(s, position=0)]
-            entries.append(
-                WeeklyPlanEntry(
-                    day_of_week=dow,
-                    sessions=sessions,
-                )
-            )
+        if dow in day_map:
+            d = day_map[dow]
+            if d.get("is_rest_day"):
+                entries.append(WeeklyPlanEntry(day_of_week=dow, is_rest_day=True))
+            else:
+                session = _dict_to_planned_session(d, position=0)
+                entries.append(WeeklyPlanEntry(day_of_week=dow, sessions=[session]))
         else:
             entries.append(WeeklyPlanEntry(day_of_week=dow))
 
     return entries
 
 
-async def _persist_new_sessions(
+async def _replace_plan(
     target_week: date,
-    existing: list[dict],
-    new_sessions: list[dict],
+    existing_plan: list[dict],
+    ai_days: list[dict],
     db: AsyncSession,
 ) -> None:
-    """Persistiert neue KI-Sessions als WeeklyPlanDay + PlannedSession in der DB."""
-    occupied = {e["day_of_week"] for e in existing}
+    """Löscht bestehende Einträge und erstellt den angepassten Plan."""
+    # Bestehende Tage + Sessions löschen
+    day_result = await db.execute(
+        select(WeeklyPlanDayModel).where(WeeklyPlanDayModel.week_start == target_week)
+    )
+    old_days = day_result.scalars().all()
 
-    # Welche Tage wurden tatsächlich belegt? (gleiche Logik wie _merge_into_plan)
-    placed: dict[int, dict] = {}
-    for s in new_sessions:
-        day = s["day_of_week"]
-        if day in occupied or day in placed:
-            day = _find_free_day(occupied | set(placed.keys()), day)
-            if day is None:
-                continue
-        placed[day] = s
-
-    for day, session_data in placed.items():
-        db_day = WeeklyPlanDayModel(
-            week_start=target_week,
-            day_of_week=day,
-            is_rest_day=False,
+    if old_days:
+        old_day_ids = [d.id for d in old_days]
+        session_result = await db.execute(
+            select(PlannedSessionModel).where(PlannedSessionModel.day_id.in_(old_day_ids))
         )
-        db.add(db_day)
-        await db.flush()
+        for s in session_result.scalars().all():
+            await db.delete(s)
 
-        run_details_str: str | None = None
-        if session_data.get("run_details"):
-            run_details_str = json.dumps(session_data["run_details"])
+    # plan_id aus bestehendem Plan übernehmen (falls vorhanden)
+    plan_id = None
+    for e in existing_plan:
+        if e.get("plan_id"):
+            plan_id = e["plan_id"]
+            break
 
-        db_session = PlannedSessionModel(
-            day_id=db_day.id,
-            position=0,
-            training_type=session_data["training_type"],
-            template_id=session_data.get("template_id"),
-            run_details_json=run_details_str,
-            notes=session_data.get("notes"),
-        )
-        db.add(db_session)
+    # Alte Days löschen (nach Sessions!)
+    for d in old_days:
+        await db.delete(d)
+    await db.flush()
+
+    # Neue Tage + Sessions erstellen
+    for ai_day in ai_days:
+        await _create_plan_day(target_week, ai_day, plan_id, db)
 
 
-def _find_free_day(occupied: set[int], preferred: int) -> int | None:
-    """Sucht den nächsten freien Tag ab preferred."""
-    for offset in range(1, 7):
-        candidate = (preferred + offset) % 7
-        if candidate not in occupied:
-            return candidate
-    return None
+async def _create_plan_day(
+    target_week: date,
+    ai_day: dict,
+    plan_id: int | None,
+    db: AsyncSession,
+) -> None:
+    """Erstellt einen einzelnen Plan-Tag mit Session in der DB."""
+    is_rest = ai_day.get("is_rest_day", False)
+
+    db_day = WeeklyPlanDayModel(
+        week_start=target_week,
+        day_of_week=ai_day["day_of_week"],
+        is_rest_day=is_rest,
+        notes=ai_day.get("notes"),
+        plan_id=plan_id,
+        edited=True,  # KI-Anpassung = editiert
+    )
+    db.add(db_day)
+    await db.flush()
+
+    if is_rest or "training_type" not in ai_day:
+        return
+
+    run_details_str: str | None = None
+    if ai_day.get("run_details"):
+        run_details_str = json.dumps(ai_day["run_details"])
+
+    db_session = PlannedSessionModel(
+        day_id=db_day.id,
+        position=0,
+        training_type=ai_day["training_type"],
+        template_id=ai_day.get("template_id"),
+        run_details_json=run_details_str,
+        notes=ai_day.get("notes"),
+    )
+    db.add(db_session)
 
 
 def _dict_to_planned_session(s: dict, position: int) -> PlannedSession:

--- a/backend/app/tests/test_recommendation_to_plan.py
+++ b/backend/app/tests/test_recommendation_to_plan.py
@@ -4,24 +4,24 @@ import json
 from datetime import date
 
 from app.services.recommendation_to_plan_service import (
+    _build_entries,
     _build_instructions,
     _build_system_prompt,
     _build_user_prompt,
-    _find_free_day,
-    _merge_into_plan,
-    _normalize_session,
-    _parse_run_details_from_ai,
-    _parse_sessions,
+    _format_plan_day,
+    _normalize_day,
+    _parse_plan,
+    _parse_run_details,
 )
 
 # ---------------------------------------------------------------------------
-# _parse_run_details_from_ai
+# _parse_run_details
 # ---------------------------------------------------------------------------
 
 
-class TestParseRunDetailsFromAI:
+class TestParseRunDetails:
     def test_valid_details(self) -> None:
-        rd = _parse_run_details_from_ai(
+        rd = _parse_run_details(
             {
                 "run_type": "easy",
                 "target_duration_minutes": 45,
@@ -34,26 +34,26 @@ class TestParseRunDetailsFromAI:
         assert rd["target_pace_min"] == "6:30"
 
     def test_invalid_run_type_falls_back_to_easy(self) -> None:
-        rd = _parse_run_details_from_ai({"run_type": "sprint"})
+        rd = _parse_run_details({"run_type": "sprint"})
         assert rd["run_type"] == "easy"
 
     def test_non_dict_returns_default(self) -> None:
-        rd = _parse_run_details_from_ai("not a dict")
+        rd = _parse_run_details("not a dict")
         assert rd == {"run_type": "easy"}
 
     def test_duration_out_of_range_ignored(self) -> None:
-        rd = _parse_run_details_from_ai({"run_type": "easy", "target_duration_minutes": 500})
+        rd = _parse_run_details({"run_type": "easy", "target_duration_minutes": 500})
         assert "target_duration_minutes" not in rd
 
 
 # ---------------------------------------------------------------------------
-# _normalize_session
+# _normalize_day
 # ---------------------------------------------------------------------------
 
 
-class TestNormalizeSession:
-    def test_valid_running_session(self) -> None:
-        result = _normalize_session(
+class TestNormalizeDay:
+    def test_valid_running_day(self) -> None:
+        result = _normalize_day(
             {
                 "day_of_week": 1,
                 "training_type": "running",
@@ -67,8 +67,8 @@ class TestNormalizeSession:
         assert result["run_details"]["run_type"] == "tempo"
         assert result["notes"] == "Tempo-Lauf"
 
-    def test_valid_strength_session(self) -> None:
-        result = _normalize_session(
+    def test_valid_strength_day(self) -> None:
+        result = _normalize_day(
             {
                 "day_of_week": 3,
                 "training_type": "strength",
@@ -79,16 +79,23 @@ class TestNormalizeSession:
         assert result["training_type"] == "strength"
         assert result["template_id"] == 5
 
-    def test_invalid_day_returns_none(self) -> None:
-        assert _normalize_session({"day_of_week": 7, "training_type": "running"}) is None
-        assert _normalize_session({"day_of_week": -1, "training_type": "running"}) is None
-        assert _normalize_session({"day_of_week": "Mon", "training_type": "running"}) is None
+    def test_rest_day(self) -> None:
+        result = _normalize_day({"day_of_week": 0, "is_rest_day": True})
+        assert result is not None
+        assert result["is_rest_day"] is True
 
-    def test_invalid_training_type_returns_none(self) -> None:
-        assert _normalize_session({"day_of_week": 0, "training_type": "yoga"}) is None
+    def test_invalid_day_returns_none(self) -> None:
+        assert _normalize_day({"day_of_week": 7, "training_type": "running"}) is None
+        assert _normalize_day({"day_of_week": -1, "training_type": "running"}) is None
+        assert _normalize_day({"day_of_week": "Mon", "training_type": "running"}) is None
+
+    def test_invalid_training_type_becomes_rest_day(self) -> None:
+        result = _normalize_day({"day_of_week": 0, "training_type": "yoga"})
+        assert result is not None
+        assert result["is_rest_day"] is True
 
     def test_notes_truncated(self) -> None:
-        result = _normalize_session(
+        result = _normalize_day(
             {
                 "day_of_week": 0,
                 "training_type": "running",
@@ -99,7 +106,7 @@ class TestNormalizeSession:
         assert len(result["notes"]) == 500
 
     def test_invalid_template_id_ignored(self) -> None:
-        result = _normalize_session(
+        result = _normalize_day(
             {
                 "day_of_week": 0,
                 "training_type": "strength",
@@ -111,101 +118,129 @@ class TestNormalizeSession:
 
 
 # ---------------------------------------------------------------------------
-# _parse_sessions
+# _parse_plan
 # ---------------------------------------------------------------------------
 
 
-class TestParseSessions:
+class TestParsePlan:
     def test_valid_json_array(self) -> None:
         raw = json.dumps(
             [
-                {"day_of_week": 0, "training_type": "running", "run_details": {"run_type": "easy"}},
+                {"day_of_week": 0, "is_rest_day": True},
+                {"day_of_week": 1, "training_type": "running", "run_details": {"run_type": "easy"}},
                 {"day_of_week": 2, "training_type": "strength"},
             ]
         )
-        sessions = _parse_sessions(raw)
-        assert len(sessions) == 2
+        days = _parse_plan(raw)
+        assert len(days) == 3
 
     def test_markdown_codeblock_stripped(self) -> None:
-        raw = '```json\n[{"day_of_week": 0, "training_type": "running"}]\n```'
-        sessions = _parse_sessions(raw)
-        assert len(sessions) == 1
+        raw = '```json\n[{"day_of_week": 0, "is_rest_day": true}]\n```'
+        days = _parse_plan(raw)
+        assert len(days) == 1
 
     def test_invalid_json_returns_empty(self) -> None:
-        assert _parse_sessions("not json") == []
+        assert _parse_plan("not json") == []
 
     def test_non_array_returns_empty(self) -> None:
-        assert _parse_sessions('{"key": "value"}') == []
+        assert _parse_plan('{"key": "value"}') == []
 
     def test_invalid_items_filtered(self) -> None:
         raw = json.dumps(
             [
-                {"day_of_week": 0, "training_type": "running"},
+                {"day_of_week": 0, "is_rest_day": True},
                 {"day_of_week": 99, "training_type": "running"},  # ungültig
                 "not a dict",
             ]
         )
-        sessions = _parse_sessions(raw)
-        assert len(sessions) == 1
+        days = _parse_plan(raw)
+        assert len(days) == 1
+
+    def test_full_7_day_plan(self) -> None:
+        raw = json.dumps(
+            [
+                {"day_of_week": 0, "is_rest_day": True},
+                {
+                    "day_of_week": 1,
+                    "training_type": "running",
+                    "run_details": {"run_type": "easy"},
+                },
+                {
+                    "day_of_week": 2,
+                    "training_type": "running",
+                    "run_details": {"run_type": "tempo"},
+                },
+                {"day_of_week": 3, "is_rest_day": True},
+                {"day_of_week": 4, "training_type": "strength"},
+                {
+                    "day_of_week": 5,
+                    "training_type": "running",
+                    "run_details": {"run_type": "long_run"},
+                },
+                {"day_of_week": 6, "is_rest_day": True},
+            ]
+        )
+        days = _parse_plan(raw)
+        assert len(days) == 7
 
 
 # ---------------------------------------------------------------------------
-# _find_free_day
+# _build_entries
 # ---------------------------------------------------------------------------
 
 
-class TestFindFreeDay:
-    def test_finds_next_free_day(self) -> None:
-        assert _find_free_day({0, 1, 2}, 0) == 3
-
-    def test_wraps_around(self) -> None:
-        assert _find_free_day({4, 5, 6}, 5) == 0
-
-    def test_no_free_day_returns_none(self) -> None:
-        assert _find_free_day({0, 1, 2, 3, 4, 5, 6}, 0) is None
-
-
-# ---------------------------------------------------------------------------
-# _merge_into_plan
-# ---------------------------------------------------------------------------
-
-
-class TestMergeIntoPlan:
-    def test_new_sessions_on_free_days(self) -> None:
-        existing = [{"day_of_week": 0, "is_rest_day": False}]
-        new_sessions = [
-            {"day_of_week": 1, "training_type": "running", "run_details": {"run_type": "easy"}}
+class TestBuildEntries:
+    def test_builds_7_entries(self) -> None:
+        ai_days: list[dict] = [
+            {"day_of_week": 0, "is_rest_day": True},
+            {"day_of_week": 1, "training_type": "running", "run_details": {"run_type": "easy"}},
         ]
-        merged = _merge_into_plan(existing, new_sessions)
-        assert len(merged) == 7
-        assert len(merged[1].sessions) == 1
+        entries = _build_entries(ai_days)
+        assert len(entries) == 7
+        assert entries[0].is_rest_day is True
+        assert len(entries[1].sessions) == 1
+        assert entries[1].sessions[0].training_type == "running"
+        # Nicht von KI gelieferte Tage = leer
+        assert len(entries[2].sessions) == 0
 
-    def test_occupied_day_redirected(self) -> None:
-        existing = [{"day_of_week": 0, "is_rest_day": False}]
-        new_sessions = [
-            {"day_of_week": 0, "training_type": "running", "run_details": {"run_type": "easy"}}
-        ]
-        merged = _merge_into_plan(existing, new_sessions)
-        # Tag 0 ist belegt → Session wird auf nächsten freien Tag verschoben
-        assert len(merged[0].sessions) == 0
-        # Irgendein anderer Tag hat die Session
-        placed = [e for e in merged if len(e.sessions) > 0]
-        assert len(placed) == 1
+    def test_empty_ai_days(self) -> None:
+        entries = _build_entries([])
+        assert len(entries) == 7
+        for e in entries:
+            assert len(e.sessions) == 0
 
-    def test_all_days_occupied_skips_session(self) -> None:
-        existing = [{"day_of_week": d, "is_rest_day": False} for d in range(7)]
-        new_sessions = [
-            {"day_of_week": 0, "training_type": "running", "run_details": {"run_type": "easy"}}
-        ]
-        merged = _merge_into_plan(existing, new_sessions)
-        placed = [e for e in merged if len(e.sessions) > 0]
-        assert len(placed) == 0
 
-    def test_empty_days_stay_empty(self) -> None:
-        merged = _merge_into_plan([], [])
-        assert len(merged) == 7
-        for entry in merged:
-            assert len(entry.sessions) == 0
+# ---------------------------------------------------------------------------
+# _format_plan_day
+# ---------------------------------------------------------------------------
+
+
+class TestFormatPlanDay:
+    def test_rest_day(self) -> None:
+        result = _format_plan_day("Montag", {"is_rest_day": True, "sessions": []})
+        assert "Ruhetag" in result
+        assert "Montag" in result
+
+    def test_running_day(self) -> None:
+        entry = {
+            "is_rest_day": False,
+            "notes": "Locker laufen",
+            "sessions": [
+                {
+                    "training_type": "running",
+                    "run_details": {"run_type": "easy", "target_duration_minutes": 45},
+                }
+            ],
+        }
+        result = _format_plan_day("Dienstag", entry)
+        assert "Dienstag" in result
+        assert "running" in result
+        assert "easy" in result
+        assert "45min" in result
+
+    def test_empty_sessions(self) -> None:
+        result = _format_plan_day("Mittwoch", {"is_rest_day": False, "sessions": []})
+        assert "(leer)" in result
 
 
 # ---------------------------------------------------------------------------
@@ -220,6 +255,10 @@ class TestPromptBuilders:
         assert "intervals" in prompt
         assert "Trainingsplaner" in prompt
 
+    def test_system_prompt_mentions_plan_adjustment(self) -> None:
+        prompt = _build_system_prompt(None, date(2026, 3, 23))
+        assert "anpass" in prompt.lower() or "bestehend" in prompt.lower()
+
     def test_system_prompt_with_race_goal(self) -> None:
         goal = {"title": "Halbmarathon", "distance_km": 21.1, "date": "2026-03-29"}
         prompt = _build_system_prompt(goal, date(2026, 3, 23))
@@ -232,18 +271,36 @@ class TestPromptBuilders:
         assert "Mehr Tempo-Läufe" in prompt
         assert "Kraft-Training" in prompt
 
-    def test_user_prompt_shows_occupied_days(self) -> None:
-        existing = [{"day_of_week": 0, "is_rest_day": False}]
+    def test_user_prompt_shows_existing_plan(self) -> None:
+        existing: list[dict] = [
+            {
+                "day_of_week": 0,
+                "is_rest_day": True,
+                "notes": None,
+                "plan_id": 1,
+                "sessions": [],
+            },
+            {
+                "day_of_week": 1,
+                "is_rest_day": False,
+                "notes": None,
+                "plan_id": 1,
+                "sessions": [{"training_type": "running", "run_details": {"run_type": "easy"}}],
+            },
+        ]
         prompt = _build_user_prompt(["Test"], existing, [])
         assert "Montag" in prompt
-        assert "NICHT belegen" in prompt
+        assert "Ruhetag" in prompt
+        assert "Dienstag" in prompt
+        assert "running" in prompt
 
     def test_user_prompt_shows_templates(self) -> None:
         templates = [{"id": 1, "name": "Oberkörper"}]
         prompt = _build_user_prompt(["Test"], [], templates)
         assert "Oberkörper" in prompt
 
-    def test_instructions_format(self) -> None:
+    def test_instructions_mention_all_7_days(self) -> None:
         instructions = _build_instructions()
-        assert "JSON-Array" in instructions
+        assert "ALLE 7 Tage" in instructions
         assert "day_of_week" in instructions
+        assert "Passe bestehende Sessions an" in instructions


### PR DESCRIPTION
## Summary
- **Problem**: Die Apply-Recommendations-Logik hat Empfehlungen nur auf **freie Tage** platziert. Bei einem vollen Trainingsplan (wie der Tapering-Woche) wurde effektiv nichts geändert.
- **Fix**: Komplette Überarbeitung — die KI bekommt jetzt den **vollen bestehenden Plan** (mit Session-Details, Pace, Dauer etc.) und gibt einen **komplett angepassten 7-Tage-Plan** zurück. Bestehende Einträge werden durch die angepassten ersetzt.
- `plan_id` bleibt erhalten, `edited: true` wird gesetzt.

## Änderungen
- `_load_full_plan()`: Lädt Sessions mit run_details, training_type, notes (statt nur day_of_week/is_rest_day)
- Prompt: Zeigt bestehenden Plan und sagt „passe an" statt „füge auf freie Tage hinzu"
- KI gibt alle 7 Tage zurück (inkl. Ruhetage)
- `_replace_plan()`: Löscht alte Einträge, erstellt neue mit plan_id
- Tests komplett überarbeitet (28 Tests)

## Test plan
- [ ] Review für aktuelle Woche generieren → Empfehlungen „In Wochenplan übernehmen"
- [ ] Wochenplan der Folgewoche laden → Sessions sind gemäß Empfehlungen angepasst
- [ ] Bestehende Sessions (Pace, Dauer, Typ) werden modifiziert, nicht nur neue hinzugefügt

🤖 Generated with [Claude Code](https://claude.com/claude-code)