### PR TITLE
feat: KI-Trainingsplan-Assistent mit Multi-Turn Chat (#36)

### DIFF
--- a/backend/alembic/versions/c038_add_chat_conversations.py
+++ b/backend/alembic/versions/c038_add_chat_conversations.py
@@ -1,0 +1,47 @@
+"""Chat-Konversationen und Nachrichten fuer KI-Trainingsplan-Assistent.
+
+Revision ID: c038
+Revises: c037
+Create Date: 2026-03-20
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "c038"
+down_revision = "c037"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "chat_conversations",
+        sa.Column("id", sa.Integer, primary_key=True, index=True),
+        sa.Column("title", sa.String(200), nullable=False),
+        sa.Column("created_at", sa.DateTime, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime, server_default=sa.func.now()),
+    )
+
+    op.create_table(
+        "chat_messages",
+        sa.Column("id", sa.Integer, primary_key=True, index=True),
+        sa.Column(
+            "conversation_id",
+            sa.Integer,
+            sa.ForeignKey("chat_conversations.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("role", sa.String(10), nullable=False),
+        sa.Column("content", sa.Text, nullable=False),
+        sa.Column("provider", sa.String(100), nullable=True),
+        sa.Column("duration_ms", sa.Integer, nullable=True),
+        sa.Column("created_at", sa.DateTime, server_default=sa.func.now()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("chat_messages")
+    op.drop_table("chat_conversations")

--- a/backend/app/api/v1/ai.py
+++ b/backend/app/api/v1/ai.py
@@ -1,7 +1,7 @@
 """
 AI API Endpoints
 
-Manage AI providers and chat functionality.
+Manage AI providers, chat functionality, and KI-Chat-Assistent.
 """
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -11,6 +11,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.api_key_resolver import resolve_claude_api_key
 from app.infrastructure.ai.ai_service import AIProviderFactory, ai_service
 from app.infrastructure.database.session import get_db
+from app.models.chat import (
+    ChatMessageRequest,
+    ChatMessageResponse,
+    ConversationDetail,
+    ConversationListResponse,
+)
+from app.services import chat_service
 
 router = APIRouter()
 
@@ -96,3 +103,55 @@ async def test_provider(provider_name: str):
 
     except Exception as e:
         return {"success": False, "provider": provider_name, "available": False, "error": str(e)}
+
+
+# --- KI Chat-Assistent (Konversationen) ---
+
+
+@router.post("/ai/conversations/messages", response_model=ChatMessageResponse)
+async def send_chat_message(
+    request: ChatMessageRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    """Sendet eine Nachricht an den KI-Trainingsassistenten."""
+    try:
+        return await chat_service.send_message(
+            message=request.message,
+            conversation_id=request.conversation_id,
+            db=db,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Chat-Fehler: {str(e)}") from e
+
+
+@router.get("/ai/conversations", response_model=ConversationListResponse)
+async def list_conversations(db: AsyncSession = Depends(get_db)):
+    """Listet alle Konversationen (neueste zuerst)."""
+    return await chat_service.list_conversations(db)
+
+
+@router.get("/ai/conversations/{conversation_id}", response_model=ConversationDetail)
+async def get_conversation(
+    conversation_id: int,
+    db: AsyncSession = Depends(get_db),
+):
+    """Laedt eine Konversation mit allen Nachrichten."""
+    try:
+        return await chat_service.get_conversation(conversation_id, db)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+
+
+@router.delete("/ai/conversations/{conversation_id}")
+async def delete_conversation(
+    conversation_id: int,
+    db: AsyncSession = Depends(get_db),
+):
+    """Loescht eine Konversation."""
+    try:
+        await chat_service.delete_conversation(conversation_id, db)
+        return {"success": True}
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e

--- a/backend/app/domain/interfaces/ai_service.py
+++ b/backend/app/domain/interfaces/ai_service.py
@@ -10,6 +10,15 @@ class AIProvider(ABC):
     async def chat(self, message: str, context: dict, api_key: str | None = None) -> str:
         pass
 
+    @abstractmethod
+    async def chat_multi_turn(
+        self,
+        messages: list[dict],
+        system_prompt: str,
+        api_key: str | None = None,
+    ) -> str:
+        pass
+
     @property
     @abstractmethod
     def name(self) -> str:

--- a/backend/app/infrastructure/ai/ai_service.py
+++ b/backend/app/infrastructure/ai/ai_service.py
@@ -130,6 +130,37 @@ class AIService:
 
         raise Exception("All AI providers failed")
 
+    async def chat_multi_turn(
+        self,
+        messages: list[dict],
+        system_prompt: str,
+        api_key: str | None = None,
+    ) -> tuple[str, str]:
+        """Multi-Turn Chat mit Konversationshistorie.
+
+        Returns:
+            Tuple von (response_text, provider_name).
+        """
+        if self.primary_provider and self.primary_provider.is_available(api_key):
+            try:
+                result = await self.primary_provider.chat_multi_turn(
+                    messages, system_prompt, api_key
+                )
+                return result, self.primary_provider.name
+            except Exception as e:
+                print(f"Primary provider failed: {e}")
+
+        for provider in self.fallback_providers:
+            if provider.is_available():
+                try:
+                    result = await provider.chat_multi_turn(messages, system_prompt)
+                    return result, provider.name
+                except Exception as e:
+                    print(f"Fallback provider {provider.name} failed: {e}")
+                    continue
+
+        raise Exception("All AI providers failed")
+
     def get_active_provider(self) -> Optional[str]:
         """Get name of currently active provider"""
         if self.primary_provider and self.primary_provider.is_available():

--- a/backend/app/infrastructure/ai/providers/claude_provider.py
+++ b/backend/app/infrastructure/ai/providers/claude_provider.py
@@ -59,6 +59,32 @@ class ClaudeProvider(AIProvider):
         except Exception as e:
             raise Exception(f"Claude API error: {str(e)}") from e
 
+    async def chat_multi_turn(
+        self,
+        messages: list[dict],
+        system_prompt: str,
+        api_key: str | None = None,
+    ) -> str:
+        """Multi-Turn Chat mit Konversationshistorie."""
+        client = self._get_client(api_key)
+        # Cast fuer Anthropic SDK Typen
+        api_messages: list[anthropic.types.MessageParam] = [
+            {"role": m["role"], "content": m["content"]}
+            for m in messages  # type: ignore[misc]
+        ]
+
+        try:
+            response = client.messages.create(
+                model=self.model,
+                max_tokens=2000,
+                temperature=0.3,
+                system=system_prompt,
+                messages=api_messages,
+            )
+            return response.content[0].text  # type: ignore[union-attr]
+        except Exception as e:
+            raise Exception(f"Claude API error: {str(e)}") from e
+
     def is_available(self, api_key: str | None = None) -> bool:
         """Check if Claude API is available"""
         key = api_key or self.default_api_key

--- a/backend/app/infrastructure/ai/providers/ollama_provider.py
+++ b/backend/app/infrastructure/ai/providers/ollama_provider.py
@@ -67,6 +67,33 @@ class OllamaProvider(AIProvider):
         except Exception as e:
             raise Exception(f"Ollama API error: {str(e)}") from e
 
+    async def chat_multi_turn(
+        self,
+        messages: list[dict],
+        system_prompt: str,
+        _api_key: str | None = None,
+    ) -> str:
+        """Multi-Turn Chat via Ollama /api/chat Endpoint."""
+        ollama_messages = [{"role": "system", "content": system_prompt}]
+        ollama_messages.extend(messages)
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.post(
+                    f"{self.base_url}/api/chat",
+                    json={
+                        "model": self.model,
+                        "messages": ollama_messages,
+                        "stream": False,
+                        "options": {"temperature": 0.5, "num_predict": 1000},
+                    },
+                )
+                response.raise_for_status()
+                result = response.json()
+                return result["message"]["content"]
+        except Exception as e:
+            raise Exception(f"Ollama API error: {str(e)}") from e
+
     def is_available(self, _api_key: str | None = None) -> bool:
         """Check if Ollama server is available"""
         try:

--- a/backend/app/infrastructure/database/models.py
+++ b/backend/app/infrastructure/database/models.py
@@ -319,3 +319,28 @@ class WeeklyReviewModel(Base):
     provider: Mapped[str] = mapped_column(String(100))
 
     review_created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+
+
+class ChatConversationModel(Base):
+    __tablename__ = "chat_conversations"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    title: Mapped[str] = mapped_column(String(200))
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), onupdate=datetime.utcnow
+    )
+
+
+class ChatMessageModel(Base):
+    __tablename__ = "chat_messages"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    conversation_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("chat_conversations.id", ondelete="CASCADE"), index=True
+    )
+    role: Mapped[str] = mapped_column(String(10))  # "user" | "assistant"
+    content: Mapped[str] = mapped_column(Text)
+    provider: Mapped[str | None] = mapped_column(String(100), default=None)
+    duration_ms: Mapped[int | None] = mapped_column(Integer, default=None)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())

--- a/backend/app/models/chat.py
+++ b/backend/app/models/chat.py
@@ -1,0 +1,64 @@
+"""Pydantic Schemas fuer Chat API."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+# --- Request Schemas ---
+
+
+class ChatMessageRequest(BaseModel):
+    """Request fuer neue Chat-Nachricht."""
+
+    message: str = Field(min_length=1, max_length=5000)
+    conversation_id: int | None = None  # None = neue Konversation
+
+
+# --- Response Schemas ---
+
+
+class ChatMessageResponse(BaseModel):
+    """Antwort nach gesendeter Nachricht."""
+
+    conversation_id: int
+    message_id: int
+    content: str
+    provider: str
+    duration_ms: int | None = None
+
+
+class ChatMessageDetail(BaseModel):
+    """Einzelne Nachricht in einer Konversation."""
+
+    id: int
+    role: str  # "user" | "assistant"
+    content: str
+    created_at: datetime
+
+
+class ConversationSummary(BaseModel):
+    """Kurzformat fuer Konversations-Liste."""
+
+    id: int
+    title: str
+    message_count: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class ConversationDetail(BaseModel):
+    """Vollstaendige Konversation mit Nachrichten."""
+
+    id: int
+    title: str
+    messages: list[ChatMessageDetail]
+    created_at: datetime
+
+
+class ConversationListResponse(BaseModel):
+    """Liste aller Konversationen."""
+
+    conversations: list[ConversationSummary]
+    total: int

--- a/backend/app/services/chat_context_service.py
+++ b/backend/app/services/chat_context_service.py
@@ -1,0 +1,250 @@
+"""Chat Context Service — Baut den Trainingskontext fuer den KI-Chat-Assistenten.
+
+Laedt Athleten-Profil, Wettkampfziel, Trainingsplan, aktuelle Phase,
+letzte Sessions und kommende Woche. Nutzt Helpers aus dem Analysis-Service.
+"""
+
+import json
+import logging
+from datetime import date, datetime, timedelta
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.infrastructure.database.models import (
+    AthleteModel,
+    PlannedSessionModel,
+    RaceGoalModel,
+    TrainingPhaseModel,
+    TrainingPlanModel,
+    WeeklyPlanDayModel,
+    WorkoutModel,
+)
+from app.services.session_analysis_service import (
+    _athlete_to_dict,
+    _goal_to_dict,
+    _workout_to_summary,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def build_chat_system_prompt(db: AsyncSession) -> str:
+    """Baut einen vollstaendigen System-Prompt mit Trainingskontext."""
+    today = date.today()
+
+    athlete = await _load_athlete(db)
+    race_goal = await _load_race_goal(db)
+    recent_sessions = await _load_recent_sessions(db, today)
+    plan_context = await _load_plan_context(db, today)
+    weekly_volume = await _load_weekly_volume(db, today)
+
+    return _assemble_prompt(athlete, race_goal, recent_sessions, plan_context, weekly_volume, today)
+
+
+async def _load_athlete(db: AsyncSession) -> dict | None:
+    result = await db.execute(select(AthleteModel).limit(1))
+    model = result.scalar_one_or_none()
+    return _athlete_to_dict(model) if model else None
+
+
+async def _load_race_goal(db: AsyncSession) -> dict | None:
+    result = await db.execute(
+        select(RaceGoalModel).where(RaceGoalModel.is_active.is_(True)).limit(1)
+    )
+    model = result.scalar_one_or_none()
+    return _goal_to_dict(model) if model else None
+
+
+async def _load_recent_sessions(db: AsyncSession, today: date) -> list[dict]:
+    two_weeks_ago = datetime.combine(today - timedelta(weeks=2), datetime.min.time())
+    result = await db.execute(
+        select(WorkoutModel)
+        .where(WorkoutModel.date >= two_weeks_ago)
+        .order_by(WorkoutModel.date.desc())
+        .limit(10)
+    )
+    return [_workout_to_summary(w) for w in result.scalars().all()]
+
+
+async def _load_plan_context(db: AsyncSession, today: date) -> dict | None:
+    """Laedt aktiven Plan, aktuelle Phase und kommende geplante Sessions."""
+    plan_result = await db.execute(
+        select(TrainingPlanModel)
+        .where(
+            TrainingPlanModel.status == "active",
+            TrainingPlanModel.start_date <= today,
+            TrainingPlanModel.end_date >= today,
+        )
+        .limit(1)
+    )
+    plan = plan_result.scalar_one_or_none()
+    if not plan:
+        return None
+
+    # Aktuelle Phase
+    weeks_since_start = max(1, (today - plan.start_date).days // 7 + 1)
+    phase_result = await db.execute(
+        select(TrainingPhaseModel)
+        .where(
+            TrainingPhaseModel.training_plan_id == plan.id,
+            TrainingPhaseModel.start_week <= weeks_since_start,
+            TrainingPhaseModel.end_week >= weeks_since_start,
+        )
+        .limit(1)
+    )
+    phase = phase_result.scalar_one_or_none()
+
+    # Kommende 7 Tage geplante Sessions
+    week_start = today - timedelta(days=today.weekday())
+    next_week_end = week_start + timedelta(days=13)
+    day_result = await db.execute(
+        select(WeeklyPlanDayModel)
+        .where(
+            WeeklyPlanDayModel.plan_id == plan.id,
+            WeeklyPlanDayModel.week_start >= week_start,
+            WeeklyPlanDayModel.week_start <= next_week_end,
+        )
+        .order_by(WeeklyPlanDayModel.week_start, WeeklyPlanDayModel.day_of_week)
+    )
+    days = day_result.scalars().all()
+
+    upcoming: list[dict] = []
+    for day in days:
+        actual_date = day.week_start + timedelta(days=day.day_of_week)
+        if actual_date < today:
+            continue
+        if day.is_rest_day:
+            upcoming.append({"date": str(actual_date), "type": "Ruhetag"})
+            continue
+        # Geplante Sessions fuer diesen Tag
+        ps_result = await db.execute(
+            select(PlannedSessionModel)
+            .where(PlannedSessionModel.day_id == day.id, PlannedSessionModel.status == "active")
+            .order_by(PlannedSessionModel.position)
+        )
+        for ps in ps_result.scalars().all():
+            entry: dict = {
+                "date": str(actual_date),
+                "type": str(ps.training_type),
+                "notes": str(ps.notes) if ps.notes else None,
+            }
+            if ps.run_details_json:
+                try:
+                    rd = json.loads(str(ps.run_details_json))
+                    entry["run_type"] = rd.get("run_type")
+                    entry["duration_min"] = rd.get("target_duration_minutes")
+                except (json.JSONDecodeError, AttributeError):
+                    pass
+            upcoming.append(entry)
+
+    return {
+        "plan_name": plan.name,
+        "phase_name": phase.name if phase else None,
+        "phase_type": str(phase.phase_type) if phase else None,
+        "week": weeks_since_start,
+        "upcoming_sessions": upcoming,
+    }
+
+
+async def _load_weekly_volume(db: AsyncSession, today: date) -> dict:
+    """Laedt das Wochenvolumen (aktuelle Woche)."""
+    week_start = datetime.combine(today - timedelta(days=today.weekday()), datetime.min.time())
+    week_end = datetime.combine(today, datetime.max.time())
+
+    result = await db.execute(
+        select(
+            func.count(WorkoutModel.id),
+            func.sum(WorkoutModel.distance_km),
+            func.sum(WorkoutModel.duration_sec),
+        ).where(
+            WorkoutModel.date >= week_start,
+            WorkoutModel.date <= week_end,
+        )
+    )
+    row = result.one()
+    return {
+        "sessions": row[0] or 0,
+        "distance_km": round(row[1], 1) if row[1] else 0,
+        "duration_min": round(row[2] / 60) if row[2] else 0,
+    }
+
+
+def _assemble_prompt(
+    athlete: dict | None,
+    race_goal: dict | None,
+    recent_sessions: list[dict],
+    plan_context: dict | None,
+    weekly_volume: dict,
+    today: date,
+) -> str:
+    """Baut den finalen System-Prompt zusammen."""
+    parts = [
+        "Du bist ein erfahrener Lauf- und Krafttrainer und Trainingsplan-Berater.",
+        "Der Athlet nutzt eine Trainings-App und chattet mit dir ueber sein Training.",
+        "Antworte immer auf Deutsch, praegnant, freundlich und kompetent.",
+        "Begruende deine Antworten mit konkreten Daten aus dem Trainingskontext.",
+        "Wenn du Planaenderungen vorschlaegst, sei spezifisch (welcher Tag, welche Session, warum).",
+        f"\nHeute ist {today.strftime('%A, %d.%m.%Y')}.",
+    ]
+
+    if athlete:
+        hr_info = []
+        if athlete.get("resting_hr"):
+            hr_info.append(f"Ruhe-HF: {athlete['resting_hr']} bpm")
+        if athlete.get("max_hr"):
+            hr_info.append(f"Max-HF: {athlete['max_hr']} bpm")
+        if hr_info:
+            parts.append(f"\n## Athlet\n{', '.join(hr_info)}")
+
+    if race_goal:
+        parts.append(
+            f"\n## Wettkampfziel\n"
+            f"- {race_goal['title']}\n"
+            f"- Datum: {race_goal['date']}\n"
+            f"- Distanz: {race_goal['distance_km']} km\n"
+            f"- Zielzeit: {race_goal.get('target_time_min')} min"
+            f" ({race_goal.get('target_pace', '?')} min/km)"
+        )
+
+    if plan_context:
+        phase = (
+            f" — Phase: {plan_context['phase_name']} ({plan_context['phase_type']})"
+            if plan_context.get("phase_name")
+            else ""
+        )
+        parts.append(
+            f"\n## Trainingsplan\n"
+            f"- Plan: {plan_context['plan_name']}{phase}\n"
+            f"- Woche: {plan_context['week']}"
+        )
+        if plan_context.get("upcoming_sessions"):
+            lines = []
+            for s in plan_context["upcoming_sessions"][:7]:
+                detail = s.get("run_type") or s["type"]
+                dur = f" ({s['duration_min']} min)" if s.get("duration_min") else ""
+                lines.append(f"  - {s['date']}: {detail}{dur}")
+            parts.append("Kommende Sessions:\n" + "\n".join(lines))
+
+    parts.append(
+        f"\n## Wochenvolumen (aktuelle Woche)\n"
+        f"- Sessions: {weekly_volume['sessions']}\n"
+        f"- Distanz: {weekly_volume['distance_km']} km\n"
+        f"- Dauer: {weekly_volume['duration_min']} min"
+    )
+
+    if recent_sessions:
+        lines = []
+        for s in recent_sessions:
+            pace = f", Pace {s['pace']}" if s.get("pace") else ""
+            hr = f", HF {s['hr_avg']}" if s.get("hr_avg") else ""
+            tt = f" [{s['training_type']}]" if s.get("training_type") else ""
+            lines.append(
+                f"  - {s['date']}: {s['type']}{tt}"
+                f" — {s.get('duration_min', '?')} min"
+                f", {s.get('distance_km', '?')} km"
+                f"{pace}{hr}"
+            )
+        parts.append("\n## Letzte Sessions (2 Wochen)\n" + "\n".join(lines))
+
+    return "\n".join(parts)

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -1,0 +1,191 @@
+"""Chat Service — KI Trainingsplan-Assistent (E06-S05).
+
+Verwaltet Konversationen und Nachrichten. Baut den vollen
+Trainingskontext als System-Prompt und sendet Multi-Turn-Anfragen
+an den AI-Provider.
+"""
+
+import logging
+import time
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.api_key_resolver import resolve_claude_api_key
+from app.infrastructure.ai.ai_service import ai_service
+from app.infrastructure.database.models import ChatConversationModel, ChatMessageModel
+from app.models.chat import (
+    ChatMessageDetail,
+    ChatMessageResponse,
+    ConversationDetail,
+    ConversationListResponse,
+    ConversationSummary,
+)
+from app.services.ai_log_service import AICallData, log_ai_call
+from app.services.chat_context_service import build_chat_system_prompt
+
+logger = logging.getLogger(__name__)
+
+MAX_HISTORY_MESSAGES = 30
+
+
+async def send_message(
+    message: str,
+    conversation_id: int | None,
+    db: AsyncSession,
+) -> ChatMessageResponse:
+    """Sendet eine Nachricht und gibt die KI-Antwort zurueck."""
+    # 1. Konversation erstellen oder laden
+    if conversation_id:
+        conversation = await _load_conversation(conversation_id, db)
+    else:
+        title = message[:100].strip()
+        conversation = ChatConversationModel(title=title)
+        db.add(conversation)
+        await db.flush()
+
+    # 2. User-Nachricht speichern
+    user_msg = ChatMessageModel(
+        conversation_id=conversation.id,
+        role="user",
+        content=message,
+    )
+    db.add(user_msg)
+    await db.flush()
+
+    # 3. Konversationshistorie laden
+    history = await _load_message_history(conversation.id, db)
+
+    # 4. System-Prompt mit Trainingskontext
+    system_prompt = await build_chat_system_prompt(db)
+
+    # 5. Messages-Array fuer Claude API
+    api_messages = [{"role": m.role, "content": m.content} for m in history]
+
+    # 6. AI-Anfrage
+    api_key = await resolve_claude_api_key(db)
+    start = time.monotonic()
+    response_text, provider_name = await ai_service.chat_multi_turn(
+        api_messages, system_prompt, api_key
+    )
+    duration_ms = int((time.monotonic() - start) * 1000)
+
+    # 7. Antwort speichern
+    assistant_msg = ChatMessageModel(
+        conversation_id=conversation.id,
+        role="assistant",
+        content=response_text,
+        provider=provider_name,
+        duration_ms=duration_ms,
+    )
+    db.add(assistant_msg)
+    await db.commit()
+
+    # 8. AI-Call loggen
+    await log_ai_call(
+        db,
+        AICallData(
+            use_case="chat",
+            provider=provider_name,
+            system_prompt=system_prompt[:2000],
+            user_prompt=message,
+            raw_response=response_text,
+            parsed_ok=True,
+            duration_ms=duration_ms,
+            context_label=f"conversation:{conversation.id}",
+        ),
+    )
+
+    return ChatMessageResponse(
+        conversation_id=conversation.id,
+        message_id=assistant_msg.id,
+        content=response_text,
+        provider=provider_name,
+        duration_ms=duration_ms,
+    )
+
+
+async def list_conversations(db: AsyncSession) -> ConversationListResponse:
+    """Listet alle Konversationen (neueste zuerst)."""
+    result = await db.execute(
+        select(ChatConversationModel).order_by(ChatConversationModel.updated_at.desc()).limit(50)
+    )
+    conversations = result.scalars().all()
+
+    summaries = []
+    for conv in conversations:
+        count_result = await db.execute(
+            select(func.count(ChatMessageModel.id)).where(
+                ChatMessageModel.conversation_id == conv.id
+            )
+        )
+        count = count_result.scalar() or 0
+        summaries.append(
+            ConversationSummary(
+                id=conv.id,
+                title=conv.title,
+                message_count=count,
+                created_at=conv.created_at,
+                updated_at=conv.updated_at,
+            )
+        )
+
+    return ConversationListResponse(conversations=summaries, total=len(summaries))
+
+
+async def get_conversation(conversation_id: int, db: AsyncSession) -> ConversationDetail:
+    """Laedt eine Konversation mit allen Nachrichten."""
+    conversation = await _load_conversation(conversation_id, db)
+
+    result = await db.execute(
+        select(ChatMessageModel)
+        .where(ChatMessageModel.conversation_id == conversation_id)
+        .order_by(ChatMessageModel.created_at)
+    )
+    messages = [
+        ChatMessageDetail(
+            id=m.id,
+            role=m.role,
+            content=m.content,
+            created_at=m.created_at,
+        )
+        for m in result.scalars().all()
+    ]
+
+    return ConversationDetail(
+        id=conversation.id,
+        title=conversation.title,
+        messages=messages,
+        created_at=conversation.created_at,
+    )
+
+
+async def delete_conversation(conversation_id: int, db: AsyncSession) -> None:
+    """Loescht eine Konversation (Messages via CASCADE)."""
+    conversation = await _load_conversation(conversation_id, db)
+    await db.delete(conversation)
+    await db.commit()
+
+
+async def _load_conversation(conversation_id: int, db: AsyncSession) -> ChatConversationModel:
+    """Laedt Konversation oder wirft ValueError."""
+    result = await db.execute(
+        select(ChatConversationModel).where(ChatConversationModel.id == conversation_id)
+    )
+    conversation = result.scalar_one_or_none()
+    if not conversation:
+        raise ValueError(f"Konversation {conversation_id} nicht gefunden")
+    return conversation
+
+
+async def _load_message_history(conversation_id: int, db: AsyncSession) -> list[ChatMessageModel]:
+    """Laedt die letzten N Nachrichten einer Konversation."""
+    result = await db.execute(
+        select(ChatMessageModel)
+        .where(ChatMessageModel.conversation_id == conversation_id)
+        .order_by(ChatMessageModel.created_at.desc())
+        .limit(MAX_HISTORY_MESSAGES)
+    )
+    messages = list(result.scalars().all())
+    messages.reverse()  # Chronologisch sortieren
+    return messages

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -106,6 +106,7 @@ const AthleteProfilePage = lazy(() =>
   import('./pages/AthleteProfile').then((m) => ({ default: m.AthleteProfilePage })),
 );
 const KiLogPage = lazy(() => import('./pages/KiLog').then((m) => ({ default: m.KiLogPage })));
+const ChatPage = lazy(() => import('./pages/Chat').then((m) => ({ default: m.ChatPage })));
 const NotFoundPage = lazy(() =>
   import('./pages/NotFound').then((m) => ({ default: m.NotFoundPage })),
 );
@@ -158,6 +159,7 @@ function App() {
                   {/* Profil (formerly Einstellungen > Athletenprofil) */}
                   <Route path="/profile" element={<AthleteProfilePage />} />
                   <Route path="/weekly-review" element={<Navigate to="/plan" replace />} />
+                  <Route path="/chat" element={<ChatPage />} />
                   <Route path="/ki-log" element={<KiLogPage />} />
 
                   {/* Redirects for old /settings paths */}

--- a/frontend/src/api/chat.ts
+++ b/frontend/src/api/chat.ts
@@ -1,0 +1,67 @@
+import { apiClient } from './client';
+
+// --- Types ---
+
+export interface ChatMessageRequest {
+  message: string;
+  conversation_id?: number;
+}
+
+export interface ChatMessageResponse {
+  conversation_id: number;
+  message_id: number;
+  content: string;
+  provider: string;
+  duration_ms: number | null;
+}
+
+export interface ChatMessageDetail {
+  id: number;
+  role: 'user' | 'assistant';
+  content: string;
+  created_at: string;
+}
+
+export interface ConversationSummary {
+  id: number;
+  title: string;
+  message_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ConversationDetail {
+  id: number;
+  title: string;
+  messages: ChatMessageDetail[];
+  created_at: string;
+}
+
+export interface ConversationListResponse {
+  conversations: ConversationSummary[];
+  total: number;
+}
+
+// --- API Functions ---
+
+export async function sendChatMessage(params: ChatMessageRequest): Promise<ChatMessageResponse> {
+  const { data } = await apiClient.post<ChatMessageResponse>(
+    '/api/v1/ai/conversations/messages',
+    params,
+  );
+  return data;
+}
+
+export async function listConversations(): Promise<ConversationListResponse> {
+  const { data } = await apiClient.get<ConversationListResponse>('/api/v1/ai/conversations');
+  return data;
+}
+
+export async function getConversation(id: number): Promise<ConversationDetail> {
+  const { data } = await apiClient.get<ConversationDetail>(`/api/v1/ai/conversations/${id}`);
+  return data;
+}
+
+export async function deleteConversation(id: number): Promise<void> {
+  await apiClient.delete(`/api/v1/ai/conversations/${id}`);
+}

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -1,0 +1,68 @@
+import { useState, useRef, useCallback } from 'react';
+import { Send } from 'lucide-react';
+import { Button } from '@nordlig/components';
+
+interface ChatInputProps {
+  onSend: (message: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+export function ChatInput({
+  onSend,
+  disabled = false,
+  placeholder = 'Stelle eine Frage zu deinem Training...',
+}: ChatInputProps) {
+  const [value, setValue] = useState('');
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleSubmit = useCallback(() => {
+    const trimmed = value.trim();
+    if (!trimmed || disabled) return;
+    onSend(trimmed);
+    setValue('');
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+    }
+  }, [value, disabled, onSend]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  const handleInput = () => {
+    const el = textareaRef.current;
+    if (el) {
+      el.style.height = 'auto';
+      el.style.height = `${Math.min(el.scrollHeight, 150)}px`;
+    }
+  };
+
+  return (
+    <div className="flex gap-2 items-end">
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onInput={handleInput}
+        disabled={disabled}
+        placeholder={placeholder}
+        rows={1}
+        className="flex-1 min-h-[44px] max-h-[150px] resize-none rounded-[var(--radius-md)] border border-[var(--color-border-base)] bg-[var(--color-bg-base)] px-3 py-2.5 text-sm text-[var(--color-text-base)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--color-border-focus)] disabled:opacity-50"
+      />
+      <Button
+        variant="primary"
+        size="sm"
+        onClick={handleSubmit}
+        disabled={disabled || !value.trim()}
+        aria-label="Nachricht senden"
+      >
+        <Send className="w-4 h-4" />
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/chat/ChatMessageBubble.tsx
+++ b/frontend/src/components/chat/ChatMessageBubble.tsx
@@ -1,0 +1,76 @@
+import { Bot, User } from 'lucide-react';
+
+interface ChatMessageBubbleProps {
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp?: string;
+}
+
+function FormatLine({ text }: { text: string }) {
+  // **bold** inline formatting (safe, no innerHTML)
+  const parts = text.split(/(\*\*.*?\*\*)/g);
+  return (
+    <>
+      {parts.map((part, i) =>
+        part.startsWith('**') && part.endsWith('**') ? (
+          <strong key={i}>{part.slice(2, -2)}</strong>
+        ) : (
+          <span key={i}>{part}</span>
+        ),
+      )}
+    </>
+  );
+}
+
+function formatContent(text: string) {
+  return text.split('\n').map((line, i) => {
+    if (line.startsWith('- ') || line.startsWith('• ')) {
+      return (
+        <li key={i} className="ml-4 list-disc">
+          <FormatLine text={line.slice(2)} />
+        </li>
+      );
+    }
+    if (line.trim() === '') return <br key={i} />;
+    return (
+      <p key={i}>
+        <FormatLine text={line} />
+      </p>
+    );
+  });
+}
+
+export function ChatMessageBubble({ role, content, timestamp }: ChatMessageBubbleProps) {
+  const isUser = role === 'user';
+
+  return (
+    <div className={`flex gap-3 ${isUser ? 'flex-row-reverse' : 'flex-row'}`}>
+      <div
+        className={`shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${
+          isUser
+            ? 'bg-[var(--color-bg-primary-subtle)] text-[var(--color-text-primary)]'
+            : 'bg-[var(--color-bg-neutral-subtle)] text-[var(--color-text-muted)]'
+        }`}
+      >
+        {isUser ? <User className="w-4 h-4" /> : <Bot className="w-4 h-4" />}
+      </div>
+      <div
+        className={`max-w-[80%] rounded-[var(--radius-md)] px-4 py-3 text-sm leading-relaxed ${
+          isUser
+            ? 'bg-[var(--color-bg-primary-subtle)] text-[var(--color-text-base)]'
+            : 'bg-[var(--color-bg-surface)] text-[var(--color-text-base)]'
+        }`}
+      >
+        <div className="space-y-1">{formatContent(content)}</div>
+        {timestamp && (
+          <div className="mt-1.5 text-[10px] text-[var(--color-text-muted)] opacity-60">
+            {new Date(timestamp).toLocaleTimeString('de-DE', {
+              hour: '2-digit',
+              minute: '2-digit',
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/chat/ChatQuickActions.tsx
+++ b/frontend/src/components/chat/ChatQuickActions.tsx
@@ -1,0 +1,38 @@
+import { Button } from '@nordlig/components';
+
+interface ChatQuickActionsProps {
+  onSelect: (question: string) => void;
+  disabled?: boolean;
+}
+
+const QUICK_QUESTIONS = [
+  'Wie war meine Trainingswoche?',
+  'Kann ich morgen schneller laufen?',
+  'Wann ist der naechste Ruhetag?',
+  'Soll ich den Trainingsplan anpassen?',
+  'Wie steht es um mein Wettkampfziel?',
+  'Was soll ich heute trainieren?',
+];
+
+export function ChatQuickActions({ onSelect, disabled }: ChatQuickActionsProps) {
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-[var(--color-text-muted)] text-center">
+        Frag mich etwas zu deinem Training:
+      </p>
+      <div className="flex flex-wrap justify-center gap-2">
+        {QUICK_QUESTIONS.map((q) => (
+          <Button
+            key={q}
+            variant="secondary"
+            size="sm"
+            onClick={() => onSelect(q)}
+            disabled={disabled}
+          >
+            {q}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/chat/ConversationList.tsx
+++ b/frontend/src/components/chat/ConversationList.tsx
@@ -1,0 +1,74 @@
+import { MessageSquarePlus, Trash2 } from 'lucide-react';
+import { Button } from '@nordlig/components';
+import type { ConversationSummary } from '@/api/chat';
+
+interface ConversationListProps {
+  conversations: ConversationSummary[];
+  activeId: number | null;
+  onSelect: (id: number) => void;
+  onNew: () => void;
+  onDelete: (id: number) => void;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit' });
+}
+
+export function ConversationList({
+  conversations,
+  activeId,
+  onSelect,
+  onNew,
+  onDelete,
+}: ConversationListProps) {
+  return (
+    <div className="space-y-2">
+      <Button variant="primary" size="sm" onClick={onNew} className="w-full">
+        <MessageSquarePlus className="w-4 h-4 mr-1.5" />
+        Neue Unterhaltung
+      </Button>
+
+      {conversations.length === 0 && (
+        <p className="text-xs text-[var(--color-text-muted)] text-center py-4">
+          Noch keine Unterhaltungen
+        </p>
+      )}
+
+      <div className="space-y-1">
+        {conversations.map((conv) => (
+          <div
+            key={conv.id}
+            role="button"
+            tabIndex={0}
+            onClick={() => onSelect(conv.id)}
+            onKeyDown={(e) => e.key === 'Enter' && onSelect(conv.id)}
+            className={`group flex items-center gap-2 rounded-[var(--radius-sm)] px-3 py-2 text-sm cursor-pointer transition-colors ${
+              activeId === conv.id
+                ? 'bg-[var(--color-bg-primary-subtle)] text-[var(--color-text-primary)]'
+                : 'text-[var(--color-text-base)] hover:bg-[var(--color-bg-neutral-subtle)]'
+            }`}
+          >
+            <div className="flex-1 min-w-0">
+              <div className="truncate font-medium">{conv.title}</div>
+              <div className="text-[10px] text-[var(--color-text-muted)]">
+                {formatDate(conv.updated_at)} · {conv.message_count} Nachrichten
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(conv.id);
+              }}
+              className="opacity-0 group-hover:opacity-100 p-1 rounded-[var(--radius-sm)] hover:bg-[var(--color-bg-error-subtle)] text-[var(--color-text-muted)] hover:text-[var(--color-text-error)] transition-all"
+              aria-label={`${conv.title} loeschen`}
+            >
+              <Trash2 className="w-3.5 h-3.5" />
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -1,0 +1,141 @@
+import { useState, useCallback, useRef } from 'react';
+import type { ChatMessageDetail, ConversationSummary, ChatMessageResponse } from '@/api/chat';
+import {
+  sendChatMessage,
+  listConversations,
+  getConversation,
+  deleteConversation,
+} from '@/api/chat';
+
+interface UseChatReturn {
+  messages: ChatMessageDetail[];
+  conversations: ConversationSummary[];
+  activeConversationId: number | null;
+  sending: boolean;
+  loading: boolean;
+  error: string | null;
+  sendMessage: (text: string) => Promise<ChatMessageResponse | null>;
+  selectConversation: (id: number) => Promise<void>;
+  startNewConversation: () => void;
+  loadConversations: () => Promise<void>;
+  removeConversation: (id: number) => Promise<void>;
+}
+
+export function useChat(): UseChatReturn {
+  const [messages, setMessages] = useState<ChatMessageDetail[]>([]);
+  const [conversations, setConversations] = useState<ConversationSummary[]>([]);
+  const [activeConversationId, setActiveConversationId] = useState<number | null>(null);
+  const [sending, setSending] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const idRef = useRef(0); // Lokale temp-ID fuer optimistic updates
+
+  const loadConversations = useCallback(async () => {
+    try {
+      const result = await listConversations();
+      setConversations(result.conversations);
+    } catch {
+      // Stille Fehlerbehandlung — Liste bleibt leer
+    }
+  }, []);
+
+  const selectConversation = useCallback(async (id: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const detail = await getConversation(id);
+      setMessages(detail.messages);
+      setActiveConversationId(id);
+    } catch {
+      setError('Konversation konnte nicht geladen werden.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const startNewConversation = useCallback(() => {
+    setActiveConversationId(null);
+    setMessages([]);
+    setError(null);
+  }, []);
+
+  const sendMessage = useCallback(
+    async (text: string): Promise<ChatMessageResponse | null> => {
+      setSending(true);
+      setError(null);
+
+      // Optimistic: User-Nachricht sofort anzeigen
+      idRef.current -= 1;
+      const tempUserMsg: ChatMessageDetail = {
+        id: idRef.current,
+        role: 'user',
+        content: text,
+        created_at: new Date().toISOString(),
+      };
+      setMessages((prev) => [...prev, tempUserMsg]);
+
+      try {
+        const response = await sendChatMessage({
+          message: text,
+          conversation_id: activeConversationId ?? undefined,
+        });
+
+        // Neue Konversation? ID merken
+        if (!activeConversationId) {
+          setActiveConversationId(response.conversation_id);
+        }
+
+        // Assistent-Antwort hinzufuegen
+        const assistantMsg: ChatMessageDetail = {
+          id: response.message_id,
+          role: 'assistant',
+          content: response.content,
+          created_at: new Date().toISOString(),
+        };
+        setMessages((prev) => [...prev, assistantMsg]);
+
+        // Konversationsliste aktualisieren
+        void loadConversations();
+
+        return response;
+      } catch {
+        setError('Nachricht konnte nicht gesendet werden.');
+        // Optimistic Update rueckgaengig machen
+        setMessages((prev) => prev.filter((m) => m.id !== tempUserMsg.id));
+        return null;
+      } finally {
+        setSending(false);
+      }
+    },
+    [activeConversationId, loadConversations],
+  );
+
+  const removeConversation = useCallback(
+    async (id: number) => {
+      try {
+        await deleteConversation(id);
+        setConversations((prev) => prev.filter((c) => c.id !== id));
+        if (activeConversationId === id) {
+          startNewConversation();
+        }
+      } catch {
+        setError('Konversation konnte nicht geloescht werden.');
+      }
+    },
+    [activeConversationId, startNewConversation],
+  );
+
+  return {
+    messages,
+    conversations,
+    activeConversationId,
+    sending,
+    loading,
+    error,
+    sendMessage,
+    selectConversation,
+    startNewConversation,
+    loadConversations,
+    removeConversation,
+  };
+}

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -13,6 +13,7 @@ import {
   BookOpen,
   ClipboardList,
   Library,
+  Bot,
 } from 'lucide-react';
 import { BottomNav } from './BottomNav';
 
@@ -27,6 +28,7 @@ const navItems: NavItem[] = [
   { to: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
   { to: '/sessions', label: 'Sessions', icon: Dumbbell },
   { to: '/analyse', label: 'Analyse', icon: TrendingUp },
+  { to: '/chat', label: 'KI-Chat', icon: Bot },
   {
     to: '/plan',
     label: 'Plan',

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Bot, PanelLeftClose, PanelLeftOpen } from 'lucide-react';
+import { Button, Card, CardBody, Breadcrumbs, BreadcrumbItem } from '@nordlig/components';
+import { useChat } from '@/hooks/useChat';
+import { ChatMessageBubble } from '@/components/chat/ChatMessageBubble';
+import { ChatInput } from '@/components/chat/ChatInput';
+import { ChatQuickActions } from '@/components/chat/ChatQuickActions';
+import { ConversationList } from '@/components/chat/ConversationList';
+import type { ChatMessageDetail } from '@/api/chat';
+
+function TypingIndicator() {
+  return (
+    <div className="flex gap-3">
+      <div className="shrink-0 w-8 h-8 rounded-full flex items-center justify-center bg-[var(--color-bg-neutral-subtle)] text-[var(--color-text-muted)]">
+        <Bot className="w-4 h-4" />
+      </div>
+      <div className="bg-[var(--color-bg-surface)] rounded-[var(--radius-md)] px-4 py-3">
+        <div className="flex gap-1">
+          <span className="w-2 h-2 rounded-full bg-[var(--color-text-muted)] animate-pulse" />
+          <span className="w-2 h-2 rounded-full bg-[var(--color-text-muted)] animate-pulse [animation-delay:150ms]" />
+          <span className="w-2 h-2 rounded-full bg-[var(--color-text-muted)] animate-pulse [animation-delay:300ms]" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ onQuickAction }: { onQuickAction: (q: string) => void }) {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center gap-6 py-12">
+      <div className="w-16 h-16 rounded-full bg-[var(--color-bg-primary-subtle)] flex items-center justify-center">
+        <Bot className="w-8 h-8 text-[var(--color-text-primary)]" />
+      </div>
+      <div className="text-center space-y-1">
+        <h2 className="text-lg font-semibold text-[var(--color-text-base)]">
+          KI-Trainingsassistent
+        </h2>
+        <p className="text-sm text-[var(--color-text-muted)] max-w-md">
+          Ich kenne deinen Trainingsplan, deine letzten Sessions und dein Wettkampfziel. Frag mich
+          etwas!
+        </p>
+      </div>
+      <ChatQuickActions onSelect={onQuickAction} />
+    </div>
+  );
+}
+
+interface ChatAreaProps {
+  messages: ChatMessageDetail[];
+  loading: boolean;
+  sending: boolean;
+  error: string | null;
+  onSend: (text: string) => void;
+  sidebarOpen: boolean;
+}
+
+function ChatArea({ messages, loading, sending, error, onSend, sidebarOpen }: ChatAreaProps) {
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages.length, sending]);
+
+  return (
+    <div className={`flex-1 flex flex-col min-w-0 ${sidebarOpen ? 'hidden lg:flex' : 'flex'}`}>
+      <Card elevation="raised" className="flex-1 flex flex-col overflow-hidden">
+        <CardBody className="flex-1 flex flex-col overflow-hidden p-0">
+          <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
+            {loading && (
+              <div className="text-center text-sm text-[var(--color-text-muted)] py-8">
+                Lade Konversation...
+              </div>
+            )}
+            {!loading && messages.length === 0 && <EmptyState onQuickAction={onSend} />}
+            {messages.map((msg) => (
+              <ChatMessageBubble
+                key={msg.id}
+                role={msg.role}
+                content={msg.content}
+                timestamp={msg.created_at}
+              />
+            ))}
+            {sending && <TypingIndicator />}
+            {error && (
+              <div className="text-center text-sm text-[var(--color-text-error)] py-2">{error}</div>
+            )}
+            <div ref={messagesEndRef} />
+          </div>
+          <div className="border-t border-[var(--color-border-base)] px-4 py-3">
+            <ChatInput onSend={onSend} disabled={sending} />
+          </div>
+        </CardBody>
+      </Card>
+    </div>
+  );
+}
+
+export function ChatPage() {
+  const {
+    messages,
+    conversations,
+    activeConversationId,
+    sending,
+    loading,
+    error,
+    sendMessage,
+    selectConversation,
+    startNewConversation,
+    loadConversations,
+    removeConversation,
+  } = useChat();
+
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  useEffect(() => {
+    void loadConversations();
+  }, [loadConversations]);
+
+  const handleSend = (text: string) => {
+    void sendMessage(text);
+    setSidebarOpen(false);
+  };
+
+  return (
+    <div className="p-4 pt-6 md:p-6 md:pt-8 max-w-5xl mx-auto">
+      <header className="space-y-2 pb-2">
+        <Breadcrumbs>
+          <BreadcrumbItem>
+            <Link to="/">Home</Link>
+          </BreadcrumbItem>
+          <BreadcrumbItem>KI-Chat</BreadcrumbItem>
+        </Breadcrumbs>
+        <div className="flex items-center justify-between">
+          <h1 className="text-xl font-bold text-[var(--color-text-base)]">
+            Trainingsplan-Assistent
+          </h1>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setSidebarOpen(!sidebarOpen)}
+            aria-label="Unterhaltungen anzeigen"
+            className="lg:hidden"
+          >
+            {sidebarOpen ? (
+              <PanelLeftClose className="w-5 h-5" />
+            ) : (
+              <PanelLeftOpen className="w-5 h-5" />
+            )}
+          </Button>
+        </div>
+      </header>
+
+      <div className="flex gap-4" style={{ height: 'calc(100vh - 200px)' }}>
+        <div
+          className={`${sidebarOpen ? 'block' : 'hidden'} lg:block w-64 shrink-0 overflow-y-auto`}
+        >
+          <Card elevation="flat">
+            <CardBody>
+              <ConversationList
+                conversations={conversations}
+                activeId={activeConversationId}
+                onSelect={(id) => {
+                  void selectConversation(id);
+                  setSidebarOpen(false);
+                }}
+                onNew={() => {
+                  startNewConversation();
+                  setSidebarOpen(false);
+                }}
+                onDelete={(id) => void removeConversation(id)}
+              />
+            </CardBody>
+          </Card>
+        </div>
+
+        <ChatArea
+          messages={messages}
+          loading={loading}
+          sending={sending}
+          error={error}
+          onSend={handleSend}
+          sidebarOpen={sidebarOpen}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Multi-Turn KI-Chat mit Trainingskontext (Athletenprofil, Wettkampfziel, aktive Woche, letzte Sessions)
- Backend: Chat-Konversationen + Nachrichten (PostgreSQL), ChatContextService, ChatService, 4 API Endpoints
- Frontend: Responsive Chat-UI mit Conversation-Sidebar, optimistischen Updates, Quick Actions
- Claude API + Ollama Fallback über AIProvider.chat_multi_turn

## Test plan
- [ ] Chat öffnen → Empty State mit Quick Actions sichtbar
- [ ] Quick Action klicken → Nachricht wird gesendet, Antwort erscheint
- [ ] Neue Konversation starten → Sidebar aktualisiert sich
- [ ] Konversation wechseln → Nachrichten laden korrekt
- [ ] Konversation löschen → Wird aus Liste entfernt
- [ ] Mobile: Sidebar toggle funktioniert
- [ ] Typing Indicator während AI-Antwort sichtbar
- [ ] Fehlerbehandlung: Nachricht rollback bei Fehler

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)