### PR TITLE
fix: FIT Export Targets + Repeat-Struktur fuer HealthFit

### DIFF
--- a/backend/app/services/fit_export.py
+++ b/backend/app/services/fit_export.py
@@ -4,6 +4,7 @@ Konvertiert Session-Templates (RunDetails mit Segmenten) in das Garmin FIT
 Workout-Format fuer den Import in HealthFit / Apple Watch / Garmin-Uhren.
 
 Teil von Issue #38 (E07-S02: Workout als FIT exportieren).
+Bugfix #343: target_value=0, Repeat-Struktur, Step-Namen, Warmup/Cooldown OPEN.
 """
 
 from __future__ import annotations
@@ -39,17 +40,37 @@ SEGMENT_TO_INTENSITY: dict[str, Intensity] = {
     "rest": Intensity.REST,
 }
 
+# Segment-Types die immer target_type=OPEN bekommen (kein Pace/HR-Zwang)
+_OPEN_TARGET_TYPES = frozenset({"warmup", "cooldown"})
+
+# Segment-Types die als Recovery in Repeat-Bloecken erkannt werden
+_RECOVERY_TYPES = frozenset({"recovery_jog", "rest"})
+
+# Deutsche Step-Namen fuer lesbare Anzeige in HealthFit / Apple Watch
+_SEGMENT_DISPLAY_NAMES: dict[str, str] = {
+    "warmup": "Einlaufen",
+    "cooldown": "Auslaufen",
+    "steady": "Dauerlauf",
+    "work": "Intervall",
+    "recovery_jog": "Trabpause",
+    "rest": "Gehpause",
+    "strides": "Steigerungen",
+    "drills": "Lauf-ABC",
+    "pace_building": "Temposteigerung",
+    "tempo_block": "Tempoblock",
+}
+
 # fit-tool Einheiten-Konstanten (empirisch verifiziert)
 _MS_PER_MIN = 60_000.0  # Millisekunden pro Minute
 _DIST_PER_KM = 100.0  # fit-tool duration_distance: 100 Einheiten = 1km
-_MPS_SCALE = 1000  # fit-tool Speed-Skalierung (m/s × 1000)
+_MPS_SCALE = 1000  # fit-tool Speed-Skalierung (m/s x 1000)
 _HR_OFFSET = 100  # FIT Custom HR Offset (BPM + 100)
 
 
 def pace_to_speed_mps(pace_str: str) -> float:
     """Konvertiert Pace-String 'M:SS' (min/km) zu Geschwindigkeit in m/s.
 
-    Beispiel: '5:30' → 1000 / 330 ≈ 3.03 m/s
+    Beispiel: '5:30' -> 1000 / 330 ~ 3.03 m/s
     """
     parts = pace_str.strip().split(":")
     if len(parts) != 2:
@@ -65,6 +86,83 @@ def pace_to_speed_mps(pace_str: str) -> float:
     return 1000.0 / total_seconds
 
 
+def _generate_step_name(segment: Segment) -> str:
+    """Generiert einen lesbaren deutschen Step-Namen fuer HealthFit-Anzeige.
+
+    Priorisiert notes > generierter Name mit Ziel-Info > Segment-Type.
+    """
+    if segment.notes:
+        return segment.notes[:50]
+
+    base = _SEGMENT_DISPLAY_NAMES.get(segment.segment_type, segment.segment_type)
+
+    # Ziel-Info fuer Work/Steady/Strides anhaengen
+    if segment.segment_type in ("work", "steady", "strides", "tempo_block", "pace_building"):
+        suffix_parts: list[str] = []
+
+        if segment.target_distance_km:
+            dist = segment.target_distance_km
+            suffix_parts.append(f"{dist:g}km" if dist != int(dist) else f"{int(dist)}km")
+        elif segment.target_duration_minutes:
+            mins = segment.target_duration_minutes
+            suffix_parts.append(f"{int(mins)}min" if mins == int(mins) else f"{mins}min")
+
+        if segment.target_pace_min and segment.target_pace_max:
+            suffix_parts.append(f"@ {segment.target_pace_min}-{segment.target_pace_max}")
+        elif segment.target_pace_min:
+            suffix_parts.append(f"@ {segment.target_pace_min}")
+
+        if suffix_parts:
+            base = f"{base} {' '.join(suffix_parts)}"
+
+    return base[:50]
+
+
+def _set_target(step: WorkoutStepMessage, segment: Segment) -> None:
+    """Setzt Target-Felder auf dem WorkoutStep.
+
+    WICHTIG: target_value = 0 MUSS gesetzt werden fuer Custom-Range-Targets,
+    sonst ignoriert HealthFit die custom_target_*-Werte komplett.
+
+    Warmup/Cooldown bekommen immer OPEN (Standard-Konvention).
+    Prioritaet: Pace > HR > Open.
+    """
+    # Warmup/Cooldown immer OPEN (kein Pace/HR-Zwang)
+    if segment.segment_type in _OPEN_TARGET_TYPES:
+        step.target_type = WorkoutStepTarget.OPEN
+        step.target_value = 0
+        return
+
+    # Pace-Target (Speed)
+    if segment.target_pace_min or segment.target_pace_max:
+        step.target_type = WorkoutStepTarget.SPEED
+        step.target_value = 0  # 0 = Custom Range (PFLICHT!)
+        # Invertiert: schnellere Pace (niedrigerer Wert) = hoeherer Speed
+        if segment.target_pace_max:  # langsamere Pace -> niedrigerer Speed = low
+            step.custom_target_speed_low = int(
+                pace_to_speed_mps(segment.target_pace_max) * _MPS_SCALE
+            )
+        if segment.target_pace_min:  # schnellere Pace -> hoeherer Speed = high
+            step.custom_target_speed_high = int(
+                pace_to_speed_mps(segment.target_pace_min) * _MPS_SCALE
+            )
+        return
+
+    # HR-Target
+    if segment.target_hr_min or segment.target_hr_max:
+        step.target_type = WorkoutStepTarget.HEART_RATE
+        step.target_value = 0  # 0 = Custom Range (PFLICHT!)
+        if segment.target_hr_min:
+            step.custom_target_heart_rate_low = segment.target_hr_min + _HR_OFFSET
+        if segment.target_hr_max:
+            step.custom_target_heart_rate_high = segment.target_hr_max + _HR_OFFSET
+        return
+
+    # Kein Target → OPEN
+    step.target_type = WorkoutStepTarget.OPEN
+    step.target_value = 0
+
+
 def _build_workout_step(
     segment: Segment,
     message_index: int,
@@ -72,7 +170,7 @@ def _build_workout_step(
     """Konvertiert ein einzelnes Segment zu einem FIT WorkoutStepMessage."""
     step = WorkoutStepMessage()
     step.message_index = message_index
-    step.workout_step_name = segment.notes or segment.segment_type
+    step.workout_step_name = _generate_step_name(segment)
     step.intensity = SEGMENT_TO_INTENSITY.get(segment.segment_type, Intensity.ACTIVE)
 
     # Duration: Zeit > Distanz > Open
@@ -85,27 +183,32 @@ def _build_workout_step(
     else:
         step.duration_type = WorkoutStepDuration.OPEN
 
-    # Target: Pace > HR > Open
-    if segment.target_pace_min or segment.target_pace_max:
-        step.target_type = WorkoutStepTarget.SPEED
-        # Invertiert: schnellere Pace (niedrigerer Wert) = hoeherer Speed
-        if segment.target_pace_max:  # langsamere Pace → niedrigerer Speed = low
-            step.custom_target_speed_low = int(
-                pace_to_speed_mps(segment.target_pace_max) * _MPS_SCALE
-            )
-        if segment.target_pace_min:  # schnellere Pace → hoeherer Speed = high
-            step.custom_target_speed_high = int(
-                pace_to_speed_mps(segment.target_pace_min) * _MPS_SCALE
-            )
-    elif segment.target_hr_min or segment.target_hr_max:
-        step.target_type = WorkoutStepTarget.HEART_RATE
-        if segment.target_hr_min:
-            step.custom_target_heart_rate_low = segment.target_hr_min + _HR_OFFSET
-        if segment.target_hr_max:
-            step.custom_target_heart_rate_high = segment.target_hr_max + _HR_OFFSET
-    else:
-        step.target_type = WorkoutStepTarget.OPEN
+    # Target (mit target_value=0 fuer Custom Ranges)
+    _set_target(step, segment)
 
+    return step
+
+
+def _build_recovery_step(
+    message_index: int,
+    recovery_segment: Segment | None = None,
+) -> WorkoutStepMessage:
+    """Erstellt einen Recovery-Step fuer Repeat-Bloecke.
+
+    Verwendet Daten aus dem Recovery-Segment wenn vorhanden,
+    sonst OPEN Duration + OPEN Target als Fallback.
+    """
+    if recovery_segment:
+        return _build_workout_step(recovery_segment, message_index)
+
+    # Fallback: Auto-generierter Recovery-Step
+    step = WorkoutStepMessage()
+    step.message_index = message_index
+    step.workout_step_name = "Trabpause"
+    step.intensity = Intensity.RECOVERY
+    step.duration_type = WorkoutStepDuration.OPEN
+    step.target_type = WorkoutStepTarget.OPEN
+    step.target_value = 0
     return step
 
 
@@ -126,17 +229,23 @@ def _build_repeat_step(
 def segments_to_fit_steps(segments: list[Segment]) -> list[WorkoutStepMessage]:
     """Konvertiert Template-Segmente zu FIT WorkoutSteps.
 
-    Segmente mit repeats > 1 nutzen den nativen FIT-Repeat-Mechanismus:
-    1. Work-Step emittieren
-    2. Recovery-Step (OPEN duration) emittieren
-    3. Repeat-Step der auf 1+2 verweist
+    Repeat-Logik:
+    - Segment mit repeats > 1 erzeugt einen Repeat-Block:
+      [Work-Step, Recovery-Step, Repeat-Step]
+    - Wenn das naechste Segment ein Recovery-Typ ist (recovery_jog/rest),
+      wird es als Recovery innerhalb des Repeat-Blocks verwendet und
+      im Hauptloop uebersprungen.
+    - Sonst wird ein Auto-Recovery (OPEN) eingefuegt.
 
     Segmente mit repeats == 1 werden direkt konvertiert.
     """
     steps: list[WorkoutStepMessage] = []
     step_index = 0
+    seg_index = 0
 
-    for segment in segments:
+    while seg_index < len(segments):
+        segment = segments[seg_index]
+
         if segment.repeats > 1:
             # Work-Step
             work_step = _build_workout_step(segment, message_index=step_index)
@@ -144,14 +253,15 @@ def segments_to_fit_steps(segments: list[Segment]) -> list[WorkoutStepMessage]:
             repeat_from = step_index
             step_index += 1
 
-            # Recovery-Step (Open, damit Sportler Pause selbst bestimmt)
-            recovery = WorkoutStepMessage()
-            recovery.message_index = step_index
-            recovery.workout_step_name = "Erholung"
-            recovery.intensity = Intensity.RECOVERY
-            recovery.duration_type = WorkoutStepDuration.OPEN
-            recovery.target_type = WorkoutStepTarget.OPEN
-            steps.append(recovery)
+            # Recovery-Step: naechstes Segment als Recovery nutzen wenn moeglich
+            next_seg = segments[seg_index + 1] if seg_index + 1 < len(segments) else None
+            if next_seg and next_seg.segment_type in _RECOVERY_TYPES:
+                recovery_step = _build_recovery_step(step_index, recovery_segment=next_seg)
+                seg_index += 1  # Recovery-Segment im Hauptloop ueberspringen
+            else:
+                recovery_step = _build_recovery_step(step_index)
+
+            steps.append(recovery_step)
             step_index += 1
 
             # Repeat-Step
@@ -165,6 +275,8 @@ def segments_to_fit_steps(segments: list[Segment]) -> list[WorkoutStepMessage]:
         else:
             steps.append(_build_workout_step(segment, message_index=step_index))
             step_index += 1
+
+        seg_index += 1
 
     return steps
 

--- a/backend/app/tests/test_fit_export.py
+++ b/backend/app/tests/test_fit_export.py
@@ -1,4 +1,4 @@
-"""Tests fuer den FIT Workout Export Service (Issue #38)."""
+"""Tests fuer den FIT Workout Export Service (Issue #38, Bugfix #343)."""
 
 import pytest
 
@@ -12,8 +12,10 @@ from fit_tool.profile.profile_type import (  # type: ignore[import-untyped]
 from app.models.segment import Segment
 from app.services.fit_export import (
     SEGMENT_TO_INTENSITY,
+    _build_recovery_step,
     _build_repeat_step,
     _build_workout_step,
+    _generate_step_name,
     export_template_to_fit,
     pace_to_speed_mps,
     segments_to_fit_steps,
@@ -39,7 +41,7 @@ class TestPaceToSpeedMps:
         assert abs(speed - 4.167) < 0.01
 
     def test_pace_with_seconds(self) -> None:
-        # 5:30 min/km = 1000m / 330s ≈ 3.030 m/s
+        # 5:30 min/km = 1000m / 330s ~ 3.030 m/s
         speed = pace_to_speed_mps("5:30")
         assert abs(speed - 3.030) < 0.01
 
@@ -52,18 +54,106 @@ class TestPaceToSpeedMps:
             pace_to_speed_mps("0:00")
 
 
+# --- _generate_step_name ---
+
+
+class TestGenerateStepName:
+    def test_notes_take_priority(self) -> None:
+        seg = Segment(position=0, segment_type="work", notes="Schnelle 1km")
+        assert _generate_step_name(seg) == "Schnelle 1km"
+
+    def test_warmup_name(self) -> None:
+        seg = Segment(position=0, segment_type="warmup", target_duration_minutes=10)
+        assert _generate_step_name(seg) == "Einlaufen"
+
+    def test_cooldown_name(self) -> None:
+        seg = Segment(position=0, segment_type="cooldown", target_duration_minutes=5)
+        assert _generate_step_name(seg) == "Auslaufen"
+
+    def test_recovery_jog_name(self) -> None:
+        seg = Segment(position=0, segment_type="recovery_jog")
+        assert _generate_step_name(seg) == "Trabpause"
+
+    def test_rest_name(self) -> None:
+        seg = Segment(position=0, segment_type="rest")
+        assert _generate_step_name(seg) == "Gehpause"
+
+    def test_work_with_distance_and_pace(self) -> None:
+        seg = Segment(
+            position=0,
+            segment_type="work",
+            target_distance_km=1.0,
+            target_pace_min="4:30",
+            target_pace_max="5:00",
+        )
+        assert _generate_step_name(seg) == "Intervall 1km @ 4:30-5:00"
+
+    def test_work_with_time_and_pace(self) -> None:
+        seg = Segment(
+            position=0,
+            segment_type="work",
+            target_duration_minutes=3,
+            target_pace_min="5:00",
+            target_pace_max="5:30",
+        )
+        assert _generate_step_name(seg) == "Intervall 3min @ 5:00-5:30"
+
+    def test_steady_with_duration(self) -> None:
+        seg = Segment(
+            position=0,
+            segment_type="steady",
+            target_duration_minutes=30,
+            target_pace_min="6:00",
+        )
+        assert _generate_step_name(seg) == "Dauerlauf 30min @ 6:00"
+
+    def test_work_without_targets(self) -> None:
+        seg = Segment(position=0, segment_type="work")
+        assert _generate_step_name(seg) == "Intervall"
+
+    def test_fractional_distance(self) -> None:
+        seg = Segment(position=0, segment_type="work", target_distance_km=0.4)
+        assert _generate_step_name(seg) == "Intervall 0.4km"
+
+    def test_long_notes_truncated(self) -> None:
+        seg = Segment(position=0, segment_type="work", notes="A" * 100)
+        assert len(_generate_step_name(seg)) == 50
+
+
 # --- _build_workout_step ---
 
 
 class TestBuildWorkoutStep:
-    def test_warmup_with_time(self) -> None:
-        seg = Segment(position=0, segment_type="warmup", target_duration_minutes=10)
+    def test_warmup_has_open_target(self) -> None:
+        """Warmup bekommt IMMER target_type=OPEN (auch mit Pace)."""
+        seg = Segment(
+            position=0,
+            segment_type="warmup",
+            target_duration_minutes=10,
+            target_pace_min="6:30",
+            target_pace_max="7:00",
+        )
         step = _build_workout_step(seg, message_index=0)
 
         assert step.intensity == Intensity.WARMUP.value
         assert step.duration_type == WorkoutStepDuration.TIME.value
         assert step.duration_time == 600_000.0  # 10min in ms
         assert step.target_type == WorkoutStepTarget.OPEN.value
+        assert step.target_value == 0
+
+    def test_cooldown_has_open_target(self) -> None:
+        """Cooldown bekommt IMMER target_type=OPEN."""
+        seg = Segment(
+            position=0,
+            segment_type="cooldown",
+            target_duration_minutes=7,
+            target_pace_min="6:00",
+        )
+        step = _build_workout_step(seg, message_index=0)
+
+        assert step.intensity == Intensity.COOLDOWN.value
+        assert step.target_type == WorkoutStepTarget.OPEN.value
+        assert step.target_value == 0
 
     def test_work_with_distance(self) -> None:
         seg = Segment(position=0, segment_type="work", target_distance_km=1.0)
@@ -73,14 +163,15 @@ class TestBuildWorkoutStep:
         assert step.duration_type == WorkoutStepDuration.DISTANCE.value
         assert step.duration_distance == 100.0  # 1km in fit-tool Einheiten
 
-    def test_cooldown_open_duration(self) -> None:
+    def test_open_duration(self) -> None:
         seg = Segment(position=0, segment_type="cooldown")
         step = _build_workout_step(seg, message_index=0)
 
         assert step.intensity == Intensity.COOLDOWN.value
         assert step.duration_type == WorkoutStepDuration.OPEN.value
 
-    def test_pace_target(self) -> None:
+    def test_pace_target_with_target_value_zero(self) -> None:
+        """target_value=0 MUSS gesetzt sein fuer Custom Speed Ranges."""
         seg = Segment(
             position=0,
             segment_type="work",
@@ -91,12 +182,14 @@ class TestBuildWorkoutStep:
         step = _build_workout_step(seg, message_index=0)
 
         assert step.target_type == WorkoutStepTarget.SPEED.value
-        # 5:30 (langsamer) → niedrigerer Speed → low
+        assert step.target_value == 0  # PFLICHT fuer Custom Range!
+        # 5:30 (langsamer) -> niedrigerer Speed -> low
         assert step.custom_target_speed_low == int(pace_to_speed_mps("5:30") * 1000)
-        # 5:00 (schneller) → hoeherer Speed → high
+        # 5:00 (schneller) -> hoeherer Speed -> high
         assert step.custom_target_speed_high == int(pace_to_speed_mps("5:00") * 1000)
 
-    def test_hr_target(self) -> None:
+    def test_hr_target_with_target_value_zero(self) -> None:
+        """target_value=0 MUSS gesetzt sein fuer Custom HR Ranges."""
         seg = Segment(
             position=0,
             segment_type="steady",
@@ -107,6 +200,7 @@ class TestBuildWorkoutStep:
         step = _build_workout_step(seg, message_index=0)
 
         assert step.target_type == WorkoutStepTarget.HEART_RATE.value
+        assert step.target_value == 0  # PFLICHT fuer Custom Range!
         assert step.custom_target_heart_rate_low == 240  # 140 + 100
         assert step.custom_target_heart_rate_high == 260  # 160 + 100
 
@@ -132,6 +226,13 @@ class TestBuildWorkoutStep:
         step = _build_workout_step(seg, message_index=0)
         assert step.duration_type == WorkoutStepDuration.TIME.value
 
+    def test_open_target_has_target_value_zero(self) -> None:
+        """Auch OPEN-Target braucht target_value=0."""
+        seg = Segment(position=0, segment_type="work", target_duration_minutes=5)
+        step = _build_workout_step(seg, message_index=0)
+        assert step.target_type == WorkoutStepTarget.OPEN.value
+        assert step.target_value == 0
+
     def test_recovery_jog_intensity(self) -> None:
         seg = Segment(position=0, segment_type="recovery_jog")
         step = _build_workout_step(seg, message_index=0)
@@ -147,20 +248,48 @@ class TestBuildWorkoutStep:
         step = _build_workout_step(seg, message_index=7)
         assert step.message_index == 7
 
+    def test_step_name_readable(self) -> None:
+        seg = Segment(position=0, segment_type="warmup", target_duration_minutes=10)
+        step = _build_workout_step(seg, message_index=0)
+        assert step.workout_step_name == "Einlaufen"
+
     def test_step_name_from_notes(self) -> None:
-        seg = Segment(
-            position=0,
-            segment_type="work",
-            target_distance_km=1.0,
-            notes="Schnelle 1km",
-        )
+        seg = Segment(position=0, segment_type="work", target_distance_km=1.0, notes="Schnelle 1km")
         step = _build_workout_step(seg, message_index=0)
         assert step.workout_step_name == "Schnelle 1km"
 
-    def test_step_name_fallback_to_type(self) -> None:
-        seg = Segment(position=0, segment_type="warmup", target_duration_minutes=10)
-        step = _build_workout_step(seg, message_index=0)
-        assert step.workout_step_name == "warmup"
+
+# --- _build_recovery_step ---
+
+
+class TestBuildRecoveryStep:
+    def test_with_segment_data(self) -> None:
+        """Recovery-Step verwendet Segment-Daten wenn vorhanden."""
+        recovery_seg = Segment(
+            position=0,
+            segment_type="recovery_jog",
+            target_duration_minutes=2,
+            target_hr_min=120,
+            target_hr_max=140,
+        )
+        step = _build_recovery_step(message_index=5, recovery_segment=recovery_seg)
+
+        assert step.intensity == Intensity.RECOVERY.value
+        assert step.duration_type == WorkoutStepDuration.TIME.value
+        assert step.duration_time == 120_000.0  # 2min in ms
+        assert step.target_type == WorkoutStepTarget.HEART_RATE.value
+        assert step.target_value == 0
+        assert step.workout_step_name == "Trabpause"
+
+    def test_without_segment_fallback(self) -> None:
+        """Ohne Segment-Daten: OPEN Duration + OPEN Target."""
+        step = _build_recovery_step(message_index=3)
+
+        assert step.intensity == Intensity.RECOVERY.value
+        assert step.duration_type == WorkoutStepDuration.OPEN.value
+        assert step.target_type == WorkoutStepTarget.OPEN.value
+        assert step.target_value == 0
+        assert step.workout_step_name == "Trabpause"
 
 
 # --- segments_to_fit_steps ---
@@ -180,14 +309,9 @@ class TestSegmentsToFitSteps:
         assert steps[2].intensity == Intensity.COOLDOWN.value
 
     def test_repeats_generate_three_steps(self) -> None:
-        """repeats=4 → work + recovery + repeat = 3 FIT steps."""
+        """repeats=4 -> work + recovery + repeat = 3 FIT steps."""
         segments = [
-            Segment(
-                position=0,
-                segment_type="work",
-                target_distance_km=1.0,
-                repeats=4,
-            ),
+            Segment(position=0, segment_type="work", target_distance_km=1.0, repeats=4),
         ]
         steps = segments_to_fit_steps(segments)
         assert len(steps) == 3
@@ -197,9 +321,10 @@ class TestSegmentsToFitSteps:
         assert steps[0].duration_type == WorkoutStepDuration.DISTANCE.value
         assert steps[0].message_index == 0
 
-        # Recovery step (open)
+        # Recovery step (auto-generated, OPEN)
         assert steps[1].intensity == Intensity.RECOVERY.value
         assert steps[1].duration_type == WorkoutStepDuration.OPEN.value
+        assert steps[1].target_value == 0
         assert steps[1].message_index == 1
 
         # Repeat step
@@ -208,8 +333,60 @@ class TestSegmentsToFitSteps:
         assert steps[2].target_repeat_steps == 4
         assert steps[2].message_index == 2
 
+    def test_repeat_consumes_following_recovery_segment(self) -> None:
+        """Repeat-Block nutzt folgendes Recovery-Segment statt Auto-Recovery."""
+        segments = [
+            Segment(
+                position=0,
+                segment_type="work",
+                target_duration_minutes=3,
+                target_pace_min="5:00",
+                target_pace_max="5:30",
+                repeats=5,
+            ),
+            Segment(
+                position=1,
+                segment_type="recovery_jog",
+                target_duration_minutes=2,
+                target_hr_min=120,
+                target_hr_max=140,
+            ),
+        ]
+        steps = segments_to_fit_steps(segments)
+
+        # work(0) + recovery(1) + repeat(2) = 3 steps (recovery consumed)
+        assert len(steps) == 3
+
+        # Work-Step hat Pace-Target
+        assert steps[0].target_type == WorkoutStepTarget.SPEED.value
+        assert steps[0].target_value == 0
+        assert steps[0].workout_step_name == "Intervall 3min @ 5:00-5:30"
+
+        # Recovery-Step hat HR-Target + Dauer vom Segment
+        assert steps[1].intensity == Intensity.RECOVERY.value
+        assert steps[1].duration_type == WorkoutStepDuration.TIME.value
+        assert steps[1].duration_time == 120_000.0  # 2min
+        assert steps[1].target_type == WorkoutStepTarget.HEART_RATE.value
+        assert steps[1].target_value == 0
+
+        # Repeat-Step
+        assert steps[2].duration_type == WorkoutStepDuration.REPEAT_UNTIL_STEPS_CMPLT.value
+        assert steps[2].duration_step == 0
+        assert steps[2].target_repeat_steps == 5
+
+    def test_repeat_consumes_rest_segment(self) -> None:
+        """Repeat-Block erkennt auch 'rest' als Recovery-Typ."""
+        segments = [
+            Segment(position=0, segment_type="work", target_distance_km=0.4, repeats=8),
+            Segment(position=1, segment_type="rest", target_duration_minutes=1),
+        ]
+        steps = segments_to_fit_steps(segments)
+        assert len(steps) == 3
+        assert steps[1].intensity == Intensity.REST.value
+        assert steps[1].duration_time == 60_000.0
+
     def test_full_interval_workout(self) -> None:
-        """Warmup + 5x1km Intervalle + Cooldown."""
+        """Warmup + 5x1km Intervalle mit Recovery + Cooldown."""
         segments = [
             Segment(position=0, segment_type="warmup", target_duration_minutes=10),
             Segment(
@@ -217,29 +394,67 @@ class TestSegmentsToFitSteps:
                 segment_type="work",
                 target_distance_km=1.0,
                 target_pace_min="4:30",
-                target_pace_max="4:50",
+                target_pace_max="5:00",
                 repeats=5,
             ),
-            Segment(position=2, segment_type="cooldown", target_duration_minutes=5),
+            Segment(
+                position=2,
+                segment_type="recovery_jog",
+                target_duration_minutes=2,
+            ),
+            Segment(position=3, segment_type="cooldown", target_duration_minutes=5),
         ]
         steps = segments_to_fit_steps(segments)
 
         # warmup(0) + work(1) + recovery(2) + repeat(3) + cooldown(4) = 5
         assert len(steps) == 5
+
+        # Warmup: OPEN target
         assert steps[0].intensity == Intensity.WARMUP.value
+        assert steps[0].target_type == WorkoutStepTarget.OPEN.value
+        assert steps[0].workout_step_name == "Einlaufen"
+
+        # Work: Speed target
         assert steps[1].target_type == WorkoutStepTarget.SPEED.value
+        assert steps[1].target_value == 0
+        assert steps[1].workout_step_name == "Intervall 1km @ 4:30-5:00"
+
+        # Recovery: consumed from recovery_jog segment
+        assert steps[2].intensity == Intensity.RECOVERY.value
+        assert steps[2].duration_time == 120_000.0
+
+        # Repeat
         assert steps[3].target_repeat_steps == 5
+        assert steps[3].duration_step == 1
+
+        # Cooldown: OPEN target
         assert steps[4].intensity == Intensity.COOLDOWN.value
+        assert steps[4].target_type == WorkoutStepTarget.OPEN.value
+        assert steps[4].workout_step_name == "Auslaufen"
 
     def test_message_indices_sequential(self) -> None:
         segments = [
             Segment(position=0, segment_type="warmup", target_duration_minutes=5),
             Segment(position=1, segment_type="work", target_distance_km=0.8, repeats=3),
-            Segment(position=2, segment_type="cooldown", target_duration_minutes=5),
+            Segment(position=2, segment_type="recovery_jog", target_duration_minutes=1.5),
+            Segment(position=3, segment_type="cooldown", target_duration_minutes=5),
         ]
         steps = segments_to_fit_steps(segments)
         for i, step in enumerate(steps):
             assert step.message_index == i
+
+    def test_repeat_without_following_recovery(self) -> None:
+        """Repeat ohne folgendes Recovery-Segment -> Auto-Recovery."""
+        segments = [
+            Segment(position=0, segment_type="work", target_distance_km=1.0, repeats=3),
+            Segment(position=1, segment_type="cooldown", target_duration_minutes=5),
+        ]
+        steps = segments_to_fit_steps(segments)
+
+        # work(0) + auto-recovery(1) + repeat(2) + cooldown(3) = 4
+        assert len(steps) == 4
+        assert steps[1].workout_step_name == "Trabpause"
+        assert steps[1].duration_type == WorkoutStepDuration.OPEN.value
 
 
 # --- _build_repeat_step ---
@@ -266,7 +481,7 @@ class TestExportTemplateToFit:
         ]
         data = export_template_to_fit("Easy Run", segments)
         assert isinstance(data, bytes)
-        assert len(data) > 50  # FIT header allein ist ~14 bytes
+        assert len(data) > 50
 
     def test_empty_segments_raises(self) -> None:
         with pytest.raises(ValueError, match="Keine Segmente"):
@@ -283,7 +498,12 @@ class TestExportTemplateToFit:
                 target_pace_max="5:00",
                 repeats=5,
             ),
-            Segment(position=2, segment_type="cooldown", target_duration_minutes=5),
+            Segment(
+                position=2,
+                segment_type="recovery_jog",
+                target_duration_minutes=2,
+            ),
+            Segment(position=3, segment_type="cooldown", target_duration_minutes=5),
         ]
         data = export_template_to_fit("5x1km Intervalle", segments)
         assert isinstance(data, bytes)
@@ -292,7 +512,6 @@ class TestExportTemplateToFit:
     def test_name_truncated(self) -> None:
         long_name = "A" * 100
         segments = [Segment(position=0, segment_type="steady", target_duration_minutes=30)]
-        # Soll nicht crashen
         data = export_template_to_fit(long_name, segments)
         assert isinstance(data, bytes)
 


### PR DESCRIPTION
## Summary
- **Hauptbug**: `target_value=0` (FIT Field 4) fehlte — HealthFit ignorierte alle Pace/HR-Targets
- Repeat-Struktur korrigiert: 1 Block `[Work + Recovery] × N` statt 2 getrennte Blöcke
- Warmup/Cooldown → `target_type=OPEN` (kein Pace-Zwang)
- Recovery im Repeat nutzt Segment-Daten (Dauer, HR-Target)
- Deutsche Step-Namen: "Einlaufen", "Intervall 3min @ 5:00-5:30", "Trabpause", "Auslaufen"

## Verifizierung

Export mit fitparse analysiert — Struktur identisch mit funktionierenden HealthFit-Exports (VO2 Light Referenz):
```
Step 0: Einlaufen           — 600s, OPEN, warmup
Step 1: Intervall 3min @... — 180s, SPEED zone=0, active
Step 2: Trabpause           — 120s, HR zone=0, recovery
Step 3: REPEAT 1→2, 5×
Step 4: Auslaufen           — 420s, OPEN, cooldown
```

## Test plan
- [x] 46 Unit Tests (vorher 33), alle grün
- [x] 744 Backend-Tests gesamt grün
- [x] Ruff lint + format + mypy bestanden
- [ ] Manueller Import in HealthFit testen

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)