### PR TITLE
feat: Streaming-Antworten im KI-Chat (#385)

### DIFF
--- a/backend/app/api/v1/ai.py
+++ b/backend/app/api/v1/ai.py
@@ -5,6 +5,7 @@ Manage AI providers, chat functionality, and KI-Chat-Assistent.
 """
 
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -124,6 +125,32 @@ async def send_chat_message(
         raise HTTPException(status_code=404, detail=str(e)) from e
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Chat-Fehler: {str(e)}") from e
+
+
+@router.post("/ai/conversations/messages/stream")
+async def stream_chat_message(
+    request: ChatMessageRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    """Streamt eine KI-Antwort als Server-Sent Events."""
+    try:
+        return StreamingResponse(
+            chat_service.stream_sse_events(
+                message=request.message,
+                conversation_id=request.conversation_id,
+                db=db,
+            ),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-Accel-Buffering": "no",
+            },
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Streaming-Fehler: {str(e)}") from e
 
 
 @router.get("/ai/conversations", response_model=ConversationListResponse)

--- a/backend/app/domain/interfaces/ai_service.py
+++ b/backend/app/domain/interfaces/ai_service.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
 
 
 class AIProvider(ABC):
@@ -18,6 +19,18 @@ class AIProvider(ABC):
         api_key: str | None = None,
     ) -> str:
         pass
+
+    @abstractmethod
+    async def stream_chat_multi_turn(
+        self,
+        messages: list[dict],
+        system_prompt: str,
+        api_key: str | None = None,
+    ) -> AsyncIterator[str]:
+        """Streamt die KI-Antwort Token fuer Token."""
+        ...  # pragma: no cover
+        # yield needed to make this an async generator in implementations
+        yield ""  # type: ignore[misc]
 
     @property
     @abstractmethod

--- a/backend/app/infrastructure/ai/ai_service.py
+++ b/backend/app/infrastructure/ai/ai_service.py
@@ -4,6 +4,7 @@ AI Service Factory and Manager
 Handles AI provider initialization, selection, and fallback logic.
 """
 
+from collections.abc import AsyncIterator
 from typing import Optional
 
 from app.core.config import settings
@@ -158,6 +159,32 @@ class AIService:
                 except Exception as e:
                     print(f"Fallback provider {provider.name} failed: {e}")
                     continue
+
+        raise Exception("All AI providers failed")
+
+    async def stream_chat_multi_turn(
+        self,
+        messages: list[dict],
+        system_prompt: str,
+        api_key: str | None = None,
+    ) -> tuple[AsyncIterator[str], str]:
+        """Streamt Multi-Turn Chat Token fuer Token.
+
+        Returns:
+            Tuple von (async_iterator, provider_name).
+        """
+        if self.primary_provider and self.primary_provider.is_available(api_key):
+            return (
+                self.primary_provider.stream_chat_multi_turn(messages, system_prompt, api_key),
+                self.primary_provider.name,
+            )
+
+        for provider in self.fallback_providers:
+            if provider.is_available():
+                return (
+                    provider.stream_chat_multi_turn(messages, system_prompt),
+                    provider.name,
+                )
 
         raise Exception("All AI providers failed")
 

--- a/backend/app/infrastructure/ai/providers/claude_provider.py
+++ b/backend/app/infrastructure/ai/providers/claude_provider.py
@@ -4,6 +4,8 @@ Claude (Anthropic) AI Provider
 High-quality AI analysis using Claude Sonnet 4.
 """
 
+from collections.abc import AsyncIterator
+
 import anthropic
 
 from app.core.config import settings
@@ -84,6 +86,29 @@ class ClaudeProvider(AIProvider):
             return response.content[0].text  # type: ignore[union-attr]
         except Exception as e:
             raise Exception(f"Claude API error: {str(e)}") from e
+
+    async def stream_chat_multi_turn(
+        self,
+        messages: list[dict],
+        system_prompt: str,
+        api_key: str | None = None,
+    ) -> AsyncIterator[str]:
+        """Streamt die KI-Antwort Token fuer Token."""
+        client = self._get_client(api_key)
+        api_messages: list[anthropic.types.MessageParam] = [
+            {"role": m["role"], "content": m["content"]}
+            for m in messages  # type: ignore[misc]
+        ]
+
+        with client.messages.stream(
+            model=self.model,
+            max_tokens=2000,
+            temperature=0.3,
+            system=system_prompt,
+            messages=api_messages,
+        ) as stream:
+            for text in stream.text_stream:
+                yield text
 
     def is_available(self, api_key: str | None = None) -> bool:
         """Check if Claude API is available"""

--- a/backend/app/infrastructure/ai/providers/ollama_provider.py
+++ b/backend/app/infrastructure/ai/providers/ollama_provider.py
@@ -4,6 +4,9 @@ Ollama AI Provider
 Self-hosted LLM provider for cost-free, privacy-focused AI analysis.
 """
 
+import json
+from collections.abc import AsyncIterator
+
 import httpx
 
 from app.core.config import settings
@@ -93,6 +96,37 @@ class OllamaProvider(AIProvider):
                 return result["message"]["content"]
         except Exception as e:
             raise Exception(f"Ollama API error: {str(e)}") from e
+
+    async def stream_chat_multi_turn(
+        self,
+        messages: list[dict],
+        system_prompt: str,
+        _api_key: str | None = None,
+    ) -> AsyncIterator[str]:
+        """Streamt die KI-Antwort Token fuer Token via Ollama."""
+        ollama_messages = [{"role": "system", "content": system_prompt}]
+        ollama_messages.extend(messages)
+
+        async with (
+            httpx.AsyncClient(timeout=self.timeout) as client,
+            client.stream(
+                "POST",
+                f"{self.base_url}/api/chat",
+                json={
+                    "model": self.model,
+                    "messages": ollama_messages,
+                    "stream": True,
+                    "options": {"temperature": 0.5, "num_predict": 1000},
+                },
+            ) as response,
+        ):
+            response.raise_for_status()
+            async for line in response.aiter_lines():
+                if line:
+                    chunk = json.loads(line)
+                    content = chunk.get("message", {}).get("content", "")
+                    if content:
+                        yield content
 
     def is_available(self, _api_key: str | None = None) -> bool:
         """Check if Ollama server is available"""

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -5,8 +5,11 @@ Trainingskontext als System-Prompt und sendet Multi-Turn-Anfragen
 an den AI-Provider.
 """
 
+import json
 import logging
 import time
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -113,6 +116,118 @@ async def send_message(
         provider=provider_name,
         duration_ms=duration_ms,
     )
+
+
+@dataclass
+class StreamContext:
+    """Kontext fuer die Nachbearbeitung nach dem Streaming."""
+
+    conversation_id: int
+    system_prompt: str
+    user_message: str
+    provider_name: str
+    start_time: float
+
+
+async def prepare_stream(
+    message: str,
+    conversation_id: int | None,
+    db: AsyncSession,
+) -> tuple[AsyncIterator[str], StreamContext]:
+    """Bereitet Streaming vor: speichert User-Msg, gibt Stream + Kontext zurueck."""
+    if conversation_id:
+        conversation = await _load_conversation(conversation_id, db)
+    else:
+        title = message[:100].strip()
+        conversation = ChatConversationModel(title=title)
+        db.add(conversation)
+        await db.flush()
+
+    user_msg = ChatMessageModel(
+        conversation_id=conversation.id,
+        role="user",
+        content=message,
+    )
+    db.add(user_msg)
+    await db.flush()
+
+    history = await _load_message_history(conversation.id, db)
+    system_prompt = await build_chat_system_prompt(db)
+    api_messages = [{"role": m.role, "content": m.content} for m in history]
+
+    api_key = await resolve_claude_api_key(db)
+    stream, provider_name = await ai_service.stream_chat_multi_turn(
+        api_messages, system_prompt, api_key
+    )
+
+    ctx = StreamContext(
+        conversation_id=conversation.id,
+        system_prompt=system_prompt,
+        user_message=message,
+        provider_name=provider_name,
+        start_time=time.monotonic(),
+    )
+    return stream, ctx
+
+
+async def finalize_stream(
+    full_response: str,
+    ctx: StreamContext,
+    db: AsyncSession,
+) -> None:
+    """Speichert die gestreamte Antwort und loggt den AI-Call."""
+    duration_ms = int((time.monotonic() - ctx.start_time) * 1000)
+
+    assistant_msg = ChatMessageModel(
+        conversation_id=ctx.conversation_id,
+        role="assistant",
+        content=full_response,
+        provider=ctx.provider_name,
+        duration_ms=duration_ms,
+    )
+    db.add(assistant_msg)
+    await db.commit()
+
+    await log_ai_call(
+        db,
+        AICallData(
+            use_case="chat",
+            provider=ctx.provider_name,
+            system_prompt=ctx.system_prompt[:2000],
+            user_prompt=ctx.user_message,
+            raw_response=full_response,
+            parsed_ok=True,
+            duration_ms=duration_ms,
+            context_label=f"conversation:{ctx.conversation_id}",
+        ),
+    )
+
+
+async def stream_sse_events(
+    message: str,
+    conversation_id: int | None,
+    db: AsyncSession,
+) -> AsyncIterator[str]:
+    """Generiert SSE-Events fuer den Streaming-Endpoint."""
+    stream, ctx = await prepare_stream(message, conversation_id, db)
+
+    # Erstes Event: Konversations-ID
+    yield f"data: {json.dumps({'type': 'start', 'conversation_id': ctx.conversation_id})}\n\n"
+
+    full_response = ""
+    try:
+        async for token in stream:
+            full_response += token
+            yield f"data: {json.dumps({'type': 'token', 'content': token})}\n\n"
+    except Exception as e:
+        logger.error("Streaming-Fehler: %s", e)
+        yield f"data: {json.dumps({'type': 'error', 'message': str(e)})}\n\n"
+        return
+
+    # Antwort persistieren
+    await finalize_stream(full_response, ctx, db)
+
+    yield f"data: {json.dumps({'type': 'done', 'conversation_id': ctx.conversation_id})}\n\n"
 
 
 async def list_conversations(db: AsyncSession) -> ConversationListResponse:

--- a/frontend/src/api/chat.ts
+++ b/frontend/src/api/chat.ts
@@ -42,6 +42,13 @@ export interface ConversationListResponse {
   total: number;
 }
 
+export interface StreamEvent {
+  type: 'start' | 'token' | 'done' | 'error';
+  conversation_id?: number;
+  content?: string;
+  message?: string;
+}
+
 // --- API Functions ---
 
 export async function sendChatMessage(params: ChatMessageRequest): Promise<ChatMessageResponse> {
@@ -50,6 +57,44 @@ export async function sendChatMessage(params: ChatMessageRequest): Promise<ChatM
     params,
   );
   return data;
+}
+
+export async function streamChatMessage(
+  params: ChatMessageRequest,
+  onEvent: (event: StreamEvent) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  const baseUrl = apiClient.defaults.baseURL ?? '';
+  const response = await fetch(`${baseUrl}/api/v1/ai/conversations/messages/stream`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(params),
+    signal,
+  });
+
+  if (!response.ok || !response.body) {
+    throw new Error(`Stream-Fehler: ${response.status}`);
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? '';
+
+    for (const line of lines) {
+      if (line.startsWith('data: ')) {
+        const event = JSON.parse(line.slice(6)) as StreamEvent;
+        onEvent(event);
+      }
+    }
+  }
 }
 
 export async function listConversations(): Promise<ConversationListResponse> {

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -1,16 +1,20 @@
 import { useState, useCallback } from 'react';
-import { Send } from 'lucide-react';
+import { Send, Square } from 'lucide-react';
 import { Button, Textarea } from '@nordlig/components';
 
 interface ChatInputProps {
   onSend: (message: string) => void;
+  onCancel?: () => void;
   disabled?: boolean;
+  streaming?: boolean;
   placeholder?: string;
 }
 
 export function ChatInput({
   onSend,
+  onCancel,
   disabled = false,
+  streaming = false,
   placeholder = 'Stelle eine Frage zu deinem Training...',
 }: ChatInputProps) {
   const [value, setValue] = useState('');
@@ -44,15 +48,21 @@ export function ChatInput({
           className="!min-h-[44px] max-h-[150px]"
         />
       </div>
-      <Button
-        variant="primary"
-        size="sm"
-        onClick={handleSubmit}
-        disabled={disabled || !value.trim()}
-        aria-label="Nachricht senden"
-      >
-        <Send className="w-4 h-4" />
-      </Button>
+      {streaming ? (
+        <Button variant="secondary" size="sm" onClick={onCancel} aria-label="Antwort abbrechen">
+          <Square className="w-4 h-4" />
+        </Button>
+      ) : (
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={handleSubmit}
+          disabled={disabled || !value.trim()}
+          aria-label="Nachricht senden"
+        >
+          <Send className="w-4 h-4" />
+        </Button>
+      )}
     </div>
   );
 }

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -1,11 +1,21 @@
 import { useState, useCallback, useRef } from 'react';
-import type { ChatMessageDetail, ConversationSummary, ChatMessageResponse } from '@/api/chat';
+import type { ChatMessageDetail, ConversationSummary, StreamEvent } from '@/api/chat';
 import {
-  sendChatMessage,
+  streamChatMessage,
   listConversations,
   getConversation,
   deleteConversation,
 } from '@/api/chat';
+
+const STREAMING_MSG_ID = -999;
+
+function createTempMsg(id: number, role: 'user' | 'assistant', content: string): ChatMessageDetail {
+  return { id, role, content, created_at: new Date().toISOString() };
+}
+
+function replaceStreamingId(msgs: ChatMessageDetail[], newId: number): ChatMessageDetail[] {
+  return msgs.map((m) => (m.id === STREAMING_MSG_ID ? { ...m, id: newId } : m));
+}
 
 interface UseChatReturn {
   messages: ChatMessageDetail[];
@@ -14,13 +24,15 @@ interface UseChatReturn {
   sending: boolean;
   loading: boolean;
   error: string | null;
-  sendMessage: (text: string) => Promise<ChatMessageResponse | null>;
+  sendMessage: (text: string) => Promise<void>;
+  cancelStream: () => void;
   selectConversation: (id: number) => Promise<void>;
   startNewConversation: () => void;
   loadConversations: () => Promise<void>;
   removeConversation: (id: number) => Promise<void>;
 }
 
+// eslint-disable-next-line max-lines-per-function -- Hook mit vielen Callbacks, Aufteilung in Sub-Hooks wuerde Lesbarkeit verschlechtern
 export function useChat(): UseChatReturn {
   const [messages, setMessages] = useState<ChatMessageDetail[]>([]);
   const [conversations, setConversations] = useState<ConversationSummary[]>([]);
@@ -28,7 +40,8 @@ export function useChat(): UseChatReturn {
   const [sending, setSending] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const idRef = useRef(0); // Lokale temp-ID fuer optimistic updates
+  const idRef = useRef(0);
+  const abortRef = useRef<AbortController | null>(null);
 
   const loadConversations = useCallback(async () => {
     try {
@@ -59,55 +72,71 @@ export function useChat(): UseChatReturn {
     setError(null);
   }, []);
 
+  const cancelStream = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+  }, []);
+
+  const handleStreamEvent = useCallback(
+    (event: StreamEvent) => {
+      if (event.type === 'start' && event.conversation_id) {
+        setActiveConversationId(event.conversation_id);
+      } else if (event.type === 'token' && event.content) {
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === STREAMING_MSG_ID ? { ...m, content: m.content + event.content } : m,
+          ),
+        );
+      } else if (event.type === 'done') {
+        idRef.current -= 1;
+        setMessages((prev) => replaceStreamingId(prev, idRef.current));
+        void loadConversations();
+      } else if (event.type === 'error') {
+        setError(event.message ?? 'Streaming-Fehler');
+        setMessages((prev) => prev.filter((m) => m.id !== STREAMING_MSG_ID));
+      }
+    },
+    [loadConversations],
+  );
+
   const sendMessage = useCallback(
-    async (text: string): Promise<ChatMessageResponse | null> => {
+    async (text: string): Promise<void> => {
       setSending(true);
       setError(null);
 
-      // Optimistic: User-Nachricht sofort anzeigen
       idRef.current -= 1;
-      const tempUserMsg: ChatMessageDetail = {
-        id: idRef.current,
-        role: 'user',
-        content: text,
-        created_at: new Date().toISOString(),
-      };
-      setMessages((prev) => [...prev, tempUserMsg]);
+      const tempUserId = idRef.current;
+      setMessages((prev) => [
+        ...prev,
+        createTempMsg(tempUserId, 'user', text),
+        createTempMsg(STREAMING_MSG_ID, 'assistant', ''),
+      ]);
+
+      const controller = new AbortController();
+      abortRef.current = controller;
 
       try {
-        const response = await sendChatMessage({
-          message: text,
-          conversation_id: activeConversationId ?? undefined,
-        });
-
-        // Neue Konversation? ID merken
-        if (!activeConversationId) {
-          setActiveConversationId(response.conversation_id);
+        await streamChatMessage(
+          { message: text, conversation_id: activeConversationId ?? undefined },
+          handleStreamEvent,
+          controller.signal,
+        );
+      } catch (e) {
+        if (e instanceof DOMException && e.name === 'AbortError') {
+          idRef.current -= 1;
+          setMessages((prev) => replaceStreamingId(prev, idRef.current));
+        } else {
+          setError('Nachricht konnte nicht gesendet werden.');
+          setMessages((prev) =>
+            prev.filter((m) => m.id !== tempUserId && m.id !== STREAMING_MSG_ID),
+          );
         }
-
-        // Assistent-Antwort hinzufuegen
-        const assistantMsg: ChatMessageDetail = {
-          id: response.message_id,
-          role: 'assistant',
-          content: response.content,
-          created_at: new Date().toISOString(),
-        };
-        setMessages((prev) => [...prev, assistantMsg]);
-
-        // Konversationsliste aktualisieren
-        void loadConversations();
-
-        return response;
-      } catch {
-        setError('Nachricht konnte nicht gesendet werden.');
-        // Optimistic Update rueckgaengig machen
-        setMessages((prev) => prev.filter((m) => m.id !== tempUserMsg.id));
-        return null;
       } finally {
         setSending(false);
+        abortRef.current = null;
       }
     },
-    [activeConversationId, loadConversations],
+    [activeConversationId, handleStreamEvent],
   );
 
   const removeConversation = useCallback(
@@ -133,6 +162,7 @@ export function useChat(): UseChatReturn {
     loading,
     error,
     sendMessage,
+    cancelStream,
     selectConversation,
     startNewConversation,
     loadConversations,

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -9,23 +9,6 @@ import { ChatQuickActions } from '@/components/chat/ChatQuickActions';
 import { ConversationList } from '@/components/chat/ConversationList';
 import type { ChatMessageDetail } from '@/api/chat';
 
-function TypingIndicator() {
-  return (
-    <div className="flex gap-3">
-      <div className="shrink-0 w-8 h-8 rounded-full flex items-center justify-center bg-[var(--color-bg-neutral-subtle)] text-[var(--color-text-muted)]">
-        <Bot className="w-4 h-4" />
-      </div>
-      <div className="bg-[var(--color-bg-surface)] rounded-[var(--radius-md)] px-4 py-3">
-        <div className="flex gap-1">
-          <span className="w-2 h-2 rounded-full bg-[var(--color-text-muted)] animate-pulse" />
-          <span className="w-2 h-2 rounded-full bg-[var(--color-text-muted)] animate-pulse [animation-delay:150ms]" />
-          <span className="w-2 h-2 rounded-full bg-[var(--color-text-muted)] animate-pulse [animation-delay:300ms]" />
-        </div>
-      </div>
-    </div>
-  );
-}
-
 function EmptyState({ onQuickAction }: { onQuickAction: (q: string) => void }) {
   return (
     <div className="flex-1 flex flex-col items-center justify-center gap-6 py-12">
@@ -52,15 +35,26 @@ interface ChatAreaProps {
   sending: boolean;
   error: string | null;
   onSend: (text: string) => void;
+  onCancel: () => void;
   sidebarOpen: boolean;
 }
 
-function ChatArea({ messages, loading, sending, error, onSend, sidebarOpen }: ChatAreaProps) {
+function ChatArea({
+  messages,
+  loading,
+  sending,
+  error,
+  onSend,
+  onCancel,
+  sidebarOpen,
+}: ChatAreaProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const lastMsg = messages[messages.length - 1];
 
+  // Auto-scroll bei neuen Nachrichten UND waehrend Streaming (content aendert sich)
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages.length, sending]);
+  }, [messages.length, lastMsg?.content, sending]);
 
   return (
     <div className={`flex-1 flex flex-col min-w-0 ${sidebarOpen ? 'hidden lg:flex' : 'flex'}`}>
@@ -81,14 +75,13 @@ function ChatArea({ messages, loading, sending, error, onSend, sidebarOpen }: Ch
                 timestamp={msg.created_at}
               />
             ))}
-            {sending && <TypingIndicator />}
             {error && (
               <div className="text-center text-sm text-[var(--color-text-error)] py-2">{error}</div>
             )}
             <div ref={messagesEndRef} />
           </div>
           <div className="px-4 py-3">
-            <ChatInput onSend={onSend} disabled={sending} />
+            <ChatInput onSend={onSend} onCancel={onCancel} disabled={sending} streaming={sending} />
           </div>
         </CardBody>
       </Card>
@@ -105,6 +98,7 @@ export function ChatPage() {
     loading,
     error,
     sendMessage,
+    cancelStream,
     selectConversation,
     startNewConversation,
     loadConversations,
@@ -180,6 +174,7 @@ export function ChatPage() {
           sending={sending}
           error={error}
           onSend={handleSend}
+          onCancel={cancelStream}
           sidebarOpen={sidebarOpen}
         />
       </div>


### PR DESCRIPTION
## Summary
- Token-für-Token Streaming statt komplette Antwort abwarten
- Backend: SSE-Endpoint mit `StreamingResponse`, Claude SDK `.stream()` + Ollama NDJSON
- Frontend: `fetch` + `ReadableStream` Parser, Stop-Button zum Abbrechen
- Antwort wird nach Streaming-Ende persistiert und geloggt

## Test plan
- [ ] Chat-Nachricht senden → Antwort erscheint Token für Token
- [ ] Auto-Scroll während des Streamings
- [ ] Stop-Button (■) erscheint während Streaming
- [ ] Stop drücken → Streaming stoppt, bisheriger Text bleibt erhalten
- [ ] Nach Streaming-Ende → Konversationsliste aktualisiert sich
- [ ] Fehler während Streaming → Fehlermeldung angezeigt
- [ ] Neue Konversation → conversation_id wird aus Start-Event übernommen

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)