### PR TITLE
fix: Intensität-Badge size=xs in KI-Analyse (#335)

### DIFF
--- a/frontend/src/components/session-detail/SessionAIAnalysis.tsx
+++ b/frontend/src/components/session-detail/SessionAIAnalysis.tsx
@@ -32,7 +32,7 @@ function IntensityBadge({ rating, text }: { rating: string; text: string }) {
     <div className="space-y-1">
       <div className="flex items-center gap-2">
         <span className="text-sm font-medium text-[var(--color-text-default)]">Intensität</span>
-        <Badge variant={config.variant as 'success' | 'info' | 'warning' | 'error'}>
+        <Badge variant={config.variant as 'success' | 'info' | 'warning' | 'error'} size="xs">
           {config.label}
         </Badge>
       </div>


### PR DESCRIPTION
Badge war default size statt xs. Einzeiler-Fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)