### PR TITLE
feat: FIT Export direkt von Wochenplan und Sessions

### DIFF
--- a/backend/app/api/v1/sessions.py
+++ b/backend/app/api/v1/sessions.py
@@ -6,6 +6,7 @@ from datetime import date, datetime, timedelta
 from typing import Optional
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
+from fastapi.responses import Response
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -1408,3 +1409,71 @@ async def _reparse_workout(
             "lap_overrides_restored": len(lap_overrides),
         },
     }
+
+
+# --- Session FIT Export (#352) ---
+
+
+@router.get("/{session_id}/export/fit")
+async def export_session_fit(
+    session_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Export einer Lauf-Session als FIT-Workout-Datei.
+
+    Konvertiert die Ist-Laps zu Workout-Steps (Ist-Daten als Soll),
+    damit das Training auf der Uhr wiederholt werden kann.
+    """
+    import re
+
+    from app.models.segment import laps_to_template_segments
+    from app.services.fit_export import export_template_to_fit
+
+    query = select(WorkoutModel).where(WorkoutModel.id == session_id)
+    result = await db.execute(query)
+    workout = result.scalar_one_or_none()
+    if not workout:
+        raise HTTPException(status_code=404, detail="Session nicht gefunden.")
+
+    if str(workout.workout_type) != "running":
+        raise HTTPException(
+            status_code=422,
+            detail="FIT-Export ist nur fuer Lauf-Sessions verfuegbar.",
+        )
+
+    if not workout.laps_json:
+        raise HTTPException(
+            status_code=422,
+            detail="Session hat keine Laps fuer den Export.",
+        )
+
+    # Laps → Template-Segmente (Ist-Daten als Soll)
+    laps_data = json.loads(str(workout.laps_json))
+    lap_responses = [LapResponse(**lap) for lap in laps_data]
+    segments = laps_to_template_segments(lap_responses)
+
+    if not segments:
+        raise HTTPException(
+            status_code=422,
+            detail="Session hat keine exportierbaren Segmente.",
+        )
+
+    # Workout-Name aus Training-Type + Datum
+    effective_type = workout.training_type_override or workout.training_type_auto or "lauf"
+    session_date = workout.date.strftime("%d.%m") if workout.date else ""
+    workout_name = f"{effective_type.capitalize()} {session_date}".strip()
+
+    fit_bytes = export_template_to_fit(
+        template_name=workout_name[:50],
+        segments=segments,
+    )
+
+    safe_name = re.sub(r"[^a-z0-9]+", "-", workout_name.lower()).strip("-")[:50]
+    today = date.today().isoformat()
+    filename = f"workout-{safe_name}-{today}.fit"
+
+    return Response(
+        content=fit_bytes,
+        media_type="application/octet-stream",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/backend/app/api/v1/weekly_plan.py
+++ b/backend/app/api/v1/weekly_plan.py
@@ -5,6 +5,7 @@ from datetime import date, datetime, timedelta
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -1268,3 +1269,62 @@ async def apply_recommendations(
     )
 
     return ApplyRecommendationsResponse(**result)
+
+
+# --- FIT Export (#352) ---
+
+
+@router.get("/entry/{entry_id}/export/fit")
+async def export_planned_session_fit(
+    entry_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Export eines geplanten Lauftrainings als FIT-Workout-Datei.
+
+    Konvertiert die Segmente eines Wochenplan-Eintrags direkt in eine
+    FIT-Datei fuer HealthFit / Apple Watch / Garmin.
+    """
+    import re
+
+    from app.services.fit_export import export_template_to_fit
+
+    result = await db.execute(select(PlannedSessionModel).where(PlannedSessionModel.id == entry_id))
+    entry = result.scalar_one_or_none()
+    if not entry:
+        raise HTTPException(status_code=404, detail="Geplanter Eintrag nicht gefunden.")
+
+    if str(entry.training_type) != "running":
+        raise HTTPException(
+            status_code=422,
+            detail="FIT-Export ist nur fuer Lauftrainings verfuegbar.",
+        )
+
+    run_details = None
+    if entry.run_details_json:
+        run_details = RunDetails.model_validate_json(str(entry.run_details_json))
+
+    if not run_details or not run_details.segments:
+        raise HTTPException(
+            status_code=422,
+            detail="Geplanter Eintrag hat keine Segmente fuer den Export.",
+        )
+
+    # Workout-Name: Notizen oder Run-Type
+    workout_name = str(entry.notes or "").split("\n")[0][:50] if entry.notes else None
+    if not workout_name:
+        workout_name = run_details.run_type or "Lauftraining"
+
+    fit_bytes = export_template_to_fit(
+        template_name=workout_name,
+        segments=run_details.segments,
+    )
+
+    safe_name = re.sub(r"[^a-z0-9]+", "-", workout_name.lower()).strip("-")[:50]
+    today = date.today().isoformat()
+    filename = f"workout-{safe_name}-{today}.fit"
+
+    return Response(
+        content=fit_bytes,
+        media_type="application/octet-stream",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/frontend/src/api/training.ts
+++ b/frontend/src/api/training.ts
@@ -656,3 +656,27 @@ export async function reparseSession(sessionId: number): Promise<ReparseResponse
   const response = await apiClient.post<ReparseResponse>(`/api/v1/sessions/${sessionId}/reparse`);
   return response.data;
 }
+
+// --- FIT Export (#352) ---
+
+export async function exportSessionFit(sessionId: number): Promise<void> {
+  const response = await apiClient.get(`/api/v1/sessions/${sessionId}/export/fit`, {
+    responseType: 'blob',
+  });
+  _downloadBlob(response.data as Blob, response.headers);
+}
+
+function _downloadBlob(blob: Blob, headers: Record<string, unknown>): void {
+  const contentDisposition = String(headers['content-disposition'] || '');
+  const match = contentDisposition.match(/filename="?([^"]+)"?/);
+  const filename = match?.[1] || 'workout.fit';
+
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/frontend/src/api/weekly-plan.ts
+++ b/frontend/src/api/weekly-plan.ts
@@ -269,3 +269,23 @@ export async function getPlannedSessionsForDate(date: string): Promise<PlannedSe
   );
   return response.data;
 }
+
+// --- FIT Export (#352) ---
+
+export async function exportPlannedSessionFit(entryId: number): Promise<void> {
+  const response = await apiClient.get(`/api/v1/weekly-plan/entry/${entryId}/export/fit`, {
+    responseType: 'blob',
+  });
+  const contentDisposition = String(response.headers['content-disposition'] || '');
+  const match = contentDisposition.match(/filename="?([^"]+)"?/);
+  const filename = match?.[1] || 'workout.fit';
+
+  const url = URL.createObjectURL(response.data as Blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/frontend/src/components/day-card/SessionDetailDialog.tsx
+++ b/frontend/src/components/day-card/SessionDetailDialog.tsx
@@ -27,12 +27,14 @@ import {
   BookmarkPlus,
   CircleCheck,
   CircleSlash,
+  Download,
   EllipsisVertical,
   LayoutTemplate,
   Pencil,
   Trash2,
 } from 'lucide-react';
 import type { PlannedSession, RunDetails } from '@/api/weekly-plan';
+import { exportPlannedSessionFit } from '@/api/weekly-plan';
 import { createEmptySegment } from '@/api/segment';
 import { getPresetSegments, hasSegmentData } from '@/config/segmentPresets';
 import { RUN_TYPE_LABELS, RUN_TYPE_OPTIONS, SESSION_TYPE_OPTIONS } from '@/constants/plan';
@@ -266,6 +268,23 @@ export function SessionDetailDialog({
                       Als Vorlage speichern
                     </DropdownMenuItem>
                   )}
+                  {session.training_type === 'running' &&
+                    session.id != null &&
+                    session.run_details?.segments &&
+                    session.run_details.segments.length > 0 && (
+                      <DropdownMenuItem
+                        icon={<Download />}
+                        onSelect={async () => {
+                          try {
+                            await exportPlannedSessionFit(session.id!);
+                          } catch {
+                            // Fehler still ignorieren — kein Toast verfuegbar
+                          }
+                        }}
+                      >
+                        Als FIT exportieren
+                      </DropdownMenuItem>
+                    )}
                   {canRemove && (
                     <DropdownMenuItem icon={<Trash2 />} onSelect={handleRemove}>
                       Entfernen

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -38,6 +38,7 @@ import {
   EllipsisVertical,
   BookmarkPlus,
   RefreshCw,
+  Download,
 } from 'lucide-react';
 import { format, parseISO } from 'date-fns';
 import { de } from 'date-fns/locale';
@@ -47,7 +48,7 @@ import {
   trainingTypeHints,
 } from '@/constants/training';
 import { createTemplateFromSession } from '@/api/session-templates';
-import { reparseSession } from '@/api/training';
+import { reparseSession, exportSessionFit } from '@/api/training';
 import type { StrengthExercisesEditorRef } from '@/components/StrengthExercisesEditor';
 import { generateInsights } from '@/utils/insights';
 import type { InsightType } from '@/utils/insights';
@@ -261,6 +262,24 @@ export function SessionDetailPage() {
               >
                 Als Template speichern
               </DropdownMenuItem>
+              {session?.workout_type === 'running' && (
+                <DropdownMenuItem
+                  icon={<Download />}
+                  onSelect={async () => {
+                    try {
+                      await exportSessionFit(Number(id));
+                    } catch {
+                      toast({
+                        title: 'Fehler',
+                        description: 'FIT-Export fehlgeschlagen.',
+                        variant: 'error',
+                      });
+                    }
+                  }}
+                >
+                  Als FIT exportieren
+                </DropdownMenuItem>
+              )}
               <DropdownMenuItem
                 icon={<RefreshCw />}
                 onSelect={async () => {


### PR DESCRIPTION
## Summary
- **Wochenplan → FIT**: "Als FIT exportieren" im Session-Dialog des Wochenplans
- **Session → FIT**: "Als FIT exportieren" im ⋮-Menü der SessionDetail
- Kein Umweg über Templates mehr nötig

## Neue Endpoints
- `GET /api/v1/weekly-plan/entry/{id}/export/fit` — geplantes Training
- `GET /api/v1/sessions/{id}/export/fit` — absolviertes Training (Ist→Soll)

## Test plan
- [x] 182 Frontend + 751 Backend Tests grün
- [x] TSC, ESLint, Prettier, Ruff, Mypy bestanden
- [ ] Wochenplan-Export auf Prod testen
- [ ] Session-Export auf Prod testen

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)