### PR TITLE
feat: Session-Referenzen als klickbare Links in KI-Chat (#387)

### DIFF
--- a/backend/app/services/chat_context_service.py
+++ b/backend/app/services/chat_context_service.py
@@ -239,12 +239,23 @@ def _assemble_prompt(
             pace = f", Pace {s['pace']}" if s.get("pace") else ""
             hr = f", HF {s['hr_avg']}" if s.get("hr_avg") else ""
             tt = f" [{s['training_type']}]" if s.get("training_type") else ""
+            sid = s.get("id")
+            link = f"[Details](/sessions/{sid})" if sid else ""
             lines.append(
                 f"  - {s['date']}: {s['type']}{tt}"
                 f" — {s.get('duration_min', '?')} min"
                 f", {s.get('distance_km', '?')} km"
                 f"{pace}{hr}"
+                f" {link}".rstrip()
             )
         parts.append("\n## Letzte Sessions (2 Wochen)\n" + "\n".join(lines))
+
+    parts.append(
+        "\n## Hinweis zu Session-Referenzen\n"
+        "Wenn du auf eine bestimmte Session verweist, verlinke sie als Markdown-Link: "
+        "[Beschreibung](/sessions/ID). Beispiel: "
+        '"Dein [Dauerlauf am 15.03.](/sessions/42) war gut dosiert." '
+        "Der Nutzer kann dann direkt zur Session navigieren."
+    )
 
     return "\n".join(parts)

--- a/backend/app/services/session_analysis_service.py
+++ b/backend/app/services/session_analysis_service.py
@@ -158,6 +158,7 @@ def _workout_to_summary(w: WorkoutModel) -> dict:
     w_date = w.date.date() if isinstance(w.date, datetime) else w.date
     effective_type = str(w.training_type_override or w.training_type_auto or "")
     return {
+        "id": w.id,
         "date": str(w_date),
         "type": str(w.workout_type),
         "training_type": effective_type,

--- a/frontend/src/components/chat/ChatMessageBubble.tsx
+++ b/frontend/src/components/chat/ChatMessageBubble.tsx
@@ -1,3 +1,5 @@
+import type { ComponentPropsWithoutRef } from 'react';
+import { Link } from 'react-router-dom';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Bot, User } from 'lucide-react';
@@ -16,6 +18,21 @@ function TypingDots() {
         />
       ))}
     </div>
+  );
+}
+
+function ChatLink({ href, children, ...props }: ComponentPropsWithoutRef<'a'>) {
+  if (href?.startsWith('/')) {
+    return (
+      <Link to={href} className="text-[var(--color-text-primary)] underline hover:opacity-80">
+        {children}
+      </Link>
+    );
+  }
+  return (
+    <a href={href} {...props} target="_blank" rel="noopener noreferrer">
+      {children}
+    </a>
   );
 }
 
@@ -51,7 +68,9 @@ export function ChatMessageBubble({ role, content, timestamp }: ChatMessageBubbl
           <TypingDots />
         ) : (
           <div className="chat-markdown">
-            <Markdown remarkPlugins={[remarkGfm]}>{content}</Markdown>
+            <Markdown remarkPlugins={[remarkGfm]} components={{ a: ChatLink }}>
+              {content}
+            </Markdown>
           </div>
         )}
         {timestamp && (


### PR DESCRIPTION
## Summary
- **Backend**: Session-IDs werden im Chat-Kontext als Markdown-Links mitgegeben (`[Details](/sessions/ID)`), KI wird instruiert diese bei Session-Verweisen zu nutzen
- **Frontend**: `ChatLink`-Komponente rendert interne Pfade (`/sessions/...`) als React Router `<Link>` für SPA-Navigation, externe URLs als `<a target="_blank">`

## Test plan
- [ ] Chat öffnen, Frage zu einer Session stellen (z.B. "Wie war mein letzter Lauf?")
- [ ] KI-Antwort enthält klickbare Session-Links
- [ ] Klick auf Link navigiert zur Session-Detailseite (kein Full-Page-Reload)
- [ ] Externe Links öffnen in neuem Tab

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)