### PR TITLE
fix: Mobile-Responsiveness für Kraft-Editoren und Formulare

### DIFF
--- a/frontend/src/components/ExerciseFormSection.tsx
+++ b/frontend/src/components/ExerciseFormSection.tsx
@@ -77,7 +77,7 @@ function DurationFormInput({
 function SetHeader({ setType }: { setType: SetType }) {
   const fields = SET_TYPE_FIELDS[setType];
   return (
-    <div className="flex items-center gap-2 text-xs text-[var(--color-text-muted)] px-1">
+    <div className="hidden sm:flex items-center gap-2 text-xs text-[var(--color-text-muted)] px-1">
       <span className="w-6 shrink-0 text-center">#</span>
       {fields.reps && <span className="flex-1">Wdh.</span>}
       {fields.weight && <span className="flex-1">kg</span>}
@@ -89,88 +89,22 @@ function SetHeader({ setType }: { setType: SetType }) {
   );
 }
 
-function SetRowForm({
+function SetStatusControls({
   set,
   setIndex,
-  setType,
   onUpdate,
   onRemove,
   canRemove,
 }: {
   set: SetForm;
   setIndex: number;
-  setType: SetType;
   onUpdate: (updates: Partial<SetForm>) => void;
   onRemove: () => void;
   canRemove: boolean;
 }) {
-  const fields = SET_TYPE_FIELDS[setType];
-
   return (
-    <div className={`flex items-center gap-2 px-1 ${set.status === 'skipped' ? 'opacity-50' : ''}`}>
-      <span className="text-xs text-[var(--color-text-muted)] w-6 shrink-0 text-center tabular-nums">
-        {setIndex + 1}
-      </span>
-
-      {fields.reps && (
-        <div className="flex-1 min-w-0">
-          <NumberInput
-            value={set.reps ?? 0}
-            onChange={(val) => onUpdate({ reps: val })}
-            min={0}
-            max={999}
-            step={1}
-            inputSize="sm"
-            aria-label={`Satz ${setIndex + 1} Wiederholungen`}
-            incrementLabel="Wiederholung hinzufügen"
-            decrementLabel="Wiederholung entfernen"
-          />
-        </div>
-      )}
-
-      {fields.weight && (
-        <div className="flex-1 min-w-0">
-          <NumberInput
-            value={set.weight_kg ?? 0}
-            onChange={(val) => onUpdate({ weight_kg: val })}
-            min={0}
-            max={999}
-            step={2.5}
-            inputSize="sm"
-            aria-label={`Satz ${setIndex + 1} Gewicht kg`}
-            incrementLabel="Gewicht erhöhen"
-            decrementLabel="Gewicht verringern"
-          />
-        </div>
-      )}
-
-      {fields.duration && (
-        <div className="flex-1 min-w-0">
-          <DurationFormInput
-            value={set.duration_sec ?? 0}
-            onChange={(sec) => onUpdate({ duration_sec: sec })}
-            label={`Satz ${setIndex + 1}`}
-          />
-        </div>
-      )}
-
-      {fields.distance && (
-        <div className="flex-1 min-w-0">
-          <NumberInput
-            value={set.distance_m ?? 0}
-            onChange={(val) => onUpdate({ distance_m: val })}
-            min={0}
-            max={99999}
-            step={5}
-            inputSize="sm"
-            aria-label={`Satz ${setIndex + 1} Distanz m`}
-            incrementLabel="Distanz erhöhen"
-            decrementLabel="Distanz verringern"
-          />
-        </div>
-      )}
-
-      <div className="w-28 shrink-0">
+    <div className="flex items-center gap-2">
+      <div className="flex-1 sm:w-28 sm:flex-none sm:shrink-0">
         <Select
           options={STATUS_SELECT_OPTIONS}
           value={set.status}
@@ -188,6 +122,110 @@ function SetRowForm({
       >
         <Trash2 className="w-3.5 h-3.5" />
       </Button>
+    </div>
+  );
+}
+
+interface SetRowFormProps {
+  set: SetForm;
+  setIndex: number;
+  setType: SetType;
+  onUpdate: (updates: Partial<SetForm>) => void;
+  onRemove: () => void;
+  canRemove: boolean;
+}
+
+function SetRowForm({ set, setIndex, setType, onUpdate, onRemove, canRemove }: SetRowFormProps) {
+  const fields = SET_TYPE_FIELDS[setType];
+
+  return (
+    <div className={`space-y-2 sm:space-y-0 px-1 ${set.status === 'skipped' ? 'opacity-50' : ''}`}>
+      {/* Zeile 1: Index + Werte-Inputs */}
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-[var(--color-text-muted)] w-6 shrink-0 text-center tabular-nums">
+          {setIndex + 1}
+        </span>
+
+        {fields.reps && (
+          <div className="flex-1 min-w-0">
+            <NumberInput
+              value={set.reps ?? 0}
+              onChange={(val) => onUpdate({ reps: val })}
+              min={0}
+              max={999}
+              step={1}
+              inputSize="sm"
+              aria-label={`Satz ${setIndex + 1} Wiederholungen`}
+              incrementLabel="Wiederholung hinzufügen"
+              decrementLabel="Wiederholung entfernen"
+            />
+          </div>
+        )}
+
+        {fields.weight && (
+          <div className="flex-1 min-w-0">
+            <NumberInput
+              value={set.weight_kg ?? 0}
+              onChange={(val) => onUpdate({ weight_kg: val })}
+              min={0}
+              max={999}
+              step={2.5}
+              inputSize="sm"
+              aria-label={`Satz ${setIndex + 1} Gewicht kg`}
+              incrementLabel="Gewicht erhöhen"
+              decrementLabel="Gewicht verringern"
+            />
+          </div>
+        )}
+
+        {fields.duration && (
+          <div className="flex-1 min-w-0">
+            <DurationFormInput
+              value={set.duration_sec ?? 0}
+              onChange={(sec) => onUpdate({ duration_sec: sec })}
+              label={`Satz ${setIndex + 1}`}
+            />
+          </div>
+        )}
+
+        {fields.distance && (
+          <div className="flex-1 min-w-0">
+            <NumberInput
+              value={set.distance_m ?? 0}
+              onChange={(val) => onUpdate({ distance_m: val })}
+              min={0}
+              max={99999}
+              step={5}
+              inputSize="sm"
+              aria-label={`Satz ${setIndex + 1} Distanz m`}
+              incrementLabel="Distanz erhöhen"
+              decrementLabel="Distanz verringern"
+            />
+          </div>
+        )}
+
+        {/* Status + Delete: inline ab sm */}
+        <div className="hidden sm:block">
+          <SetStatusControls
+            set={set}
+            setIndex={setIndex}
+            onUpdate={onUpdate}
+            onRemove={onRemove}
+            canRemove={canRemove}
+          />
+        </div>
+      </div>
+
+      {/* Zeile 2 (nur Mobile): Status + Delete */}
+      <div className="pl-8 sm:hidden">
+        <SetStatusControls
+          set={set}
+          setIndex={setIndex}
+          onUpdate={onUpdate}
+          onRemove={onRemove}
+          canRemove={canRemove}
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/RunDetailsEditor.tsx
+++ b/frontend/src/components/RunDetailsEditor.tsx
@@ -163,7 +163,7 @@ function SegmentEditorRow({
       {/* Row 3: Pace range */}
       <div>
         <Label className="text-[10px] mb-0.5">Pace (M:SS / km)</Label>
-        <div className="grid grid-cols-2 gap-1.5">
+        <div className="grid grid-cols-2 gap-2">
           <div>
             <Label className="text-[10px] text-[var(--color-text-muted)] mb-0.5">
               Von (schnell)
@@ -196,7 +196,7 @@ function SegmentEditorRow({
       {/* Row 4: HR range */}
       <div>
         <Label className="text-[10px] mb-0.5">Herzfrequenz (bpm)</Label>
-        <div className="grid grid-cols-2 gap-1.5">
+        <div className="grid grid-cols-2 gap-2">
           <div>
             <Label className="text-[10px] text-[var(--color-text-muted)] mb-0.5">Min</Label>
             <Input

--- a/frontend/src/components/StrengthExerciseEditor.tsx
+++ b/frontend/src/components/StrengthExerciseEditor.tsx
@@ -154,7 +154,7 @@ function ExerciseRow({
 
       {/* Row 3: Sets / Reps / Weight */}
       {exercise.name && (
-        <div className="grid grid-cols-3 gap-1.5">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
           <div>
             <Label className="text-[10px] mb-0.5">Sätze</Label>
             <NumberInput

--- a/frontend/src/components/session-template/StrengthExercisesEditSection.tsx
+++ b/frontend/src/components/session-template/StrengthExercisesEditSection.tsx
@@ -174,7 +174,7 @@ export function StrengthExercisesEditSection({
                           </button>
                         ))}
                       </div>
-                      <div className="grid grid-cols-3 gap-3">
+                      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 sm:gap-3">
                         <div>
                           <Label className="mb-1 block text-xs text-[var(--color-text-muted)]">
                             Sätze

--- a/frontend/src/features/strength/SetRow.tsx
+++ b/frontend/src/features/strength/SetRow.tsx
@@ -31,7 +31,7 @@ function DurationInput({
   const secs = value % 60;
 
   return (
-    <div className="flex items-center gap-0.5">
+    <div className="flex items-center gap-1">
       <NumberInput
         value={mins}
         onChange={(m) => onChange(m * 60 + secs)}
@@ -59,74 +59,16 @@ function DurationInput({
   );
 }
 
-export function SetRow({ index, set, setType, onChange, onRemove, canRemove }: SetRowProps) {
-  const fields = SET_TYPE_FIELDS[setType];
-
+function SetRowStatusControls({
+  index,
+  set,
+  onChange,
+  onRemove,
+  canRemove,
+}: Omit<SetRowProps, 'setType'>) {
   return (
     <div className="flex items-center gap-2">
-      <span className="text-xs text-[var(--color-text-muted)] w-6 shrink-0 text-center tabular-nums">
-        {index + 1}
-      </span>
-
-      {fields.reps && (
-        <div className="flex-1 min-w-0">
-          <NumberInput
-            value={set.reps ?? 0}
-            onChange={(val) => onChange(index, { ...set, reps: val })}
-            min={0}
-            max={999}
-            step={1}
-            inputSize="sm"
-            aria-label={`Satz ${index + 1} Wiederholungen`}
-            incrementLabel="Wiederholung hinzufügen"
-            decrementLabel="Wiederholung entfernen"
-          />
-        </div>
-      )}
-
-      {fields.weight && (
-        <div className="flex-1 min-w-0">
-          <NumberInput
-            value={set.weight_kg ?? 0}
-            onChange={(val) => onChange(index, { ...set, weight_kg: val })}
-            min={0}
-            max={999}
-            step={2.5}
-            inputSize="sm"
-            aria-label={`Satz ${index + 1} Gewicht kg`}
-            incrementLabel="Gewicht erhöhen"
-            decrementLabel="Gewicht verringern"
-          />
-        </div>
-      )}
-
-      {fields.duration && (
-        <div className="flex-1 min-w-0">
-          <DurationInput
-            value={set.duration_sec ?? 0}
-            onChange={(sec) => onChange(index, { ...set, duration_sec: sec })}
-            label={`Satz ${index + 1}`}
-          />
-        </div>
-      )}
-
-      {fields.distance && (
-        <div className="flex-1 min-w-0">
-          <NumberInput
-            value={set.distance_m ?? 0}
-            onChange={(val) => onChange(index, { ...set, distance_m: val })}
-            min={0}
-            max={99999}
-            step={5}
-            inputSize="sm"
-            aria-label={`Satz ${index + 1} Distanz m`}
-            incrementLabel="Distanz erhöhen"
-            decrementLabel="Distanz verringern"
-          />
-        </div>
-      )}
-
-      <div className="w-28 shrink-0">
+      <div className="flex-1 sm:w-28 sm:flex-none sm:shrink-0">
         <Select
           options={statusOptions}
           value={set.status}
@@ -144,6 +86,101 @@ export function SetRow({ index, set, setType, onChange, onRemove, canRemove }: S
       >
         <Trash2 className="w-3.5 h-3.5" />
       </Button>
+    </div>
+  );
+}
+
+export function SetRow({ index, set, setType, onChange, onRemove, canRemove }: SetRowProps) {
+  const fields = SET_TYPE_FIELDS[setType];
+
+  return (
+    <div className="space-y-2 sm:space-y-0">
+      {/* Zeile 1: Index + Werte-Inputs */}
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-[var(--color-text-muted)] w-6 shrink-0 text-center tabular-nums">
+          {index + 1}
+        </span>
+
+        {fields.reps && (
+          <div className="flex-1 min-w-0">
+            <NumberInput
+              value={set.reps ?? 0}
+              onChange={(val) => onChange(index, { ...set, reps: val })}
+              min={0}
+              max={999}
+              step={1}
+              inputSize="sm"
+              aria-label={`Satz ${index + 1} Wiederholungen`}
+              incrementLabel="Wiederholung hinzufügen"
+              decrementLabel="Wiederholung entfernen"
+            />
+          </div>
+        )}
+
+        {fields.weight && (
+          <div className="flex-1 min-w-0">
+            <NumberInput
+              value={set.weight_kg ?? 0}
+              onChange={(val) => onChange(index, { ...set, weight_kg: val })}
+              min={0}
+              max={999}
+              step={2.5}
+              inputSize="sm"
+              aria-label={`Satz ${index + 1} Gewicht kg`}
+              incrementLabel="Gewicht erhöhen"
+              decrementLabel="Gewicht verringern"
+            />
+          </div>
+        )}
+
+        {fields.duration && (
+          <div className="flex-1 min-w-0">
+            <DurationInput
+              value={set.duration_sec ?? 0}
+              onChange={(sec) => onChange(index, { ...set, duration_sec: sec })}
+              label={`Satz ${index + 1}`}
+            />
+          </div>
+        )}
+
+        {fields.distance && (
+          <div className="flex-1 min-w-0">
+            <NumberInput
+              value={set.distance_m ?? 0}
+              onChange={(val) => onChange(index, { ...set, distance_m: val })}
+              min={0}
+              max={99999}
+              step={5}
+              inputSize="sm"
+              aria-label={`Satz ${index + 1} Distanz m`}
+              incrementLabel="Distanz erhöhen"
+              decrementLabel="Distanz verringern"
+            />
+          </div>
+        )}
+
+        {/* Status + Delete: inline ab sm */}
+        <div className="hidden sm:block">
+          <SetRowStatusControls
+            index={index}
+            set={set}
+            onChange={onChange}
+            onRemove={onRemove}
+            canRemove={canRemove}
+          />
+        </div>
+      </div>
+
+      {/* Zeile 2 (nur Mobile): Status + Delete */}
+      <div className="pl-8 sm:hidden">
+        <SetRowStatusControls
+          index={index}
+          set={set}
+          onChange={onChange}
+          onRemove={onRemove}
+          canRemove={canRemove}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Kraft-Session-Editor und Template-Editoren waren auf 375px (iPhone SE) nicht nutzbar — alle Felder in einer Zeile gequetscht.

**Vorher:** # | Wdh. | kg | Status | 🗑️ — alles in einer Zeile → unbenutzbar auf Mobile
**Nachher:** Zeile 1: # | Wdh. | kg → Zeile 2: Status | 🗑️ (nur auf Mobile)

### Geänderte Dateien
- `SetRow.tsx` — Status+Delete in eigene Zeile auf Mobile
- `ExerciseFormSection.tsx` — Gleicher Ansatz + Header nur ab sm
- `StrengthExerciseEditor.tsx` — `grid-cols-1 sm:grid-cols-3`
- `StrengthExercisesEditSection.tsx` — `grid-cols-1 sm:grid-cols-3`
- `RunDetailsEditor.tsx` — `gap-2` statt `gap-1.5`

## Test plan
- [x] 182 Frontend-Tests grün
- [x] ESLint 0 Warnings, TSC, Prettier bestanden
- [ ] Mobile-Test auf 375px

Closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)