### PR TITLE
fix: Soll/Ist-Vergleich expandiert Work+Recovery als Paar

### DIFF
--- a/backend/app/models/segment.py
+++ b/backend/app/models/segment.py
@@ -63,10 +63,13 @@ class Segment(BaseModel):
     user_override: Optional[str] = None
 
     def expand(self) -> list[Segment]:
-        """Expandiert repeats zu einzelnen Segmenten (fuer Soll/Ist-Matching).
+        """Expandiert repeats zu einzelnen Segmenten (DEPRECATED).
 
-        Ein Segment mit repeats=4 wird zu 4 Work-Segmenten + 3 Recovery-Jog-Segmenten.
-        Segmente mit repeats=1 werden unveraendert zurueckgegeben.
+        HINWEIS: Fuer Soll/Ist-Matching `expand_segments()` verwenden!
+        Diese Methode expandiert nur ein einzelnes Segment und erzeugt dabei
+        auto-generierte Recovery-Segmente OHNE Targets. Die listenbasierte
+        `expand_segments()` erkennt Work+Recovery-Paare und uebertraegt die
+        Recovery-Targets korrekt.
         """
         if self.repeats <= 1:
             return [self.model_copy(update={"repeats": 1})]
@@ -90,6 +93,61 @@ class Segment(BaseModel):
                     )
                 )
         return result
+
+
+# Recovery-Types die nach einem Work-Segment als Paar erkannt werden
+_RECOVERY_TYPES = frozenset({"recovery_jog", "rest"})
+
+
+def expand_segments(segments: list[Segment]) -> list[Segment]:
+    """Expandiert eine Liste von Segmenten mit korrekter Paar-Erkennung.
+
+    Wenn ein Segment mit repeats > 1 gefolgt wird von einem Recovery-Segment,
+    werden sie als Paar [Work + Recovery] x N expandiert (letzter Recovery entfaellt).
+    Das Recovery-Segment behaelt dabei alle Targets (Pace, HR, Dauer).
+
+    Beispiel:
+        Input:  [warmup, work(repeats=3), recovery_jog(2min, pace 7:00), cooldown]
+        Output: [warmup, work, recovery_jog, work, recovery_jog, work, cooldown]
+                        (alle recovery_jog haben 2min + pace 7:00)
+    """
+    result: list[Segment] = []
+    pos = 0
+    i = 0
+
+    while i < len(segments):
+        seg = segments[i]
+
+        if seg.repeats > 1:
+            # Pruefen ob naechstes Segment ein Recovery ist
+            next_seg = segments[i + 1] if i + 1 < len(segments) else None
+            has_recovery_pair = next_seg is not None and next_seg.segment_type in _RECOVERY_TYPES
+
+            for rep in range(seg.repeats):
+                # Work-Segment (mit allen Targets)
+                result.append(seg.model_copy(update={"position": pos, "repeats": 1}))
+                pos += 1
+
+                # Recovery zwischen Wiederholungen (nicht nach der letzten)
+                if rep < seg.repeats - 1:
+                    if has_recovery_pair and next_seg is not None:
+                        # Recovery-Segment MIT Targets verwenden
+                        result.append(next_seg.model_copy(update={"position": pos, "repeats": 1}))
+                    else:
+                        # Auto-generierter Recovery-Fallback (OHNE Targets)
+                        result.append(Segment(position=pos, segment_type="recovery_jog"))
+                    pos += 1
+
+            # Recovery-Segment ueberspringen wenn als Paar konsumiert
+            if has_recovery_pair:
+                i += 1
+        else:
+            result.append(seg.model_copy(update={"position": pos}))
+            pos += 1
+
+        i += 1
+
+    return result
 
 
 # --- Konvertierungsfunktionen ---

--- a/backend/app/services/segment_matcher.py
+++ b/backend/app/services/segment_matcher.py
@@ -12,6 +12,7 @@ from app.models.segment import (
     MatchedSegment,
     Segment,
     SegmentDelta,
+    expand_segments,
 )
 
 
@@ -105,9 +106,7 @@ def match_segments(
 
     Geplante Segmente werden zuerst expandiert (repeats aufloesen).
     """
-    expanded = []
-    for seg in planned:
-        expanded.extend(seg.expand())
+    expanded = expand_segments(planned)
 
     result: list[MatchedSegment] = []
     for i, (p, a) in enumerate(zip_longest(expanded, actual)):
@@ -151,7 +150,7 @@ def build_comparison(
     planned_run_type: str | None = None,
 ) -> ComparisonResponse:
     """Erstellt eine vollstaendige ComparisonResponse."""
-    expanded_count = sum(len(seg.expand()) for seg in planned_segments)
+    expanded_count = len(expand_segments(planned_segments))
     matched = match_segments(planned_segments, actual_segments)
 
     return ComparisonResponse(

--- a/backend/app/tests/test_segment.py
+++ b/backend/app/tests/test_segment.py
@@ -4,6 +4,7 @@ import pytest
 
 from app.models.segment import (
     Segment,
+    expand_segments,
     intervals_to_segments,
     lap_to_segment,
     laps_to_segments,
@@ -127,6 +128,154 @@ class TestExpand:
         expanded = seg.expand()
         positions = [s.position for s in expanded]
         assert positions == [5, 6, 7, 8, 9]
+
+
+class TestExpandSegments:
+    """Test expand_segments() — paar-basierte Expansion (Issue #345)."""
+
+    def test_no_repeats_passthrough(self) -> None:
+        """Segmente ohne repeats werden unveraendert durchgereicht."""
+        segments = [
+            Segment(position=0, segment_type="warmup", target_duration_minutes=10),
+            Segment(position=1, segment_type="steady", target_duration_minutes=30),
+            Segment(position=2, segment_type="cooldown", target_duration_minutes=5),
+        ]
+        result = expand_segments(segments)
+        assert len(result) == 3
+        assert [s.segment_type for s in result] == ["warmup", "steady", "cooldown"]
+
+    def test_work_with_recovery_pair(self) -> None:
+        """Work(repeats=3) + Recovery → [W, R, W, R, W] (Recovery hat Targets)."""
+        segments = [
+            Segment(
+                position=0,
+                segment_type="work",
+                target_duration_minutes=3,
+                target_pace_min="6:05",
+                target_pace_max="6:15",
+                repeats=3,
+            ),
+            Segment(
+                position=1,
+                segment_type="recovery_jog",
+                target_duration_minutes=2,
+                target_pace_min="7:00",
+                target_pace_max="7:30",
+            ),
+        ]
+        result = expand_segments(segments)
+
+        assert len(result) == 5
+        types = [s.segment_type for s in result]
+        assert types == ["work", "recovery_jog", "work", "recovery_jog", "work"]
+
+        # Alle Work-Segmente haben Targets
+        for s in result:
+            if s.segment_type == "work":
+                assert s.target_pace_min == "6:05"
+                assert s.target_duration_minutes == 3
+
+        # Alle Recovery-Segmente haben Targets vom Original
+        for s in result:
+            if s.segment_type == "recovery_jog":
+                assert s.target_pace_min == "7:00"
+                assert s.target_pace_max == "7:30"
+                assert s.target_duration_minutes == 2
+
+    def test_full_interval_workout(self) -> None:
+        """Session 20 Szenario: Warmup + 3x3min + Recovery + Cooldown → 7 Segmente."""
+        segments = [
+            Segment(position=0, segment_type="warmup", target_duration_minutes=10),
+            Segment(position=1, segment_type="work", target_duration_minutes=3, repeats=3),
+            Segment(
+                position=2,
+                segment_type="recovery_jog",
+                target_duration_minutes=2,
+                target_pace_min="7:00",
+                target_pace_max="7:30",
+            ),
+            Segment(position=3, segment_type="cooldown", target_duration_minutes=7),
+        ]
+        result = expand_segments(segments)
+
+        assert len(result) == 7
+        types = [s.segment_type for s in result]
+        assert types == [
+            "warmup",
+            "work",
+            "recovery_jog",
+            "work",
+            "recovery_jog",
+            "work",
+            "cooldown",
+        ]
+        # Kein doppelter Cooldown!
+        assert sum(1 for s in result if s.segment_type == "cooldown") == 1
+        # Recovery hat Targets
+        for s in result:
+            if s.segment_type == "recovery_jog":
+                assert s.target_pace_min == "7:00"
+
+    def test_work_without_following_recovery(self) -> None:
+        """Work(repeats=3) ohne Recovery → auto-generierte Recovery."""
+        segments = [
+            Segment(position=0, segment_type="work", target_distance_km=1, repeats=3),
+            Segment(position=1, segment_type="cooldown", target_duration_minutes=5),
+        ]
+        result = expand_segments(segments)
+
+        assert len(result) == 6  # W, R, W, R, W, Cooldown
+        types = [s.segment_type for s in result]
+        assert types == ["work", "recovery_jog", "work", "recovery_jog", "work", "cooldown"]
+        # Auto-Recovery hat KEINE Targets
+        for s in result:
+            if s.segment_type == "recovery_jog":
+                assert s.target_duration_minutes is None
+                assert s.target_pace_min is None
+
+    def test_rest_recognized_as_recovery_pair(self) -> None:
+        """'rest' wird als Recovery-Paar erkannt."""
+        segments = [
+            Segment(position=0, segment_type="work", target_distance_km=0.4, repeats=4),
+            Segment(position=1, segment_type="rest", target_duration_minutes=1),
+        ]
+        result = expand_segments(segments)
+        assert len(result) == 7  # W, rest, W, rest, W, rest, W
+        rest_segs = [s for s in result if s.segment_type == "rest"]
+        assert len(rest_segs) == 3
+        for s in rest_segs:
+            assert s.target_duration_minutes == 1
+
+    def test_positions_sequential(self) -> None:
+        """Positionen sind nach Expansion sequentiell."""
+        segments = [
+            Segment(position=0, segment_type="warmup", target_duration_minutes=5),
+            Segment(position=1, segment_type="work", repeats=3),
+            Segment(position=2, segment_type="recovery_jog", target_duration_minutes=2),
+            Segment(position=3, segment_type="cooldown", target_duration_minutes=5),
+        ]
+        result = expand_segments(segments)
+        positions = [s.position for s in result]
+        assert positions == list(range(len(result)))
+
+    def test_recovery_with_own_repeats_consumed_as_pair(self) -> None:
+        """Recovery mit repeats>1 wird als Paar konsumiert (nicht eigens expandiert)."""
+        segments = [
+            Segment(position=0, segment_type="work", repeats=3),
+            Segment(
+                position=1,
+                segment_type="recovery_jog",
+                target_duration_minutes=2,
+                target_pace_min="7:00",
+                target_pace_max="7:30",
+                repeats=2,
+            ),
+        ]
+        result = expand_segments(segments)
+        # Work bestimmt die Anzahl: W, R, W, R, W = 5
+        assert len(result) == 5
+        types = [s.segment_type for s in result]
+        assert types == ["work", "recovery_jog", "work", "recovery_jog", "work"]
 
 
 class TestRunIntervalToSegment:


### PR DESCRIPTION
## Summary
- `expand_segments()` erkennt Work+Recovery als Paar: `[W, R, W, R, W]` statt getrennte Expansion
- Recovery behält alle Targets (Pace, HR, Dauer) bei Expansion
- Behebt Session 20 auf Prod: 10 geplante Segmente → korrekt 7
- Kein doppelter Cooldown, keine überflüssigen Trabphasen mehr

## Vorher → Nachher (Session 20)

**Vorher (10 Segmente, falsch):**
```
warmup → work → recovery(LEER) → work → recovery(LEER) → work
→ recovery(mit Pace) → recovery(LEER) → recovery(mit Pace) → cooldown
```

**Nachher (7 Segmente, korrekt):**
```
warmup → work → recovery(7:00-7:30) → work → recovery(7:00-7:30) → work → cooldown
```

## Test plan
- [x] 7 neue Tests für `expand_segments()` (Paar-Erkennung, Targets, Positionen, Fallback)
- [x] 751 Backend-Tests gesamt grün
- [x] Ruff + mypy + format bestanden

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)