### PR TITLE
refactor: Session-KI-Empfehlungen aus UI entfernen (#335)

### DIFF
--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -61,7 +61,6 @@ import {
   SessionEditFields,
   SessionComparisonSection,
   SessionAIAnalysis,
-  SessionRecommendations,
 } from '@/components/session-detail';
 
 const workoutTypeHeadings: Record<string, string> = {
@@ -340,9 +339,6 @@ export function SessionDetailPage() {
           data.setSession((prev) => (prev ? { ...prev, ai_analysis: analysis } : prev))
         }
       />
-
-      {/* KI-Empfehlungen (#34) */}
-      <SessionRecommendations sessionId={sessionId} hasAnalysis={!!session.ai_analysis} />
 
       {/* Exercises (Strength) */}
       {session.exercises && session.exercises.length > 0 && (


### PR DESCRIPTION
## Summary
- SessionRecommendations-Komponente aus SessionDetail entfernt
- KI-Analyse enthält bereits Empfehlungen — separate Card war redundant
- Backend-Endpoints bleiben erhalten (kein Breaking Change)

## Test plan
- [ ] Session-Detail öffnen → keine KI-Empfehlungen-Card mehr
- [ ] KI-Analyse mit Empfehlungen weiterhin sichtbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)