### PR TITLE
fix: FIT start_time für Tageszeit-Tagging (#379)

### DIFF
--- a/backend/app/api/v1/sessions.py
+++ b/backend/app/api/v1/sessions.py
@@ -234,6 +234,19 @@ def _apply_lap_overrides(laps: list[dict] | None, overrides_json: str | None) ->
         pass
 
 
+def _resolve_session_datetime(training_date: date, summary: dict) -> datetime:
+    """Kombiniert Datum mit Uhrzeit aus Parser (FIT start_time) oder Fallback 00:00."""
+    start_time_str = summary.get("start_time")
+    if start_time_str:
+        try:
+            parsed_dt = datetime.fromisoformat(start_time_str)
+            # Uhrzeit aus FIT auf das vom User gewählte Datum setzen
+            return datetime.combine(training_date, parsed_dt.time())
+        except (ValueError, AttributeError):
+            pass
+    return datetime.combine(training_date, datetime.min.time())
+
+
 def _validate_type_override(override: str | None) -> str | None:
     """Gibt Override zurück wenn gültig, sonst None."""
     if override and override not in VALID_TRAINING_TYPES:
@@ -254,7 +267,7 @@ def _build_workout_model(
     laps = parsed["laps"]
 
     return WorkoutModel(
-        date=datetime.combine(form.training_date, datetime.min.time()),
+        date=_resolve_session_datetime(form.training_date, summary),
         workout_type=form.training_type.value,
         subtype=form.training_subtype.value if form.training_subtype else None,
         training_type_auto=classification.training_type if classification else None,

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -187,15 +187,12 @@ class SessionResponse(BaseModel):
             with contextlib.suppress(json.JSONDecodeError, Exception):
                 surface = json.loads(str(model.surface_json))
 
-        # Tageszeit-Tag berechnen
-        session_dt = (
-            model.date
-            if isinstance(model.date, datetime)
-            else datetime.combine(model.date, datetime.min.time().replace(hour=9))
-        )
+        # Tageszeit-Tag berechnen (nur wenn echte Uhrzeit vorhanden)
         sunrise = weather.sunrise if weather else None
         sunset = weather.sunset if weather else None
-        daytime_tag = compute_daytime_tag(session_dt, sunrise, sunset)
+        daytime_tag: str | None = None
+        if isinstance(model.date, datetime) and (model.date.hour != 0 or model.date.minute != 0):
+            daytime_tag = compute_daytime_tag(model.date, sunrise, sunset)
 
         return cls(
             id=model.id,
@@ -227,7 +224,7 @@ class SessionResponse(BaseModel):
             surface=surface,
             elevation_corrected=bool(model.elevation_corrected),
             daytime_tag=daytime_tag,
-            daytime_label=DAYTIME_LABELS.get(daytime_tag),
+            daytime_label=DAYTIME_LABELS.get(daytime_tag) if daytime_tag else None,
             sunrise=sunrise,
             sunset=sunset,
             created_at=model.created_at,
@@ -296,13 +293,10 @@ class SessionListItem(BaseModel):
                 sunrise = w.get("sunrise")
                 sunset = w.get("sunset")
 
-        # Tageszeit-Tag berechnen
-        session_dt = (
-            model.date
-            if isinstance(model.date, datetime)
-            else datetime.combine(model.date, datetime.min.time().replace(hour=9))
-        )
-        daytime_tag = compute_daytime_tag(session_dt, sunrise, sunset)
+        # Tageszeit-Tag berechnen (nur wenn echte Uhrzeit vorhanden)
+        daytime_tag: str | None = None
+        if isinstance(model.date, datetime) and (model.date.hour != 0 or model.date.minute != 0):
+            daytime_tag = compute_daytime_tag(model.date, sunrise, sunset)
 
         return cls(
             id=model.id,
@@ -319,7 +313,7 @@ class SessionListItem(BaseModel):
             location_name=model.location_name if model.location_name else None,
             weather_label=weather_label,
             daytime_tag=daytime_tag,
-            daytime_label=DAYTIME_LABELS.get(daytime_tag),
+            daytime_label=DAYTIME_LABELS.get(daytime_tag) if daytime_tag else None,
         )
 
 

--- a/backend/app/services/fit_parser.py
+++ b/backend/app/services/fit_parser.py
@@ -154,12 +154,18 @@ class TrainingFITParser(TrainingParser):
             pace_sec = int((avg_pace - pace_min) * 60)
             avg_pace_formatted = f"{pace_min}:{pace_sec:02d}"
 
+        # Start-Zeit aus FIT-Session (datetime mit Uhrzeit)
+        start_time = session_data.get("start_time")
+
         summary: dict = {
             "total_duration_seconds": duration_sec,
             "total_duration_formatted": self._format_duration(duration_sec),
             "avg_hr_bpm": int(avg_hr) if avg_hr else None,
             "max_hr_bpm": int(max_hr) if max_hr else None,
             "min_hr_bpm": int(min_hr) if min_hr else None,
+            "start_time": start_time.isoformat()
+            if start_time and hasattr(start_time, "isoformat")
+            else None,
         }
 
         if training_type == TrainingType.RUNNING:


### PR DESCRIPTION
## Summary

- **Bug:** Alle Sessions wurden als "Nachtlauf" getaggt, weil `WorkoutModel.date` immer mit `00:00:00` gespeichert wurde
- **Root Cause:** `datetime.combine(form.training_date, datetime.min.time())` in `sessions.py` ignoriert die echte Startzeit aus FIT-Dateien
- **Fix:** Neue Hilfsfunktion `_resolve_session_datetime()` extrahiert `start_time` aus dem FIT-Parser Summary und setzt die Uhrzeit korrekt

## Test plan

- [x] Backend-Tests: 773 passed
- [x] Mypy: clean
- [x] Ruff: clean
- [ ] Manuell: FIT-Upload und prüfen ob Tageszeit-Tag korrekt ist

Fixes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)