### PR TITLE
feat: Auto-Titel für Chat-Konversationen (#386)

### DIFF
--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -27,6 +27,17 @@ from app.services.chat_context_service import build_chat_system_prompt
 logger = logging.getLogger(__name__)
 
 MAX_HISTORY_MESSAGES = 30
+MAX_TITLE_LENGTH = 50
+
+
+def _generate_title(message: str) -> str:
+    """Erzeugt einen kurzen Konversationstitel aus der ersten Nachricht."""
+    title = message.replace("\n", " ").strip()
+    if len(title) <= MAX_TITLE_LENGTH:
+        return title
+    # An Wortgrenze kuerzen
+    truncated = title[:MAX_TITLE_LENGTH].rsplit(" ", 1)[0]
+    return f"{truncated}..." if truncated else f"{title[:MAX_TITLE_LENGTH]}..."
 
 
 async def send_message(
@@ -39,8 +50,7 @@ async def send_message(
     if conversation_id:
         conversation = await _load_conversation(conversation_id, db)
     else:
-        title = message[:100].strip()
-        conversation = ChatConversationModel(title=title)
+        conversation = ChatConversationModel(title=_generate_title(message))
         db.add(conversation)
         await db.flush()
 


### PR DESCRIPTION
## Summary
- Konversationstitel wird automatisch aus der ersten User-Nachricht generiert
- Max 50 Zeichen, an Wortgrenze gekürzt, Zeilenumbrüche entfernt
- Ersetzt bisheriges `message[:100]` durch saubere `_generate_title()` Funktion

## Test plan
- [ ] Neue Konversation starten → Titel in Sidebar ist gekürzte erste Nachricht
- [ ] Kurze Nachricht (<50 Zeichen) → Titel ist die volle Nachricht
- [ ] Lange Nachricht → Titel endet mit "..." an Wortgrenze
- [ ] Mehrzeilige Nachricht → Zeilenumbrüche werden zu Leerzeichen

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)