### PR TITLE
fix: Chat-Einträge fehlen im KI Analyse-Log (#405)

### DIFF
--- a/backend/app/services/ai_log_service.py
+++ b/backend/app/services/ai_log_service.py
@@ -44,4 +44,5 @@ async def log_ai_call(db: AsyncSession, data: AICallData) -> None:
             context_label=data.context_label,
         )
     )
+    await db.commit()
     logger.info("KI-Log geschrieben: use_case=%s, parsed_ok=%s", data.use_case, data.parsed_ok)

--- a/frontend/src/pages/KiLog.tsx
+++ b/frontend/src/pages/KiLog.tsx
@@ -16,6 +16,8 @@ import type { AILogEntry, AILogDetail } from '@/api/training';
 const USE_CASE_LABELS: Record<string, string> = {
   session_analysis: 'Session-Analyse',
   exercise_enrichment: 'Übungs-Anreicherung',
+  chat: 'Chat',
+  apply_recommendations: 'Plan-Empfehlung',
 };
 
 function getUseCaseLabel(useCase: string): string {


### PR DESCRIPTION
## Summary
- `log_ai_call()` fehlte `await db.commit()` — Einträge wurden nie persistiert
- USE_CASE_LABELS für `chat` und `apply_recommendations` im Frontend ergänzt

## Test plan
- [ ] Chat-Nachricht senden
- [ ] KI-Log öffnen — Chat-Eintrag muss sichtbar sein mit Label "Chat"
- [ ] apply_recommendations Einträge zeigen "Plan-Empfehlung" statt rohen Key

Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)