### PR TITLE
feat: Undo für Planänderungen (#340)

### DIFF
--- a/backend/app/api/v1/weekly_plan.py
+++ b/backend/app/api/v1/weekly_plan.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.v1.training_plans import log_plan_change
 from app.infrastructure.database.models import (
+    PlanChangeLogModel,
     PlannedSessionModel,
     SessionTemplateModel,
     TrainingPhaseModel,
@@ -36,6 +37,8 @@ from app.models.weekly_plan import (
     RunDetails,
     SyncToPlanRequest,
     SyncToPlanResponse,
+    UndoResponse,
+    UndoStatusResponse,
     WeeklyPlanEntry,
     WeeklyPlanResponse,
     WeeklyPlanSaveRequest,
@@ -156,6 +159,84 @@ async def _load_days_with_sessions(
         result[dow] = (day, sessions_by_day_id.get(day_id, []))
 
     return result
+
+
+def _build_week_snapshot(
+    week_start: date,
+    old_data: dict[int, tuple[WeeklyPlanDayModel, list[PlannedSessionModel]]],
+    phase_id: int | None = None,
+    phase_templates_json: str | None = None,
+) -> dict:
+    """Build a complete snapshot of the week's state for undo."""
+    days: list[dict] = []
+    for dow in range(7):
+        if dow not in old_data:
+            continue
+        day, sessions = old_data[dow]
+        days.append(
+            {
+                "day_of_week": dow,
+                "is_rest_day": bool(day.is_rest_day),
+                "notes": day.notes,
+                "plan_id": day.plan_id,
+                "edited": bool(day.edited),
+                "sessions": [
+                    {
+                        "position": int(s.position),
+                        "training_type": str(s.training_type),
+                        "template_id": s.template_id,
+                        "run_details_json": s.run_details_json,
+                        "exercises_json": s.exercises_json,
+                        "notes": s.notes,
+                        "status": str(s.status) if s.status else "active",
+                    }
+                    for s in sorted(sessions, key=lambda x: int(x.position))
+                ],
+            }
+        )
+    return {
+        "week_start": str(week_start),
+        "days": days,
+        "phase_id": phase_id,
+        "phase_weekly_templates_json": phase_templates_json,
+    }
+
+
+async def _load_linked_phase_template(
+    db: AsyncSession,
+    old_data: dict[int, tuple[WeeklyPlanDayModel, list[PlannedSessionModel]]],
+    week_start: date,
+) -> tuple[int | None, str | None]:
+    """Load the phase template JSON linked to this week (for undo snapshot)."""
+    plan_id: int | None = None
+    for day, _sessions in old_data.values():
+        if day.plan_id:
+            plan_id = int(day.plan_id)
+            break
+
+    if not plan_id:
+        return None, None
+
+    plan = await db.get(TrainingPlanModel, plan_id)
+    if not plan:
+        return None, None
+
+    plan_start = plan.start_date
+    plan_start_monday = plan_start - timedelta(days=plan_start.weekday())
+    week_number = ((week_start - plan_start_monday).days // 7) + 1
+
+    result = await db.execute(
+        select(TrainingPhaseModel).where(
+            TrainingPhaseModel.training_plan_id == plan_id,
+            TrainingPhaseModel.start_week <= week_number,
+            TrainingPhaseModel.end_week >= week_number,
+        )
+    )
+    phase = result.scalar_one_or_none()
+    if not phase:
+        return None, None
+
+    return phase.id, phase.weekly_templates_json
 
 
 def _build_entry_from_db(
@@ -370,6 +451,23 @@ async def save_weekly_plan(  # noqa: C901, PLR0912  # TODO: E16 Refactoring
     # Fetch existing days + sessions BEFORE deletion (for plan_id + edited preservation)
     old_data = await _load_days_with_sessions(db, week_start)
 
+    # Capture snapshot for undo (before any deletion)
+    undo_phase_id, undo_phase_json = await _load_linked_phase_template(
+        db,
+        old_data,
+        week_start,
+    )
+    undo_snapshot = (
+        _build_week_snapshot(
+            week_start,
+            old_data,
+            undo_phase_id,
+            undo_phase_json,
+        )
+        if old_data
+        else None
+    )
+
     # Delete existing sessions then days
     for _day, sessions in old_data.values():
         for s in sessions:
@@ -447,17 +545,21 @@ async def save_weekly_plan(  # noqa: C901, PLR0912  # TODO: E16 Refactoring
                 )
     for pid, changed_days in changed_plan_days.items():
         count = len(changed_days)
+        details: dict = {
+            "category": "content",
+            "source": "user",
+            "week_start": str(week_start),
+            "changed_days": changed_days,
+        }
+        if undo_snapshot:
+            details["snapshot_before"] = undo_snapshot
+            details["undoable"] = True
         await log_plan_change(
             db,
             pid,
             "manual_edit",
             f"Wochenplan {week_start}: {count} Eintraege bearbeitet",
-            details={
-                "category": "content",
-                "source": "user",
-                "week_start": str(week_start),
-                "changed_days": changed_days,
-            },
+            details=details,
         )
 
     await db.commit()
@@ -961,6 +1063,189 @@ async def sync_to_plan(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refactoring
         week_key=week_key,
         apply_to_all_weeks=data.apply_to_all_weeks,
         synced_days=synced_days,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Undo
+# ---------------------------------------------------------------------------
+
+UNDO_WINDOW_HOURS = 24
+
+
+async def _find_undoable_entry(
+    db: AsyncSession,
+    week_start: date,
+) -> PlanChangeLogModel | None:
+    """Find the most recent undoable changelog entry for a week.
+
+    Returns None if an undo was already performed for this week (within the window).
+    Only one undo per week is allowed.
+    """
+    cutoff = datetime.utcnow() - timedelta(hours=UNDO_WINDOW_HOURS)
+    week_str = str(week_start)
+
+    result = await db.execute(
+        select(PlanChangeLogModel)
+        .where(PlanChangeLogModel.created_at >= cutoff)
+        .order_by(PlanChangeLogModel.created_at.desc())
+    )
+    entries = result.scalars().all()
+
+    # If an undo was already performed for this week, block further undos
+    for entry in entries:
+        if entry.change_type != "undo" or not entry.details_json:
+            continue
+        try:
+            details = json.loads(entry.details_json)
+        except json.JSONDecodeError:
+            continue
+        if details.get("week_start") == week_str:
+            return None
+
+    # Find the most recent undoable entry for this week
+    for entry in entries:
+        if entry.change_type == "undo" or not entry.details_json:
+            continue
+        try:
+            details = json.loads(entry.details_json)
+        except json.JSONDecodeError:
+            continue
+        if details.get("undoable") is True and details.get("week_start") == week_str:
+            return entry
+
+    return None
+
+
+@router.get("/undo-status", response_model=UndoStatusResponse)
+async def get_undo_status(
+    week_start: date = Query(...),
+    db: AsyncSession = Depends(get_db),
+) -> UndoStatusResponse:
+    """Check if undo is available for a given week."""
+    week_start = _monday_of_week(week_start)
+    entry = await _find_undoable_entry(db, week_start)
+
+    if not entry:
+        return UndoStatusResponse(available=False)
+
+    expires_at = entry.created_at + timedelta(hours=UNDO_WINDOW_HOURS)
+    return UndoStatusResponse(
+        available=True,
+        changelog_id=entry.id,
+        summary=entry.summary,
+        created_at=entry.created_at.isoformat(),
+        expires_at=expires_at.isoformat(),
+    )
+
+
+@router.post("/undo", response_model=UndoResponse)
+async def undo_weekly_plan(
+    week_start: date = Query(...),
+    db: AsyncSession = Depends(get_db),
+) -> UndoResponse:
+    """Undo the most recent change to a weekly plan (within 24h window)."""
+    week_start = _monday_of_week(week_start)
+    entry = await _find_undoable_entry(db, week_start)
+
+    if not entry or not entry.details_json:
+        raise HTTPException(status_code=404, detail="Kein rückgängig machbarer Eintrag gefunden.")
+
+    details = json.loads(entry.details_json)
+    snapshot = details.get("snapshot_before")
+    if not snapshot or not isinstance(snapshot.get("days"), list):
+        raise HTTPException(status_code=409, detail="Snapshot-Daten fehlen oder sind ungültig.")
+
+    # Capture current state before restoring (for audit trail)
+    current_data = await _load_days_with_sessions(db, week_start)
+    current_phase_id, current_phase_json = await _load_linked_phase_template(
+        db,
+        current_data,
+        week_start,
+    )
+    current_snapshot = _build_week_snapshot(
+        week_start,
+        current_data,
+        current_phase_id,
+        current_phase_json,
+    )
+
+    # Delete current days + sessions
+    for _day, sessions in current_data.values():
+        for s in sessions:
+            await db.delete(s)
+    for day, _sessions in current_data.values():
+        await db.delete(day)
+    await db.flush()
+
+    # Restore days + sessions from snapshot
+    restored_count = 0
+    for snap_day in snapshot["days"]:
+        plan_id = snap_day.get("plan_id")
+        db_day = WeeklyPlanDayModel(
+            week_start=week_start,
+            day_of_week=snap_day["day_of_week"],
+            is_rest_day=snap_day.get("is_rest_day", False),
+            notes=snap_day.get("notes"),
+            plan_id=plan_id,
+            edited=snap_day.get("edited", False),
+        )
+        db.add(db_day)
+        await db.flush()
+
+        for snap_session in snap_day.get("sessions", []):
+            db_session = PlannedSessionModel(
+                day_id=db_day.id,
+                position=snap_session.get("position", 0),
+                training_type=snap_session["training_type"],
+                template_id=snap_session.get("template_id"),
+                run_details_json=snap_session.get("run_details_json"),
+                exercises_json=snap_session.get("exercises_json"),
+                notes=snap_session.get("notes"),
+                status=snap_session.get("status", "active"),
+            )
+            db.add(db_session)
+
+        restored_count += 1
+
+    # Restore phase template if snapshot contains it
+    phase_id = snapshot.get("phase_id")
+    phase_json = snapshot.get("phase_weekly_templates_json")
+    if phase_id and phase_json is not None:
+        phase = await db.get(TrainingPhaseModel, phase_id)
+        if phase:
+            phase.weekly_templates_json = phase_json
+
+    # Log undo as non-undoable changelog entry
+    plan_id_for_log = snapshot["days"][0].get("plan_id") if snapshot["days"] else None
+    if plan_id_for_log:
+        await log_plan_change(
+            db,
+            plan_id_for_log,
+            "undo",
+            f"Rückgängig: Wochenplan {week_start} wiederhergestellt",
+            details={
+                "category": "content",
+                "source": "undo",
+                "week_start": str(week_start),
+                "undoable": False,
+                "undone_changelog_id": entry.id,
+                "snapshot_before": current_snapshot,
+            },
+            category="content",
+        )
+
+    # Mark original entry as undone (prevent double-undo)
+    details["undoable"] = False
+    entry.details_json = json.dumps(details)
+
+    await db.commit()
+
+    return UndoResponse(
+        success=True,
+        week_start=str(week_start),
+        changelog_id=entry.id,
+        restored_days=restored_count,
     )
 
 

--- a/backend/app/models/weekly_plan.py
+++ b/backend/app/models/weekly_plan.py
@@ -295,3 +295,22 @@ class SyncToPlanResponse(BaseModel):
     week_key: str
     apply_to_all_weeks: bool
     synced_days: int
+
+
+class UndoStatusResponse(BaseModel):
+    """Whether undo is available for a given week."""
+
+    available: bool
+    changelog_id: Optional[int] = None
+    summary: Optional[str] = None
+    created_at: Optional[str] = None
+    expires_at: Optional[str] = None
+
+
+class UndoResponse(BaseModel):
+    """Result of an undo operation."""
+
+    success: bool
+    week_start: str
+    changelog_id: int
+    restored_days: int

--- a/backend/app/services/recommendation_to_plan_service.py
+++ b/backend/app/services/recommendation_to_plan_service.py
@@ -78,9 +78,17 @@ async def apply_recommendations(
 
     # Sync zurück zum Trainingsplan + Changelog
     if ai_days and plan_id:
+        # Capture phase template BEFORE sync (for undo snapshot)
+        phase_snapshot = await _load_phase_snapshot(plan_id, target_week, db)
         await _sync_back_to_plan(target_week, plan_id, ai_days, db)
         _log_recommendation_change(
-            plan_id, target_week, recommendations, existing_plan, ai_days, db
+            plan_id,
+            target_week,
+            recommendations,
+            existing_plan,
+            ai_days,
+            db,
+            phase_snapshot=phase_snapshot,
         )
 
     # AI-Log
@@ -595,6 +603,42 @@ def _dict_to_planned_session(s: dict, position: int) -> PlannedSession:
 
 
 # ---------------------------------------------------------------------------
+# Phase-Snapshot für Undo
+# ---------------------------------------------------------------------------
+
+
+async def _load_phase_snapshot(
+    plan_id: int,
+    target_week: date,
+    db: AsyncSession,
+) -> dict | None:
+    """Load current phase template state for undo snapshot."""
+    plan = await db.get(TrainingPlanModel, plan_id)
+    if not plan:
+        return None
+
+    plan_start = plan.start_date
+    plan_start_monday = plan_start - timedelta(days=plan_start.weekday())
+    week_number = ((target_week - plan_start_monday).days // 7) + 1
+
+    result = await db.execute(
+        select(TrainingPhaseModel).where(
+            TrainingPhaseModel.training_plan_id == plan_id,
+            TrainingPhaseModel.start_week <= week_number,
+            TrainingPhaseModel.end_week >= week_number,
+        )
+    )
+    phase = result.scalar_one_or_none()
+    if not phase:
+        return None
+
+    return {
+        "phase_id": phase.id,
+        "phase_weekly_templates_json": phase.weekly_templates_json,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Trainingsplan-Sync + Changelog
 # ---------------------------------------------------------------------------
 
@@ -693,6 +737,8 @@ def _log_recommendation_change(
     old_plan: list[dict],
     new_days: list[dict],
     db: AsyncSession,
+    *,
+    phase_snapshot: dict | None = None,
 ) -> None:
     """Erstellt einen detaillierten Changelog-Eintrag im Trainingsplan."""
     changed_days = _diff_plans(old_plan, new_days)
@@ -704,11 +750,23 @@ def _log_recommendation_change(
     )
     reason = "; ".join(recommendations[:10])
 
-    details = {
+    # Build undo snapshot from old_plan (dict-based format from _load_full_plan)
+    snapshot_before: dict = {
+        "week_start": str(target_week),
+        "days": old_plan,
+        "phase_id": phase_snapshot.get("phase_id") if phase_snapshot else None,
+        "phase_weekly_templates_json": (
+            phase_snapshot.get("phase_weekly_templates_json") if phase_snapshot else None
+        ),
+    }
+
+    details: dict = {
         "category": "content",
         "source": "ai_recommendation",
         "week_start": str(target_week),
         "changed_days": changed_days,
+        "snapshot_before": snapshot_before,
+        "undoable": True,
     }
 
     entry = PlanChangeLogModel(

--- a/backend/app/tests/test_weekly_plan_undo.py
+++ b/backend/app/tests/test_weekly_plan_undo.py
@@ -1,0 +1,207 @@
+"""Tests for Weekly Plan Undo (Issue #340)."""
+
+from datetime import date, datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.infrastructure.database.models import PlanChangeLogModel
+
+WEEK = "2026-08-03"  # A Monday (matches _generate_plan_entries pattern)
+
+
+async def _setup_plan_linked_week(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> int:
+    """Create a training plan with a phase+template and generate weekly entries.
+
+    Returns the plan_id. After this, weekly plan entries for WEEK have plan_id set.
+    """
+    end_date = (date.fromisoformat(WEEK) + timedelta(days=6)).isoformat()
+    plan_resp = await client.post(
+        "/api/v1/training-plans",
+        json={
+            "name": "Undo Test Plan",
+            "start_date": WEEK,
+            "end_date": end_date,
+            "phases": [
+                {
+                    "name": "Base",
+                    "phase_type": "base",
+                    "start_week": 1,
+                    "end_week": 1,
+                    "weekly_template": {
+                        "days": [
+                            {
+                                "day_of_week": i,
+                                "training_type": "running" if i < 3 else None,
+                                "is_rest_day": i >= 3,
+                            }
+                            for i in range(7)
+                        ],
+                    },
+                },
+            ],
+        },
+    )
+    assert plan_resp.status_code == 201
+    plan_id: int = plan_resp.json()["id"]
+
+    gen_resp = await client.post(f"/api/v1/training-plans/{plan_id}/generate")
+    assert gen_resp.status_code == 200
+    return plan_id
+
+
+def _plan_v1() -> dict:
+    """Modified plan: strength Mon, running Tue, rest Wed."""
+    return {
+        "week_start": WEEK,
+        "entries": [
+            {
+                "day_of_week": 0,
+                "sessions": [{"training_type": "strength", "position": 0}],
+            },
+            {
+                "day_of_week": 1,
+                "sessions": [{"training_type": "running", "position": 0}],
+            },
+            {"day_of_week": 2, "is_rest_day": True},
+        ],
+    }
+
+
+def _plan_v2() -> dict:
+    """Another modification: running Mon, rest Tue, strength Wed."""
+    return {
+        "week_start": WEEK,
+        "entries": [
+            {
+                "day_of_week": 0,
+                "sessions": [{"training_type": "running", "position": 0}],
+            },
+            {"day_of_week": 1, "is_rest_day": True},
+            {
+                "day_of_week": 2,
+                "sessions": [{"training_type": "strength", "position": 0}],
+            },
+        ],
+    }
+
+
+@pytest.mark.anyio
+async def test_undo_status_no_changes(client: AsyncClient) -> None:
+    """Undo should not be available when no changes exist."""
+    response = await client.get("/api/v1/weekly-plan/undo-status", params={"week_start": WEEK})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["available"] is False
+    assert body["changelog_id"] is None
+
+
+@pytest.mark.anyio
+async def test_undo_not_found(client: AsyncClient) -> None:
+    """Undo should return 404 when no undoable entry exists."""
+    response = await client.post("/api/v1/weekly-plan/undo", params={"week_start": WEEK})
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_undo_restores_weekly_plan(client: AsyncClient, db_session: AsyncSession) -> None:
+    """Save v1, save v2, undo → plan should be back to v1."""
+    await _setup_plan_linked_week(client, db_session)
+
+    # Save v1 (this changes the generated plan → changelog with snapshot)
+    resp1 = await client.put("/api/v1/weekly-plan", json=_plan_v1())
+    assert resp1.status_code == 200
+
+    # Verify v1
+    get1 = await client.get("/api/v1/weekly-plan", params={"week_start": WEEK})
+    assert get1.json()["entries"][0]["sessions"][0]["training_type"] == "strength"
+
+    # Save v2 (triggers another changelog with snapshot of v1)
+    resp2 = await client.put("/api/v1/weekly-plan", json=_plan_v2())
+    assert resp2.status_code == 200
+
+    # Verify v2
+    get2 = await client.get("/api/v1/weekly-plan", params={"week_start": WEEK})
+    assert get2.json()["entries"][0]["sessions"][0]["training_type"] == "running"
+
+    # Check undo is available
+    status_resp = await client.get("/api/v1/weekly-plan/undo-status", params={"week_start": WEEK})
+    status = status_resp.json()
+    assert status["available"] is True
+    assert status["changelog_id"] is not None
+
+    # Execute undo
+    undo_resp = await client.post("/api/v1/weekly-plan/undo", params={"week_start": WEEK})
+    assert undo_resp.status_code == 200
+    undo_body = undo_resp.json()
+    assert undo_body["success"] is True
+    assert undo_body["restored_days"] > 0
+
+    # Verify plan is back to v1 state
+    get3 = await client.get("/api/v1/weekly-plan", params={"week_start": WEEK})
+    entries = get3.json()["entries"]
+    mon = next(e for e in entries if e["day_of_week"] == 0)
+    assert mon["sessions"][0]["training_type"] == "strength"
+
+
+@pytest.mark.anyio
+async def test_undo_creates_changelog_entry(client: AsyncClient, db_session: AsyncSession) -> None:
+    """Undo should create a changelog entry with change_type='undo'."""
+    await _setup_plan_linked_week(client, db_session)
+    await client.put("/api/v1/weekly-plan", json=_plan_v1())
+    await client.put("/api/v1/weekly-plan", json=_plan_v2())
+
+    # Undo
+    await client.post("/api/v1/weekly-plan/undo", params={"week_start": WEEK})
+
+    # Check changelog
+    result = await db_session.execute(
+        select(PlanChangeLogModel)
+        .where(PlanChangeLogModel.change_type == "undo")
+        .order_by(PlanChangeLogModel.created_at.desc())
+    )
+    undo_entry = result.scalars().first()
+    assert undo_entry is not None
+    assert "Rückgängig" in str(undo_entry.summary)
+
+
+@pytest.mark.anyio
+async def test_undo_not_undoable_itself(client: AsyncClient, db_session: AsyncSession) -> None:
+    """After undo, the undo entry itself should NOT be undoable."""
+    await _setup_plan_linked_week(client, db_session)
+    await client.put("/api/v1/weekly-plan", json=_plan_v1())
+    await client.put("/api/v1/weekly-plan", json=_plan_v2())
+
+    # Undo once
+    undo1 = await client.post("/api/v1/weekly-plan/undo", params={"week_start": WEEK})
+    assert undo1.status_code == 200
+
+    # Second undo should fail (no more undoable entries)
+    undo2 = await client.post("/api/v1/weekly-plan/undo", params={"week_start": WEEK})
+    assert undo2.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_undo_status_expired(client: AsyncClient, db_session: AsyncSession) -> None:
+    """Undo should not be available after 24h."""
+    await _setup_plan_linked_week(client, db_session)
+    await client.put("/api/v1/weekly-plan", json=_plan_v1())
+    await client.put("/api/v1/weekly-plan", json=_plan_v2())
+
+    # Verify undo is available
+    status1 = await client.get("/api/v1/weekly-plan/undo-status", params={"week_start": WEEK})
+    assert status1.json()["available"] is True
+
+    # Backdate changelog entries to 25h ago
+    old_time = datetime.utcnow() - timedelta(hours=25)
+    await db_session.execute(update(PlanChangeLogModel).values(created_at=old_time))
+    await db_session.commit()
+
+    # Undo should no longer be available
+    status2 = await client.get("/api/v1/weekly-plan/undo-status", params={"week_start": WEEK})
+    assert status2.json()["available"] is False

--- a/frontend/src/api/weekly-plan.ts
+++ b/frontend/src/api/weekly-plan.ts
@@ -161,6 +161,23 @@ export interface ApplyRecommendationsResponse {
   applied_count: number;
 }
 
+// --- Undo Types ---
+
+export interface UndoStatusResponse {
+  available: boolean;
+  changelog_id: number | null;
+  summary: string | null;
+  created_at: string | null;
+  expires_at: string | null;
+}
+
+export interface UndoResponse {
+  success: boolean;
+  week_start: string;
+  changelog_id: number;
+  restored_days: number;
+}
+
 // --- Planned Session Option (for upload linking) ---
 
 export interface PlannedSessionOption {
@@ -228,6 +245,20 @@ export async function applyRecommendations(
   const response = await apiClient.post<ApplyRecommendationsResponse>(
     '/api/v1/weekly-plan/apply-recommendations',
     data,
+  );
+  return response.data;
+}
+
+export async function getUndoStatus(weekStart: string): Promise<UndoStatusResponse> {
+  const response = await apiClient.get<UndoStatusResponse>(
+    `/api/v1/weekly-plan/undo-status?week_start=${weekStart}`,
+  );
+  return response.data;
+}
+
+export async function undoWeeklyPlan(weekStart: string): Promise<UndoResponse> {
+  const response = await apiClient.post<UndoResponse>(
+    `/api/v1/weekly-plan/undo?week_start=${weekStart}`,
   );
   return response.data;
 }

--- a/frontend/src/components/PlanChangeLog.tsx
+++ b/frontend/src/components/PlanChangeLog.tsx
@@ -9,6 +9,7 @@ import {
   CalendarPlus,
   ArrowUpToLine,
   PenLine,
+  Undo2,
   Upload,
   Dumbbell,
   ChevronDown,
@@ -41,6 +42,7 @@ const CHANGE_TYPE_ICONS: Record<string, React.ReactNode> = {
   manual_edit: <PenLine className="w-3.5 h-3.5" />,
   yaml_import: <Upload className="w-3.5 h-3.5" />,
   session_configured: <Dumbbell className="w-3.5 h-3.5" />,
+  undo: <Undo2 className="w-3.5 h-3.5" />,
 };
 
 type CategoryFilter = ChangelogCategory | 'all';

--- a/frontend/src/hooks/useWeeklyPlan.ts
+++ b/frontend/src/hooks/useWeeklyPlan.ts
@@ -9,8 +9,10 @@ import {
   syncToPlan,
   getCompliance,
   clearWeeklyPlan,
+  getUndoStatus,
+  undoWeeklyPlan,
 } from '@/api/weekly-plan';
-import type { WeeklyPlanEntry, ComplianceResponse } from '@/api/weekly-plan';
+import type { WeeklyPlanEntry, ComplianceResponse, UndoStatusResponse } from '@/api/weekly-plan';
 import { getMondayOfWeek, addWeeks } from '@/utils/weeklyPlanUtils';
 
 // eslint-disable-next-line max-lines-per-function -- consolidated weekly plan hook
@@ -28,6 +30,9 @@ export function useWeeklyPlan() {
   const [deleting, setDeleting] = useState(false);
   const [showSyncBar, setShowSyncBar] = useState(false);
   const [showSaveDialog, setShowSaveDialog] = useState(false);
+  const [undoStatus, setUndoStatus] = useState<UndoStatusResponse | null>(null);
+  const [undoing, setUndoing] = useState(false);
+  const [showUndoDialog, setShowUndoDialog] = useState(false);
 
   // --- Load ---
 
@@ -37,12 +42,14 @@ export function useWeeklyPlan() {
       setError(null);
       setShowSyncBar(false);
       try {
-        const [planResult, complianceResult] = await Promise.all([
+        const [planResult, complianceResult, undoResult] = await Promise.all([
           getWeeklyPlan(ws),
           getCompliance(ws).catch(() => null),
+          getUndoStatus(ws).catch(() => null),
         ]);
         setEntries(planResult.entries);
         setCompliance(complianceResult);
+        setUndoStatus(undoResult);
         setDirty(false);
       } catch {
         toast({ title: 'Laden fehlgeschlagen', variant: 'error' });
@@ -213,6 +220,22 @@ export function useWeeklyPlan() {
     }
   }, [weekStart, toast, loadWeek]);
 
+  // --- Undo ---
+
+  const handleUndo = useCallback(async () => {
+    setUndoing(true);
+    try {
+      await undoWeeklyPlan(weekStart);
+      toast({ title: 'Rückgängig gemacht', variant: 'success' });
+      setShowUndoDialog(false);
+      await loadWeek(weekStart);
+    } catch {
+      toast({ title: 'Rückgängig machen fehlgeschlagen', variant: 'error' });
+    } finally {
+      setUndoing(false);
+    }
+  }, [weekStart, toast, loadWeek]);
+
   // --- Stats ---
 
   const stats = useMemo(() => {
@@ -274,5 +297,10 @@ export function useWeeklyPlan() {
     linkedPlanId,
     editedPlanCount,
     loadWeek,
+    undoStatus,
+    undoing,
+    showUndoDialog,
+    setShowUndoDialog,
+    handleUndo,
   };
 }

--- a/frontend/src/pages/WeeklyPlan.tsx
+++ b/frontend/src/pages/WeeklyPlan.tsx
@@ -32,6 +32,7 @@ import {
   Trash2,
   TrendingDown,
   TrendingUp,
+  Undo2,
   Upload,
 } from 'lucide-react';
 import { formatTonnage } from '@/hooks/useTonnageCalc';
@@ -247,6 +248,27 @@ export function WeeklyPlanPage() {
             })()}
           {/* Day grid */}
           <div className="mt-10">
+            {/* Undo Banner */}
+            {plan.undoStatus?.available && (
+              <Alert variant="info">
+                <AlertDescription>
+                  <div className="flex items-center justify-between gap-2 flex-wrap">
+                    <span className="text-sm text-[var(--color-text-base)]">
+                      {plan.undoStatus.summary}
+                    </span>
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => plan.setShowUndoDialog(true)}
+                    >
+                      <Undo2 className="w-4 h-4 mr-1" />
+                      Rückgängig
+                    </Button>
+                  </div>
+                </AlertDescription>
+              </Alert>
+            )}
+
             {plan.loading ? (
               <div className="flex justify-center py-8">
                 <Spinner size="lg" />
@@ -342,6 +364,24 @@ export function WeeklyPlanPage() {
             <AlertDialogCancel>Abbrechen</AlertDialogCancel>
             <AlertDialogAction onClick={plan.handleDeleteWeek} disabled={plan.deleting}>
               {plan.deleting ? <Spinner size="sm" /> : 'Löschen'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Undo Dialog */}
+      <AlertDialog open={plan.showUndoDialog} onOpenChange={plan.setShowUndoDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Änderung rückgängig machen?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Der Wochenplan und der Trainingsplan werden auf den vorherigen Stand zurückgesetzt.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Abbrechen</AlertDialogCancel>
+            <AlertDialogAction onClick={plan.handleUndo} disabled={plan.undoing}>
+              {plan.undoing ? <Spinner size="sm" /> : 'Rückgängig machen'}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>


### PR DESCRIPTION
## Summary

- Snapshot-basiertes Undo für Wochenplan-Änderungen mit **bidirektionaler Wiederherstellung** (Wochenplan + Trainingsplan-Phase)
- 24h-Zeitfenster, max. ein Undo pro Woche, kein Ketten-Undo
- Undo-Banner im Wochenplan mit Bestätigungs-Dialog

## Änderungen

**Backend (3 Dateien + 1 Test-Datei):**
- `weekly_plan.py`: Snapshot-Helper, `GET /undo-status`, `POST /undo`, Snapshot-Erfassung bei `save_weekly_plan()`
- `recommendation_to_plan_service.py`: Snapshot-Erfassung bei KI-Empfehlungsänderungen
- `weekly_plan.py` (Models): `UndoStatusResponse`, `UndoResponse`
- `test_weekly_plan_undo.py`: 6 Tests (Status, Restore, Changelog, Double-Undo, Expiry)

**Frontend (4 Dateien):**
- `weekly-plan.ts`: API Types + Funktionen
- `useWeeklyPlan.ts`: Undo-State, paralleler Load, Handler
- `WeeklyPlan.tsx`: Undo-Banner + AlertDialog
- `PlanChangeLog.tsx`: Undo2 Icon

## Test plan

- [x] Backend: 698 Tests bestanden (inkl. 6 neue Undo-Tests)
- [x] Frontend: 182 Tests bestanden
- [x] Ruff, Mypy, TSC, ESLint, Prettier alle grün
- [ ] Manuell: Plan speichern → Undo-Banner → Rückgängig → Plan + Phase wiederhergestellt

Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)