### PR TITLE
feat: Sunrise/Sunset + Tageszeit-Tagging (#372)

### DIFF
--- a/backend/app/infrastructure/external/open_meteo_weather.py
+++ b/backend/app/infrastructure/external/open_meteo_weather.py
@@ -14,6 +14,7 @@ class OpenMeteoWeatherClient:
     """Wetterdaten von Open-Meteo (kostenlos, kein API-Key)."""
 
     HOURLY_PARAMS = "temperature_2m,relative_humidity_2m,wind_speed_10m,precipitation,weather_code"
+    DAILY_PARAMS = "sunrise,sunset"
 
     def __init__(self) -> None:
         self.client = ExternalAPIClient(
@@ -28,6 +29,7 @@ class OpenMeteoWeatherClient:
             "latitude": lat,
             "longitude": lon,
             "hourly": self.HOURLY_PARAMS,
+            "daily": self.DAILY_PARAMS,
             "start_date": date_str,
             "end_date": date_str,
             "timezone": "auto",
@@ -51,6 +53,7 @@ class OpenMeteoWeatherClient:
                 "latitude": lat,
                 "longitude": lon,
                 "hourly": self.HOURLY_PARAMS,
+                "daily": self.DAILY_PARAMS,
                 "start_date": date_str,
                 "end_date": date_str,
                 "timezone": "auto",
@@ -59,7 +62,7 @@ class OpenMeteoWeatherClient:
         return self._extract_closest_hour(data, dt)
 
     def _extract_closest_hour(self, data: dict | None, dt: datetime) -> WeatherData | None:
-        """Extrahiert den naechstliegenden Stundenwert."""
+        """Extrahiert den naechstliegenden Stundenwert + Sunrise/Sunset."""
         if not data or "hourly" not in data:
             return None
 
@@ -72,6 +75,15 @@ class OpenMeteoWeatherClient:
         target_hour = dt.hour
         idx = min(target_hour, len(times) - 1)
 
+        # Sunrise/Sunset aus daily extrahieren
+        sunrise = None
+        sunset = None
+        daily = data.get("daily", {})
+        if daily.get("sunrise"):
+            sunrise = daily["sunrise"][0] if daily["sunrise"] else None
+        if daily.get("sunset"):
+            sunset = daily["sunset"][0] if daily["sunset"] else None
+
         try:
             weather_code = int(hourly["weather_code"][idx] or 0)
             return WeatherData(
@@ -81,6 +93,8 @@ class OpenMeteoWeatherClient:
                 precipitation_mm=float(hourly["precipitation"][idx] or 0),
                 weather_code=weather_code,
                 weather_label=wmo_to_label(weather_code),
+                sunrise=sunrise,
+                sunset=sunset,
             )
         except (IndexError, TypeError, ValueError) as e:
             logger.warning("Fehler beim Parsen der Wetterdaten: %s", e)

--- a/backend/app/models/enrichment.py
+++ b/backend/app/models/enrichment.py
@@ -1,5 +1,7 @@
 """Pydantic Schemas fuer Session-Enrichment (externe APIs)."""
 
+from datetime import datetime
+
 from pydantic import BaseModel
 
 
@@ -12,6 +14,8 @@ class WeatherData(BaseModel):
     precipitation_mm: float
     weather_code: int  # WMO-Code
     weather_label: str  # Deutsch: "Klar", "Bewölkt", etc.
+    sunrise: str | None = None  # ISO-Zeit, z.B. "2026-03-20T06:15"
+    sunset: str | None = None  # ISO-Zeit, z.B. "2026-03-20T18:30"
 
 
 class AirQualityData(BaseModel):
@@ -93,3 +97,47 @@ def uv_to_label(uv: float) -> str:
     if uv <= 10:
         return "Sehr hoch"
     return "Extrem"
+
+
+# --- Tageszeit-Tagging ---
+
+DAYTIME_LABELS: dict[str, str] = {
+    "dawn": "Morgenlauf",
+    "day": "Tageslauf",
+    "dusk": "Abendlauf",
+    "night": "Nachtlauf",
+}
+
+
+def _classify_hour(session_hour: float, sr_hour: float, ss_hour: float) -> str:
+    """Klassifiziert Tageszeit anhand Session-Stunde und Sunrise/Sunset."""
+    if session_hour < sr_hour - 0.5 or session_hour >= ss_hour + 0.5:
+        return "night"
+    if session_hour < sr_hour + 1:
+        return "dawn"
+    if session_hour < ss_hour - 1:
+        return "day"
+    return "dusk"
+
+
+def compute_daytime_tag(
+    session_dt: datetime,
+    sunrise: str | None = None,
+    sunset: str | None = None,
+) -> str:
+    """Tageszeit-Tag basierend auf Sunrise/Sunset oder Heuristik.
+
+    Returns: "dawn", "day", "dusk", "night"
+    """
+    session_hour = session_dt.hour + session_dt.minute / 60
+
+    if sunrise and sunset:
+        try:
+            sr = datetime.fromisoformat(sunrise)
+            ss = datetime.fromisoformat(sunset)
+            return _classify_hour(session_hour, sr.hour + sr.minute / 60, ss.hour + ss.minute / 60)
+        except (ValueError, AttributeError):
+            pass
+
+    # Heuristik-Fallback: Sunrise ~6:00, Sunset ~20:00
+    return _classify_hour(session_hour, 6.0, 20.0)

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -9,7 +9,12 @@ from typing import TYPE_CHECKING, Optional
 
 from pydantic import BaseModel, Field
 
-from app.models.enrichment import AirQualityData, WeatherData
+from app.models.enrichment import (
+    DAYTIME_LABELS,
+    AirQualityData,
+    WeatherData,
+    compute_daytime_tag,
+)
 from app.models.segment import Segment, laps_to_segments
 
 if TYPE_CHECKING:
@@ -110,6 +115,10 @@ class SessionResponse(BaseModel):
     air_quality: Optional[AirQualityData] = None
     surface: Optional[dict[str, float]] = None  # {"Asphalt": 70.0, "Schotter": 30.0}
     elevation_corrected: bool = False
+    daytime_tag: Optional[str] = None  # "dawn", "day", "dusk", "night"
+    daytime_label: Optional[str] = None  # "Morgenlauf", "Tageslauf", etc.
+    sunrise: Optional[str] = None  # ISO-Zeit
+    sunset: Optional[str] = None  # ISO-Zeit
     created_at: datetime
     updated_at: datetime
 
@@ -178,6 +187,16 @@ class SessionResponse(BaseModel):
             with contextlib.suppress(json.JSONDecodeError, Exception):
                 surface = json.loads(str(model.surface_json))
 
+        # Tageszeit-Tag berechnen
+        session_dt = (
+            model.date
+            if isinstance(model.date, datetime)
+            else datetime.combine(model.date, datetime.min.time().replace(hour=9))
+        )
+        sunrise = weather.sunrise if weather else None
+        sunset = weather.sunset if weather else None
+        daytime_tag = compute_daytime_tag(session_dt, sunrise, sunset)
+
         return cls(
             id=model.id,
             date=session_date,
@@ -207,6 +226,10 @@ class SessionResponse(BaseModel):
             air_quality=air_quality,
             surface=surface,
             elevation_corrected=bool(model.elevation_corrected),
+            daytime_tag=daytime_tag,
+            daytime_label=DAYTIME_LABELS.get(daytime_tag),
+            sunrise=sunrise,
+            sunset=sunset,
             created_at=model.created_at,
             updated_at=model.updated_at,
         )
@@ -229,6 +252,8 @@ class SessionListItem(BaseModel):
     # Enrichment (kompakt fuer Liste)
     location_name: Optional[str] = None
     weather_label: Optional[str] = None
+    daytime_tag: Optional[str] = None  # "dawn", "day", "dusk", "night"
+    daytime_label: Optional[str] = None  # "Morgenlauf", "Tageslauf", etc.
 
     @classmethod
     def from_db(cls, model: WorkoutModel) -> SessionListItem:
@@ -260,12 +285,24 @@ class SessionListItem(BaseModel):
             exercises_count = m["total_exercises"]
             total_tonnage_kg = m["total_tonnage_kg"]
 
-        # Wetter-Label fuer Liste
+        # Wetter-Label + Sunrise/Sunset fuer Liste
         weather_label = None
+        sunrise = None
+        sunset = None
         if model.weather_json:
             with contextlib.suppress(json.JSONDecodeError, Exception):
                 w = json.loads(str(model.weather_json))
                 weather_label = w.get("weather_label")
+                sunrise = w.get("sunrise")
+                sunset = w.get("sunset")
+
+        # Tageszeit-Tag berechnen
+        session_dt = (
+            model.date
+            if isinstance(model.date, datetime)
+            else datetime.combine(model.date, datetime.min.time().replace(hour=9))
+        )
+        daytime_tag = compute_daytime_tag(session_dt, sunrise, sunset)
 
         return cls(
             id=model.id,
@@ -281,6 +318,8 @@ class SessionListItem(BaseModel):
             total_tonnage_kg=total_tonnage_kg,
             location_name=model.location_name if model.location_name else None,
             weather_label=weather_label,
+            daytime_tag=daytime_tag,
+            daytime_label=DAYTIME_LABELS.get(daytime_tag),
         )
 
 

--- a/frontend/src/api/training.ts
+++ b/frontend/src/api/training.ts
@@ -71,6 +71,8 @@ export interface SessionSummary {
   // Enrichment
   location_name: string | null;
   weather_label: string | null;
+  daytime_tag: string | null; // "dawn", "day", "dusk", "night"
+  daytime_label: string | null; // "Morgenlauf", "Tageslauf", etc.
 }
 
 interface SessionListApiResponse {
@@ -277,6 +279,10 @@ export interface SessionDetail {
   air_quality: AirQualityData | null;
   surface: Record<string, number> | null; // {"Asphalt": 70.0, "Schotter": 30.0}
   elevation_corrected: boolean;
+  daytime_tag: string | null; // "dawn", "day", "dusk", "night"
+  daytime_label: string | null; // "Morgenlauf", "Tageslauf", etc.
+  sunrise: string | null; // ISO-Zeit
+  sunset: string | null; // ISO-Zeit
   created_at: string;
   updated_at: string;
 }
@@ -288,6 +294,8 @@ export interface WeatherData {
   precipitation_mm: number;
   weather_code: number;
   weather_label: string;
+  sunrise: string | null;
+  sunset: string | null;
 }
 
 export interface AirQualityData {

--- a/frontend/src/components/session-detail/SessionEnvironmentSection.tsx
+++ b/frontend/src/components/session-detail/SessionEnvironmentSection.tsx
@@ -5,14 +5,17 @@ import {
   Droplets,
   Haze,
   MapPin,
+  Moon,
   ShieldCheck,
   Sun,
   SunDim,
+  Sunrise,
+  Sunset,
   Thermometer,
   Wind,
   Zap,
 } from 'lucide-react';
-import { Card, CardHeader, CardBody } from '@nordlig/components';
+import { Card, CardHeader, CardBody, Badge } from '@nordlig/components';
 import type { WeatherData, AirQualityData } from '@/api/training';
 
 interface SessionEnvironmentSectionProps {
@@ -20,6 +23,10 @@ interface SessionEnvironmentSectionProps {
   airQuality: AirQualityData | null;
   locationName: string | null;
   surface: Record<string, number> | null;
+  daytimeTag: string | null;
+  daytimeLabel: string | null;
+  sunrise: string | null;
+  sunset: string | null;
 }
 
 function weatherIcon(code: number) {
@@ -49,6 +56,28 @@ function MetricItem({
       </div>
     </div>
   );
+}
+
+function daytimeIcon(tag: string) {
+  switch (tag) {
+    case 'dawn':
+      return <Sunrise className="w-4 h-4" />;
+    case 'dusk':
+      return <Sunset className="w-4 h-4" />;
+    case 'night':
+      return <Moon className="w-4 h-4" />;
+    default:
+      return <Sun className="w-4 h-4" />;
+  }
+}
+
+function formatTime(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+  } catch {
+    return iso;
+  }
 }
 
 const SURFACE_COLORS = [
@@ -91,84 +120,128 @@ function SurfaceBar({ surface }: { surface: Record<string, number> }) {
   );
 }
 
+function EnvironmentMetricsGrid({
+  weather,
+  airQuality,
+  sunrise,
+  sunset,
+}: {
+  weather: WeatherData | null;
+  airQuality: AirQualityData | null;
+  sunrise: string | null;
+  sunset: string | null;
+}) {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      {weather && (
+        <>
+          <MetricItem
+            icon={weatherIcon(weather.weather_code)}
+            label="Wetter"
+            value={weather.weather_label}
+          />
+          <MetricItem
+            icon={<Thermometer className="w-4 h-4" />}
+            label="Temperatur"
+            value={`${weather.temperature_c.toFixed(1)} °C`}
+          />
+          <MetricItem
+            icon={<Wind className="w-4 h-4" />}
+            label="Wind"
+            value={`${weather.wind_speed_kmh.toFixed(0)} km/h`}
+          />
+          <MetricItem
+            icon={<Droplets className="w-4 h-4" />}
+            label="Luftfeuchtigkeit"
+            value={`${weather.humidity_pct.toFixed(0)} %`}
+          />
+        </>
+      )}
+      {airQuality && (
+        <>
+          <MetricItem
+            icon={<ShieldCheck className="w-4 h-4" />}
+            label="Luftqualität"
+            value={`AQI ${airQuality.european_aqi} — ${airQuality.aqi_label}`}
+          />
+          <MetricItem
+            icon={<SunDim className="w-4 h-4" />}
+            label="UV-Index"
+            value={`${airQuality.uv_index.toFixed(1)} — ${airQuality.uv_label}`}
+          />
+          <MetricItem
+            icon={<Haze className="w-4 h-4" />}
+            label="PM2.5"
+            value={`${airQuality.pm2_5.toFixed(1)} µg/m³`}
+          />
+          <MetricItem
+            icon={<Haze className="w-4 h-4" />}
+            label="PM10"
+            value={`${airQuality.pm10.toFixed(1)} µg/m³`}
+          />
+        </>
+      )}
+      {sunrise && (
+        <MetricItem
+          icon={<Sunrise className="w-4 h-4" />}
+          label="Sonnenaufgang"
+          value={formatTime(sunrise)}
+        />
+      )}
+      {sunset && (
+        <MetricItem
+          icon={<Sunset className="w-4 h-4" />}
+          label="Sonnenuntergang"
+          value={formatTime(sunset)}
+        />
+      )}
+    </div>
+  );
+}
+
 export function SessionEnvironmentSection({
   weather,
   airQuality,
   locationName,
   surface,
+  daytimeTag,
+  daytimeLabel,
+  sunrise,
+  sunset,
 }: SessionEnvironmentSectionProps) {
-  if (!weather && !airQuality && !locationName && !surface) return null;
+  if (!weather && !airQuality && !locationName && !surface && !daytimeTag) return null;
 
   return (
     <Card elevation="raised">
       <CardHeader>
-        <h2 className="text-sm font-semibold text-[var(--color-text-base)]">
-          Umgebungsbedingungen
-        </h2>
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-[var(--color-text-base)]">
+            Umgebungsbedingungen
+          </h2>
+          {daytimeTag && daytimeLabel && (
+            <Badge variant="neutral" size="sm">
+              <span className="flex items-center gap-1">
+                {daytimeIcon(daytimeTag)}
+                {daytimeLabel}
+              </span>
+            </Badge>
+          )}
+        </div>
       </CardHeader>
       <CardBody>
         <div className="space-y-4">
-          {/* Location */}
           {locationName && (
             <div className="flex items-center gap-2 text-sm text-[var(--color-text-muted)]">
               <MapPin className="w-4 h-4 shrink-0" />
               <span>{locationName}</span>
             </div>
           )}
-
-          {/* Alle Metriken in einheitlichem Grid */}
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-            {weather && (
-              <>
-                <MetricItem
-                  icon={weatherIcon(weather.weather_code)}
-                  label="Wetter"
-                  value={weather.weather_label}
-                />
-                <MetricItem
-                  icon={<Thermometer className="w-4 h-4" />}
-                  label="Temperatur"
-                  value={`${weather.temperature_c.toFixed(1)} °C`}
-                />
-                <MetricItem
-                  icon={<Wind className="w-4 h-4" />}
-                  label="Wind"
-                  value={`${weather.wind_speed_kmh.toFixed(0)} km/h`}
-                />
-                <MetricItem
-                  icon={<Droplets className="w-4 h-4" />}
-                  label="Luftfeuchtigkeit"
-                  value={`${weather.humidity_pct.toFixed(0)} %`}
-                />
-              </>
-            )}
-            {airQuality && (
-              <>
-                <MetricItem
-                  icon={<ShieldCheck className="w-4 h-4" />}
-                  label="Luftqualität"
-                  value={`AQI ${airQuality.european_aqi} — ${airQuality.aqi_label}`}
-                />
-                <MetricItem
-                  icon={<SunDim className="w-4 h-4" />}
-                  label="UV-Index"
-                  value={`${airQuality.uv_index.toFixed(1)} — ${airQuality.uv_label}`}
-                />
-                <MetricItem
-                  icon={<Haze className="w-4 h-4" />}
-                  label="PM2.5"
-                  value={`${airQuality.pm2_5.toFixed(1)} µg/m³`}
-                />
-                <MetricItem
-                  icon={<Haze className="w-4 h-4" />}
-                  label="PM10"
-                  value={`${airQuality.pm10.toFixed(1)} µg/m³`}
-                />
-              </>
-            )}
-          </div>
-
-          {/* Untergrund */}
+          <EnvironmentMetricsGrid
+            weather={weather}
+            airQuality={airQuality}
+            sunrise={sunrise}
+            sunset={sunset}
+          />
           {surface && Object.keys(surface).length > 0 && <SurfaceBar surface={surface} />}
         </div>
       </CardBody>

--- a/frontend/src/pages/SessionDetail.test.tsx
+++ b/frontend/src/pages/SessionDetail.test.tsx
@@ -102,6 +102,10 @@ const mockSession: SessionDetail = {
   air_quality: null,
   surface: null,
   elevation_corrected: false,
+  daytime_tag: 'dawn',
+  daytime_label: 'Morgenlauf',
+  sunrise: '2025-02-25T07:00',
+  sunset: '2025-02-25T17:45',
   created_at: '2025-02-25T08:00:00',
   updated_at: '2025-02-25T08:15:00',
 };

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -416,13 +416,21 @@ export function SessionDetailPage() {
         />
       )}
 
-      {/* Umgebungsbedingungen (Wetter, Luftqualität, Location, Untergrund) */}
-      {(session.weather || session.air_quality || session.location_name || session.surface) && (
+      {/* Umgebungsbedingungen (Wetter, Luftqualität, Location, Untergrund, Tageszeit) */}
+      {(session.weather ||
+        session.air_quality ||
+        session.location_name ||
+        session.surface ||
+        session.daytime_tag) && (
         <SessionEnvironmentSection
           weather={session.weather}
           airQuality={session.air_quality}
           locationName={session.location_name}
           surface={session.surface}
+          daytimeTag={session.daytime_tag}
+          daytimeLabel={session.daytime_label}
+          sunrise={session.sunrise}
+          sunset={session.sunset}
         />
       )}
 

--- a/frontend/src/pages/Sessions.tsx
+++ b/frontend/src/pages/Sessions.tsx
@@ -342,10 +342,12 @@ export function SessionsPage() {
                         }
                       })()}
                     </p>
-                    {/* Location + Wetter */}
-                    {(session.location_name || session.weather_label) && (
+                    {/* Location + Wetter + Tageszeit */}
+                    {(session.location_name || session.weather_label || session.daytime_label) && (
                       <p className="text-[11px] text-[var(--color-text-muted)] mb-[4px] truncate">
-                        {[session.location_name, session.weather_label].filter(Boolean).join(' · ')}
+                        {[session.location_name, session.weather_label, session.daytime_label]
+                          .filter(Boolean)
+                          .join(' · ')}
                       </p>
                     )}
                     {/* Colored border tags */}


### PR DESCRIPTION
## Summary
- Open-Meteo daily API liefert Sunrise/Sunset-Zeiten für Sessions
- Automatisches Tageszeit-Tagging: Morgenlauf, Tageslauf, Abendlauf, Nachtlauf
- Tag basiert auf Session-Startzeit relativ zu Sonnenauf-/-untergang (Heuristik-Fallback wenn keine Daten)
- Sonnenauf-/untergangszeiten im Session-Detail angezeigt
- Tageszeit-Label in der Session-Liste

## Test plan
- [x] Ruff check + format: bestanden
- [x] Mypy: bestanden
- [x] Pytest: 773 passed
- [x] TSC + ESLint + Prettier: bestanden
- [x] Vitest: 182 passed
- [ ] CI grün
- [ ] Session-Detail: Badge "Morgenlauf"/"Tageslauf" etc. + Sunrise/Sunset-Zeiten
- [ ] Session-Liste: Tageszeit-Label neben Location + Wetter

Fixes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)