### PR TITLE
fix: Session-Insights als Fallback (#335)

### DIFF
--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -312,8 +312,8 @@ export function SessionDetailPage() {
       {/* Metrics */}
       <SessionMetricsGrid session={session} sessionGap={sessionGap} effectiveRpe={effectiveRpe} />
 
-      {/* Insights */}
-      {insights.length > 0 && (
+      {/* Insights — nur als Fallback wenn keine KI-Analyse vorhanden */}
+      {insights.length > 0 && !session.ai_analysis && (
         <section aria-label="Insights">
           <Card elevation="raised">
             <CardHeader>


### PR DESCRIPTION
## Summary
- Insights-Card (algorithmisch) nur anzeigen wenn keine KI-Analyse vorhanden
- 1-Zeilen-Änderung: `&& !session.ai_analysis` als Bedingung

## Test plan
- [ ] Session mit KI-Analyse öffnen → keine Insights-Card
- [ ] Session ohne KI-Analyse öffnen → Insights-Card wie bisher

🤖 Generated with [Claude Code](https://claude.com/claude-code)