### PR TITLE
feat: Swagger-Docs unter /api/docs verfügbar

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -28,6 +28,9 @@ app = FastAPI(
     description="API for analyzing running and strength training data",
     version="0.1.0",
     lifespan=lifespan,
+    docs_url="/api/docs",
+    redoc_url="/api/redoc",
+    openapi_url="/api/openapi.json",
 )
 
 # CORS Middleware


### PR DESCRIPTION
## Summary
- `/api/docs` — Swagger UI (interaktiv, alle Endpoints ausprobieren)
- `/api/redoc` — ReDoc (übersichtliche Referenz)
- `/api/openapi.json` — OpenAPI Schema (für Tools/Import)

Verschiebt die FastAPI-Docs auf `/api/` Prefix, damit das Frontend-SPA Catch-All sie nicht überdeckt.

## Test plan
- [x] 751 Backend-Tests grün
- [ ] `/api/docs` auf Prod erreichbar nach Deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)