### PR TITLE
feat: KI-Chat Tool Use — 11 Tools für vollständigen Trainingskontext (#407)

### DIFF
--- a/backend/app/infrastructure/ai/ai_service.py
+++ b/backend/app/infrastructure/ai/ai_service.py
@@ -5,7 +5,7 @@ Handles AI provider initialization, selection, and fallback logic.
 """
 
 from collections.abc import AsyncIterator
-from typing import Optional
+from typing import Any, Optional
 
 from app.core.config import settings
 from app.domain.interfaces.ai_service import AIProvider
@@ -187,6 +187,40 @@ class AIService:
                 )
 
         raise Exception("All AI providers failed")
+
+    async def stream_chat_with_tools(
+        self,
+        messages: list[dict],
+        system_prompt: str,
+        tools: list[dict],
+        tool_handler: Any,
+        api_key: str | None = None,
+    ) -> tuple[AsyncIterator[dict], str]:
+        """Streamt Chat mit Tool Use. Nur Claude unterstuetzt Tools.
+
+        Returns:
+            Tuple von (async_iterator mit dicts, provider_name).
+        """
+        if self.primary_provider and isinstance(self.primary_provider, ClaudeProvider):
+            return (
+                self.primary_provider.stream_chat_with_tools(
+                    messages, system_prompt, tools, tool_handler, api_key
+                ),
+                self.primary_provider.name,
+            )
+
+        # Fallback: Ohne Tools streamen (Ollama etc.)
+        if self.primary_provider and self.primary_provider.is_available(api_key):
+
+            async def _wrap_stream() -> AsyncIterator[dict]:
+                async for text in self.primary_provider.stream_chat_multi_turn(  # type: ignore[union-attr]
+                    messages, system_prompt, api_key
+                ):
+                    yield {"type": "token", "content": text}
+
+            return _wrap_stream(), self.primary_provider.name
+
+        raise Exception("No AI provider available for tool-use streaming")
 
     def get_active_provider(self) -> Optional[str]:
         """Get name of currently active provider"""

--- a/backend/app/infrastructure/ai/providers/claude_provider.py
+++ b/backend/app/infrastructure/ai/providers/claude_provider.py
@@ -2,14 +2,20 @@
 Claude (Anthropic) AI Provider
 
 High-quality AI analysis using Claude Sonnet 4.
+Unterstuetzt Tool Use fuer den KI-Chat (#407).
 """
 
+import json
+import logging
 from collections.abc import AsyncIterator
+from typing import Any
 
 import anthropic
 
 from app.core.config import settings
 from app.domain.interfaces.ai_service import AIProvider
+
+logger = logging.getLogger(__name__)
 
 
 class ClaudeProvider(AIProvider):
@@ -116,6 +122,60 @@ class ClaudeProvider(AIProvider):
         ) as stream:
             async for text in stream.text_stream:
                 yield text
+
+    async def stream_chat_with_tools(
+        self,
+        messages: list[dict],
+        system_prompt: str,
+        tools: list[dict],
+        tool_handler: Any,
+        api_key: str | None = None,
+    ) -> AsyncIterator[dict]:
+        """Streamt Chat mit Tool Use. Yields dicts mit type: tool_call | token."""
+        client = self._get_async_client(api_key)
+        api_messages: list[anthropic.types.MessageParam] = [
+            {"role": m["role"], "content": m["content"]}
+            for m in messages  # type: ignore[misc]
+        ]
+
+        max_tool_rounds = 5
+        for _ in range(max_tool_rounds):
+            async with client.messages.stream(
+                model=self.model,
+                max_tokens=4000,
+                temperature=0.3,
+                system=system_prompt,
+                messages=api_messages,
+                tools=tools,  # type: ignore[arg-type]
+            ) as stream:
+                # Text-Tokens streamen
+                async for text in stream.text_stream:
+                    yield {"type": "token", "content": text}
+
+                final = await stream.get_final_message()
+
+            # Pruefen ob Tool-Calls vorhanden
+            if final.stop_reason != "tool_use":
+                return  # Fertig, kein Tool-Call
+
+            # Tool-Calls verarbeiten
+            api_messages.append({"role": "assistant", "content": final.content})  # type: ignore[arg-type]
+
+            tool_results: list[dict] = []
+            for block in final.content:
+                if block.type == "tool_use":
+                    yield {"type": "tool_call", "name": block.name, "input": block.input}
+                    logger.info("Tool-Call: %s(%s)", block.name, json.dumps(block.input)[:200])
+                    result = await tool_handler(block.name, block.input)
+                    tool_results.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": block.id,
+                            "content": json.dumps(result, ensure_ascii=False),
+                        }
+                    )
+
+            api_messages.append({"role": "user", "content": tool_results})  # type: ignore[arg-type,typeddict-item]
 
     def is_available(self, api_key: str | None = None) -> bool:
         """Check if Claude API is available"""

--- a/backend/app/services/chat_context_service.py
+++ b/backend/app/services/chat_context_service.py
@@ -251,11 +251,15 @@ def _assemble_prompt(
         parts.append("\n## Letzte Sessions (2 Wochen)\n" + "\n".join(lines))
 
     parts.append(
-        "\n## Hinweis zu Session-Referenzen\n"
-        "Wenn du auf eine bestimmte Session verweist, verlinke sie als Markdown-Link: "
+        "\n## Hinweise\n"
+        "- Wenn du auf eine bestimmte Session verweist, verlinke sie als Markdown-Link: "
         "[Beschreibung](/sessions/ID). Beispiel: "
-        '"Dein [Dauerlauf am 15.03.](/sessions/42) war gut dosiert." '
-        "Der Nutzer kann dann direkt zur Session navigieren."
+        '"Dein [Dauerlauf am 15.03.](/sessions/42) war gut dosiert."\n'
+        "- Du hast Zugriff auf Tools um Details nachzuladen. "
+        "Nutze sie aktiv wenn der User nach spezifischen Daten fragt "
+        "(Session-Details, Statistiken, Plandetails, Uebungen etc.).\n"
+        "- Fasse Tool-Ergebnisse kompakt und hilfreich zusammen — "
+        "gib nicht alle Rohdaten wieder, sondern die relevanten Erkenntnisse."
     )
 
     return "\n".join(parts)

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -2,7 +2,7 @@
 
 Verwaltet Konversationen und Nachrichten. Baut den vollen
 Trainingskontext als System-Prompt und sendet Multi-Turn-Anfragen
-an den AI-Provider.
+an den AI-Provider. Unterstuetzt Tool Use (#407).
 """
 
 import json
@@ -10,6 +10,7 @@ import logging
 import time
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
+from functools import partial
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -26,6 +27,8 @@ from app.models.chat import (
 )
 from app.services.ai_log_service import AICallData, log_ai_call
 from app.services.chat_context_service import build_chat_system_prompt
+from app.services.chat_tool_handlers import dispatch_tool
+from app.services.chat_tools import CHAT_TOOLS
 
 logger = logging.getLogger(__name__)
 
@@ -129,12 +132,12 @@ class StreamContext:
     start_time: float
 
 
-async def prepare_stream(
+async def prepare_stream_with_tools(
     message: str,
     conversation_id: int | None,
     db: AsyncSession,
-) -> tuple[AsyncIterator[str], StreamContext]:
-    """Bereitet Streaming vor: speichert User-Msg, gibt Stream + Kontext zurueck."""
+) -> tuple[AsyncIterator[dict], StreamContext]:
+    """Bereitet Streaming mit Tool Use vor."""
     if conversation_id:
         conversation = await _load_conversation(conversation_id, db)
     else:
@@ -156,8 +159,9 @@ async def prepare_stream(
     api_messages = [{"role": m.role, "content": m.content} for m in history]
 
     api_key = await resolve_claude_api_key(db)
-    stream, provider_name = await ai_service.stream_chat_multi_turn(
-        api_messages, system_prompt, api_key
+    tool_handler = partial(dispatch_tool, db=db)
+    stream, provider_name = await ai_service.stream_chat_with_tools(
+        api_messages, system_prompt, CHAT_TOOLS, tool_handler, api_key
     )
 
     ctx = StreamContext(
@@ -208,17 +212,20 @@ async def stream_sse_events(
     conversation_id: int | None,
     db: AsyncSession,
 ) -> AsyncIterator[str]:
-    """Generiert SSE-Events fuer den Streaming-Endpoint."""
-    stream, ctx = await prepare_stream(message, conversation_id, db)
+    """Generiert SSE-Events fuer den Streaming-Endpoint (mit Tool Use)."""
+    stream, ctx = await prepare_stream_with_tools(message, conversation_id, db)
 
     # Erstes Event: Konversations-ID
     yield f"data: {json.dumps({'type': 'start', 'conversation_id': ctx.conversation_id})}\n\n"
 
     full_response = ""
     try:
-        async for token in stream:
-            full_response += token
-            yield f"data: {json.dumps({'type': 'token', 'content': token})}\n\n"
+        async for event in stream:
+            if event["type"] == "token":
+                full_response += event["content"]
+                yield f"data: {json.dumps({'type': 'token', 'content': event['content']})}\n\n"
+            elif event["type"] == "tool_call":
+                yield f"data: {json.dumps({'type': 'tool_call', 'name': event['name']})}\n\n"
     except Exception as e:
         logger.error("Streaming-Fehler: %s", e)
         yield f"data: {json.dumps({'type': 'error', 'message': str(e)})}\n\n"

--- a/backend/app/services/chat_tool_handlers.py
+++ b/backend/app/services/chat_tool_handlers.py
@@ -1,0 +1,658 @@
+"""Chat Tool Handlers — DB-Queries fuer die 11 KI-Chat-Tools.
+
+Jeder Handler bekommt die Tool-Argumente und eine DB-Session,
+fuehrt die Abfrage durch und gibt ein JSON-serialisierbares Dict zurueck.
+"""
+
+import json
+import logging
+from datetime import date, datetime, timedelta
+
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.infrastructure.database.models import (
+    AIRecommendationModel,
+    ChatConversationModel,
+    ChatMessageModel,
+    ExerciseModel,
+    PlanChangeLogModel,
+    PlannedSessionModel,
+    TrainingPhaseModel,
+    TrainingPlanModel,
+    WeeklyPlanDayModel,
+    WeeklyReviewModel,
+    WorkoutModel,
+)
+
+logger = logging.getLogger(__name__)
+
+PERIOD_MAP = {
+    "1w": timedelta(weeks=1),
+    "2w": timedelta(weeks=2),
+    "4w": timedelta(weeks=4),
+    "3m": timedelta(days=90),
+    "6m": timedelta(days=180),
+    "1y": timedelta(days=365),
+}
+
+
+async def dispatch_tool(name: str, args: dict, db: AsyncSession) -> dict:
+    """Ruft den passenden Tool-Handler auf."""
+    handlers = {
+        "get_session_details": handle_get_session_details,
+        "search_sessions": handle_search_sessions,
+        "get_training_stats": handle_get_training_stats,
+        "get_plan_details": handle_get_plan_details,
+        "get_plan_compliance": handle_get_plan_compliance,
+        "get_personal_records": handle_get_personal_records,
+        "get_exercises": handle_get_exercises,
+        "get_ai_recommendations": handle_get_ai_recommendations,
+        "get_weekly_review": handle_get_weekly_review,
+        "search_conversations": handle_search_conversations,
+        "get_plan_change_log": handle_get_plan_change_log,
+    }
+    handler = handlers.get(name)
+    if not handler:
+        return {"error": f"Unbekanntes Tool: {name}"}
+    try:
+        return await handler(args, db)
+    except Exception as e:
+        logger.exception("Tool-Handler %s fehlgeschlagen", name)
+        return {"error": f"Fehler bei {name}: {str(e)}"}
+
+
+async def handle_get_session_details(args: dict, db: AsyncSession) -> dict:
+    """Laedt vollstaendige Session-Details."""
+    session_id = args["session_id"]
+    result = await db.execute(select(WorkoutModel).where(WorkoutModel.id == session_id))
+    w = result.scalar_one_or_none()
+    if not w:
+        return {"error": f"Session {session_id} nicht gefunden"}
+
+    w_date = w.date.date() if isinstance(w.date, datetime) else w.date
+    data: dict = {
+        "id": w.id,
+        "date": str(w_date),
+        "workout_type": str(w.workout_type),
+        "training_type": str(w.training_type_override or w.training_type_auto or ""),
+        "duration_min": round(w.duration_sec / 60) if w.duration_sec else None,
+        "distance_km": w.distance_km,
+        "pace": str(w.pace) if w.pace else None,
+        "hr_avg": w.hr_avg,
+        "hr_max": w.hr_max,
+        "hr_min": w.hr_min,
+        "cadence_avg": w.cadence_avg,
+        "rpe": w.rpe,
+        "notes": w.notes,
+    }
+
+    data["laps"] = _parse_json(w.laps_json)
+    data["hr_zones"] = _parse_json(w.hr_zones_json)
+    data["weather"] = _parse_json(w.weather_json)
+    data["air_quality"] = _parse_json(w.air_quality_json)
+    data["surface"] = _parse_json(w.surface_json)
+    data["location"] = w.location_name
+    data["exercises"] = _parse_json(w.exercises_json)
+
+    # Hoehenmeter aus GPS-Track
+    gps = _parse_json(w.gps_track_json)
+    if isinstance(gps, dict):
+        data["elevation"] = {
+            "ascent_m": gps.get("total_ascent_m"),
+            "descent_m": gps.get("total_descent_m"),
+        }
+
+    # KI-Analyse (gecached)
+    data["ai_analysis"] = _parse_json(w.ai_analysis)
+
+    # Soll/Ist: geplante Session
+    if w.planned_entry_id:
+        data["planned_session"] = await _load_planned_session(w.planned_entry_id, db)
+
+    return data
+
+
+async def handle_search_sessions(args: dict, db: AsyncSession) -> dict:
+    """Sucht Sessions mit Filtern."""
+    query = select(WorkoutModel)
+
+    if args.get("workout_type"):
+        query = query.where(WorkoutModel.workout_type == args["workout_type"])
+    if args.get("training_type"):
+        tt = args["training_type"]
+        query = query.where(
+            or_(WorkoutModel.training_type_override == tt, WorkoutModel.training_type_auto == tt)
+        )
+    if args.get("date_from"):
+        query = query.where(WorkoutModel.date >= datetime.fromisoformat(args["date_from"]))
+    if args.get("date_to"):
+        dt_to = datetime.fromisoformat(args["date_to"])
+        query = query.where(WorkoutModel.date <= dt_to.replace(hour=23, minute=59, second=59))
+    if args.get("min_distance_km"):
+        query = query.where(WorkoutModel.distance_km >= args["min_distance_km"])
+    if args.get("max_distance_km"):
+        query = query.where(WorkoutModel.distance_km <= args["max_distance_km"])
+
+    sort_col = _get_sort_column(args.get("sort_by", "date"))
+    query = query.order_by(sort_col.desc() if args.get("sort_order") != "asc" else sort_col.asc())
+
+    limit = min(args.get("limit", 10), 50)
+    query = query.limit(limit)
+
+    result = await db.execute(query)
+    sessions = []
+    for w in result.scalars().all():
+        w_date = w.date.date() if isinstance(w.date, datetime) else w.date
+        sessions.append(
+            {
+                "id": w.id,
+                "date": str(w_date),
+                "workout_type": str(w.workout_type),
+                "training_type": str(w.training_type_override or w.training_type_auto or ""),
+                "duration_min": round(w.duration_sec / 60) if w.duration_sec else None,
+                "distance_km": w.distance_km,
+                "pace": str(w.pace) if w.pace else None,
+                "hr_avg": w.hr_avg,
+                "rpe": w.rpe,
+            }
+        )
+
+    return {"sessions": sessions, "count": len(sessions)}
+
+
+async def handle_get_training_stats(args: dict, db: AsyncSession) -> dict:
+    """Aggregierte Trainingsstatistiken."""
+    today = date.today()
+    delta = PERIOD_MAP.get(args["period"], timedelta(weeks=4))
+    start = datetime.combine(today - delta, datetime.min.time())
+    end = datetime.combine(today, datetime.max.time())
+
+    stats = await _compute_period_stats(start, end, db)
+
+    result: dict = {"period": args["period"], "from": str(start.date()), "to": str(today), **stats}
+
+    # Vergleich mit vorherigem Zeitraum
+    if args.get("compare_previous", True):
+        prev_end = start
+        prev_start = datetime.combine(start.date() - delta, datetime.min.time())
+        prev_stats = await _compute_period_stats(prev_start, prev_end, db)
+        result["previous_period"] = {
+            "from": str(prev_start.date()),
+            "to": str(prev_end.date()),
+            **prev_stats,
+        }
+
+    return result
+
+
+async def handle_get_plan_details(args: dict, db: AsyncSession) -> dict:
+    """Laedt aktiven Trainingsplan mit Phasen und Wochenstruktur."""
+    today = date.today()
+    plan_result = await db.execute(
+        select(TrainingPlanModel)
+        .where(
+            TrainingPlanModel.status == "active",
+            TrainingPlanModel.start_date <= today,
+            TrainingPlanModel.end_date >= today,
+        )
+        .limit(1)
+    )
+    plan = plan_result.scalar_one_or_none()
+    if not plan:
+        return {"error": "Kein aktiver Trainingsplan gefunden"}
+
+    # Phasen laden
+    phases_result = await db.execute(
+        select(TrainingPhaseModel)
+        .where(TrainingPhaseModel.training_plan_id == plan.id)
+        .order_by(TrainingPhaseModel.start_week)
+    )
+    phases = [
+        {
+            "name": p.name,
+            "phase_type": str(p.phase_type),
+            "start_week": p.start_week,
+            "end_week": p.end_week,
+            "focus": _parse_json(p.focus_json),
+            "target_metrics": _parse_json(p.target_metrics_json),
+            "notes": p.notes,
+        }
+        for p in phases_result.scalars().all()
+    ]
+
+    # Geplante Sessions fuer die angefragte Woche
+    week_offset = args.get("week_offset", 0)
+    target_week = today + timedelta(weeks=week_offset)
+    week_start = target_week - timedelta(days=target_week.weekday())
+    week_sessions = await _load_week_planned_sessions(plan.id, week_start, db)
+
+    return {
+        "plan_name": plan.name,
+        "description": plan.description,
+        "start_date": str(plan.start_date),
+        "end_date": str(plan.end_date),
+        "current_week": max(1, (today - plan.start_date).days // 7 + 1),
+        "total_weeks": (plan.end_date - plan.start_date).days // 7 + 1,
+        "phases": phases,
+        "week_sessions": week_sessions,
+        "week_start": str(week_start),
+    }
+
+
+async def handle_get_plan_compliance(args: dict, db: AsyncSession) -> dict:
+    """Soll/Ist-Vergleich fuer eine Woche."""
+    today = date.today()
+    week_offset = args.get("week_offset", 0)
+    target_date = today + timedelta(weeks=week_offset)
+    week_start = target_date - timedelta(days=target_date.weekday())
+    week_end = week_start + timedelta(days=6)
+
+    # Geplante Sessions
+    plan_result = await db.execute(
+        select(TrainingPlanModel)
+        .where(
+            TrainingPlanModel.status == "active",
+            TrainingPlanModel.start_date <= today,
+            TrainingPlanModel.end_date >= today,
+        )
+        .limit(1)
+    )
+    plan = plan_result.scalar_one_or_none()
+    planned = await _load_week_planned_sessions(plan.id, week_start, db) if plan else []
+
+    # Tatsaechliche Sessions
+    actual_result = await db.execute(
+        select(WorkoutModel)
+        .where(
+            WorkoutModel.date >= datetime.combine(week_start, datetime.min.time()),
+            WorkoutModel.date <= datetime.combine(week_end, datetime.max.time()),
+        )
+        .order_by(WorkoutModel.date)
+    )
+    actual = []
+    for w in actual_result.scalars().all():
+        w_date = w.date.date() if isinstance(w.date, datetime) else w.date
+        actual.append(
+            {
+                "id": w.id,
+                "date": str(w_date),
+                "workout_type": str(w.workout_type),
+                "training_type": str(w.training_type_override or w.training_type_auto or ""),
+                "duration_min": round(w.duration_sec / 60) if w.duration_sec else None,
+                "distance_km": w.distance_km,
+                "pace": str(w.pace) if w.pace else None,
+                "planned_entry_id": w.planned_entry_id,
+            }
+        )
+
+    planned_count = len([p for p in planned if p.get("type") != "Ruhetag"])
+    actual_count = len(actual)
+    compliance = round(actual_count / planned_count * 100) if planned_count > 0 else 0
+
+    return {
+        "week_start": str(week_start),
+        "week_end": str(week_end),
+        "planned_sessions": planned,
+        "actual_sessions": actual,
+        "planned_count": planned_count,
+        "actual_count": actual_count,
+        "compliance_pct": min(compliance, 100),
+    }
+
+
+async def handle_get_personal_records(_args: dict, db: AsyncSession) -> dict:
+    """Persoenliche Bestleistungen."""
+    # Schnellste Pace (nur Laeufe mit Pace-Wert)
+    pace_result = await db.execute(
+        select(WorkoutModel)
+        .where(WorkoutModel.workout_type == "running", WorkoutModel.pace.is_not(None))
+        .order_by(WorkoutModel.pace.asc())
+        .limit(5)
+    )
+    fastest = [
+        {
+            "id": w.id,
+            "date": str(w.date.date() if isinstance(w.date, datetime) else w.date),
+            "pace": str(w.pace),
+            "distance_km": w.distance_km,
+            "training_type": str(w.training_type_override or w.training_type_auto or ""),
+        }
+        for w in pace_result.scalars().all()
+    ]
+
+    # Laengster Lauf
+    dist_result = await db.execute(
+        select(WorkoutModel)
+        .where(WorkoutModel.workout_type == "running", WorkoutModel.distance_km.is_not(None))
+        .order_by(WorkoutModel.distance_km.desc())
+        .limit(3)
+    )
+    longest = [
+        {
+            "id": w.id,
+            "date": str(w.date.date() if isinstance(w.date, datetime) else w.date),
+            "distance_km": w.distance_km,
+            "duration_min": round(w.duration_sec / 60) if w.duration_sec else None,
+        }
+        for w in dist_result.scalars().all()
+    ]
+
+    # Hoechstes Wochenvolumen
+    weekly_vol = await db.execute(
+        select(
+            func.date_trunc("week", WorkoutModel.date).label("week"),
+            func.sum(WorkoutModel.distance_km).label("total_km"),
+            func.count(WorkoutModel.id).label("sessions"),
+        )
+        .where(WorkoutModel.workout_type == "running")
+        .group_by("week")
+        .order_by(func.sum(WorkoutModel.distance_km).desc())
+        .limit(3)
+    )
+    best_weeks = [
+        {
+            "week": str(row.week.date() if row.week else ""),
+            "total_km": round(row.total_km, 1),
+            "sessions": row.sessions,
+        }
+        for row in weekly_vol.all()
+    ]
+
+    return {
+        "fastest_pace": fastest,
+        "longest_runs": longest,
+        "best_weekly_volume": best_weeks,
+    }
+
+
+async def handle_get_exercises(args: dict, db: AsyncSession) -> dict:
+    """Durchsucht die Uebungsdatenbank."""
+    query = select(ExerciseModel)
+
+    if args.get("category"):
+        query = query.where(ExerciseModel.category == args["category"])
+    if args.get("equipment"):
+        query = query.where(ExerciseModel.equipment == args["equipment"])
+    if args.get("level"):
+        query = query.where(ExerciseModel.level == args["level"])
+    if args.get("muscle_group"):
+        query = query.where(ExerciseModel.primary_muscles_json.contains(args["muscle_group"]))
+    if args.get("search"):
+        query = query.where(ExerciseModel.name.ilike(f"%{args['search']}%"))
+
+    limit = min(args.get("limit", 20), 50)
+    query = query.order_by(ExerciseModel.usage_count.desc()).limit(limit)
+
+    result = await db.execute(query)
+    exercises = [
+        {
+            "id": e.id,
+            "name": e.name,
+            "category": e.category,
+            "equipment": e.equipment,
+            "level": e.level,
+            "primary_muscles": _parse_json(e.primary_muscles_json),
+            "instructions": _parse_json(e.instructions_json),
+            "usage_count": e.usage_count,
+        }
+        for e in result.scalars().all()
+    ]
+
+    return {"exercises": exercises, "count": len(exercises)}
+
+
+async def handle_get_ai_recommendations(args: dict, db: AsyncSession) -> dict:
+    """Laedt KI-Empfehlungen."""
+    query = select(AIRecommendationModel)
+
+    period = args.get("period", "4w")
+    delta = PERIOD_MAP.get(period, timedelta(weeks=4))
+    start = datetime.combine(date.today() - delta, datetime.min.time())
+    query = query.where(AIRecommendationModel.created_at >= start)
+
+    if args.get("status"):
+        query = query.where(AIRecommendationModel.status == args["status"])
+
+    query = query.order_by(AIRecommendationModel.created_at.desc()).limit(30)
+
+    result = await db.execute(query)
+    recs = [
+        {
+            "id": r.id,
+            "session_id": r.session_id,
+            "type": str(r.type),
+            "title": r.title,
+            "reasoning": r.reasoning,
+            "priority": r.priority,
+            "status": r.status,
+            "current_value": r.current_value,
+            "suggested_value": r.suggested_value,
+            "created_at": str(r.created_at),
+        }
+        for r in result.scalars().all()
+    ]
+
+    return {"recommendations": recs, "count": len(recs)}
+
+
+async def handle_get_weekly_review(args: dict, db: AsyncSession) -> dict:
+    """Laedt den Wochenrueckblick."""
+    today = date.today()
+    week_offset = args.get("week_offset", -1)
+    target_date = today + timedelta(weeks=week_offset)
+    week_start = target_date - timedelta(days=target_date.weekday())
+
+    result = await db.execute(
+        select(WeeklyReviewModel).where(WeeklyReviewModel.week_start == week_start)
+    )
+    review = result.scalar_one_or_none()
+    if not review:
+        return {"error": f"Kein Wochenrueckblick fuer KW ab {week_start} vorhanden"}
+
+    return {
+        "week_start": str(review.week_start),
+        "summary": review.summary,
+        "overall_rating": review.overall_rating,
+        "fatigue_assessment": review.fatigue_assessment,
+        "session_count": review.session_count,
+        "volume_comparison": _parse_json(review.volume_comparison_json),
+        "highlights": _parse_json(review.highlights_json),
+        "improvements": _parse_json(review.improvements_json),
+        "next_week_recommendations": _parse_json(review.next_week_recommendations_json),
+    }
+
+
+async def handle_search_conversations(args: dict, db: AsyncSession) -> dict:
+    """Durchsucht fruehere Chat-Konversationen."""
+    query_text = args["query"]
+    limit = min(args.get("limit", 5), 20)
+
+    result = await db.execute(
+        select(ChatMessageModel, ChatConversationModel.title)
+        .join(ChatConversationModel, ChatMessageModel.conversation_id == ChatConversationModel.id)
+        .where(ChatMessageModel.content.ilike(f"%{query_text}%"))
+        .order_by(ChatMessageModel.created_at.desc())
+        .limit(limit)
+    )
+    matches = [
+        {
+            "conversation_title": row.title,
+            "conversation_id": row.ChatMessageModel.conversation_id,
+            "role": row.ChatMessageModel.role,
+            "content_excerpt": row.ChatMessageModel.content[:300],
+            "created_at": str(row.ChatMessageModel.created_at),
+        }
+        for row in result.all()
+    ]
+
+    return {"matches": matches, "count": len(matches)}
+
+
+async def handle_get_plan_change_log(args: dict, db: AsyncSession) -> dict:
+    """Laedt Planaenderungshistorie."""
+    period = args.get("period", "4w")
+    delta = PERIOD_MAP.get(period, timedelta(weeks=4))
+    start = datetime.combine(date.today() - delta, datetime.min.time())
+    limit = min(args.get("limit", 20), 50)
+
+    result = await db.execute(
+        select(PlanChangeLogModel)
+        .where(PlanChangeLogModel.created_at >= start)
+        .order_by(PlanChangeLogModel.created_at.desc())
+        .limit(limit)
+    )
+    changes = [
+        {
+            "id": c.id,
+            "change_type": c.change_type,
+            "category": c.category,
+            "summary": c.summary,
+            "reason": c.reason,
+            "details": _parse_json(c.details_json),
+            "created_by": c.created_by,
+            "created_at": str(c.created_at),
+        }
+        for c in result.scalars().all()
+    ]
+
+    return {"changes": changes, "count": len(changes)}
+
+
+# --- Helpers ---
+
+
+def _parse_json(raw: str | None) -> dict | list | None:
+    """Parst JSON-String, gibt None bei Fehler zurueck."""
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def _get_sort_column(sort_by: str):
+    """Gibt die SQLAlchemy-Spalte fuer die Sortierung zurueck."""
+    mapping = {
+        "date": WorkoutModel.date,
+        "distance": WorkoutModel.distance_km,
+        "duration": WorkoutModel.duration_sec,
+        "pace": WorkoutModel.pace,
+    }
+    return mapping.get(sort_by, WorkoutModel.date)
+
+
+async def _compute_period_stats(start: datetime, end: datetime, db: AsyncSession) -> dict:
+    """Berechnet aggregierte Stats fuer einen Zeitraum."""
+    result = await db.execute(
+        select(
+            func.count(WorkoutModel.id).label("total_sessions"),
+            func.sum(WorkoutModel.distance_km).label("total_km"),
+            func.sum(WorkoutModel.duration_sec).label("total_sec"),
+            func.avg(WorkoutModel.hr_avg).label("avg_hr"),
+            func.avg(WorkoutModel.cadence_avg).label("avg_cadence"),
+        ).where(WorkoutModel.date >= start, WorkoutModel.date <= end)
+    )
+    row = result.one()
+
+    # Typ-Verteilung
+    type_result = await db.execute(
+        select(
+            func.coalesce(
+                WorkoutModel.training_type_override, WorkoutModel.training_type_auto, "unknown"
+            ).label("tt"),
+            func.count(WorkoutModel.id).label("cnt"),
+        )
+        .where(
+            WorkoutModel.date >= start,
+            WorkoutModel.date <= end,
+            WorkoutModel.workout_type == "running",
+        )
+        .group_by("tt")
+    )
+    type_dist = {str(r.tt): r.cnt for r in type_result.all()}
+
+    total_km = round(row.total_km, 1) if row.total_km else 0
+    total_sec = row.total_sec or 0
+
+    return {
+        "total_sessions": row.total_sessions or 0,
+        "total_km": total_km,
+        "total_duration_min": round(total_sec / 60) if total_sec else 0,
+        "avg_hr": round(row.avg_hr) if row.avg_hr else None,
+        "avg_cadence": round(row.avg_cadence) if row.avg_cadence else None,
+        "type_distribution": type_dist,
+    }
+
+
+async def _load_planned_session(planned_id: int, db: AsyncSession) -> dict | None:
+    """Laedt eine geplante Session fuer Soll/Ist."""
+    result = await db.execute(
+        select(PlannedSessionModel).where(PlannedSessionModel.id == planned_id)
+    )
+    ps = result.scalar_one_or_none()
+    if not ps:
+        return None
+
+    data: dict = {
+        "training_type": str(ps.training_type),
+        "notes": str(ps.notes) if ps.notes else None,
+    }
+    if ps.run_details_json:
+        rd = _parse_json(ps.run_details_json)
+        if rd:
+            data["run_details"] = rd
+    if ps.exercises_json:
+        ex = _parse_json(ps.exercises_json)
+        if ex:
+            data["exercises"] = ex
+    return data
+
+
+async def _load_week_planned_sessions(
+    plan_id: int, week_start: date, db: AsyncSession
+) -> list[dict]:
+    """Laedt geplante Sessions fuer eine Woche."""
+    day_result = await db.execute(
+        select(WeeklyPlanDayModel)
+        .where(
+            WeeklyPlanDayModel.plan_id == plan_id,
+            WeeklyPlanDayModel.week_start == week_start,
+        )
+        .order_by(WeeklyPlanDayModel.day_of_week)
+    )
+    days = day_result.scalars().all()
+
+    sessions: list[dict] = []
+    for day in days:
+        actual_date = day.week_start + timedelta(days=day.day_of_week)
+        if day.is_rest_day:
+            sessions.append({"date": str(actual_date), "type": "Ruhetag"})
+            continue
+
+        ps_result = await db.execute(
+            select(PlannedSessionModel)
+            .where(
+                PlannedSessionModel.day_id == day.id,
+                PlannedSessionModel.status == "active",
+            )
+            .order_by(PlannedSessionModel.position)
+        )
+        for ps in ps_result.scalars().all():
+            entry: dict = {
+                "date": str(actual_date),
+                "training_type": str(ps.training_type),
+                "notes": str(ps.notes) if ps.notes else None,
+            }
+            if ps.run_details_json:
+                rd = _parse_json(ps.run_details_json)
+                if rd:
+                    entry["run_details"] = rd
+            if ps.exercises_json:
+                ex = _parse_json(ps.exercises_json)
+                if ex:
+                    entry["exercises"] = ex
+            sessions.append(entry)
+
+    return sessions

--- a/backend/app/services/chat_tools.py
+++ b/backend/app/services/chat_tools.py
@@ -1,0 +1,288 @@
+"""Chat Tool Definitions — JSON-Schemas fuer Claude Tool Use.
+
+Definiert die 11 Tools, die der KI-Chat nutzen kann, um
+Trainingsdaten on-demand nachzuladen.
+"""
+
+CHAT_TOOLS: list[dict] = [
+    {
+        "name": "get_session_details",
+        "description": (
+            "Laedt vollstaendige Details einer Trainingseinheit: "
+            "Segmente/Laps, HF-Zonen, Wetter, Luftqualitaet, Hoehenmeter, "
+            "KI-Analyse, Soll/Ist-Vergleich, Notizen, RPE. "
+            "Nutze dieses Tool wenn der User nach Details einer bestimmten Session fragt."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "session_id": {
+                    "type": "integer",
+                    "description": "ID der Session (aus dem Kontext oder vorherigen Suchergebnissen)",
+                },
+            },
+            "required": ["session_id"],
+        },
+    },
+    {
+        "name": "search_sessions",
+        "description": (
+            "Sucht und filtert Trainingseinheiten. "
+            "Nutze dieses Tool fuer Fragen wie 'Alle Intervalltrainings im Februar', "
+            "'Laeufe ueber 15km', 'Letzte 5 Krafttrainings'."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "workout_type": {
+                    "type": "string",
+                    "description": "Workout-Typ: running, strength",
+                    "enum": ["running", "strength"],
+                },
+                "training_type": {
+                    "type": "string",
+                    "description": (
+                        "Trainingsart (nur Lauf): steady, progression, tempo, "
+                        "interval, fartlek, repetitions, long_run, recovery_jog"
+                    ),
+                },
+                "date_from": {
+                    "type": "string",
+                    "description": "Startdatum (YYYY-MM-DD)",
+                },
+                "date_to": {
+                    "type": "string",
+                    "description": "Enddatum (YYYY-MM-DD)",
+                },
+                "min_distance_km": {
+                    "type": "number",
+                    "description": "Minimale Distanz in km",
+                },
+                "max_distance_km": {
+                    "type": "number",
+                    "description": "Maximale Distanz in km",
+                },
+                "sort_by": {
+                    "type": "string",
+                    "description": "Sortierung",
+                    "enum": ["date", "distance", "duration", "pace"],
+                },
+                "sort_order": {
+                    "type": "string",
+                    "enum": ["asc", "desc"],
+                    "description": "Sortierrichtung (Standard: desc)",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max. Anzahl Ergebnisse (Standard: 10, Max: 50)",
+                },
+            },
+            "required": [],
+        },
+    },
+    {
+        "name": "get_training_stats",
+        "description": (
+            "Liefert aggregierte Trainingsstatistiken fuer einen Zeitraum: "
+            "Volumen, Durchschnittswerte, Verteilung nach Trainingstyp, Trend-Vergleich. "
+            "Nutze dieses Tool fuer Fragen wie 'Wie viel bin ich diesen Monat gelaufen?', "
+            "'Wie hat sich mein Volumen entwickelt?'."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "period": {
+                    "type": "string",
+                    "description": "Zeitraum: 1w, 2w, 4w, 3m, 6m, 1y",
+                    "enum": ["1w", "2w", "4w", "3m", "6m", "1y"],
+                },
+                "compare_previous": {
+                    "type": "boolean",
+                    "description": "Vergleich mit vorherigem Zeitraum (Standard: true)",
+                },
+            },
+            "required": ["period"],
+        },
+    },
+    {
+        "name": "get_plan_details",
+        "description": (
+            "Laedt den aktiven Trainingsplan: Phasen, Wochenstruktur, "
+            "geplante Sessions einer bestimmten Woche. "
+            "Nutze dieses Tool fuer Fragen zum Trainingsplan, Phasen, was ansteht."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "week_offset": {
+                    "type": "integer",
+                    "description": (
+                        "Wochen-Offset relativ zu heute. "
+                        "0 = aktuelle Woche, 1 = naechste, -1 = letzte."
+                    ),
+                },
+            },
+            "required": [],
+        },
+    },
+    {
+        "name": "get_plan_compliance",
+        "description": (
+            "Vergleicht geplante vs. tatsaechliche Sessions (Soll/Ist). "
+            "Zeigt Abweichungen bei Pace, Dauer, Distanz und uebersprungene Sessions. "
+            "Nutze dieses Tool fuer Fragen wie 'Habe ich meinen Plan eingehalten?'."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "week_offset": {
+                    "type": "integer",
+                    "description": "Wochen-Offset (0 = aktuelle Woche, -1 = letzte)",
+                },
+            },
+            "required": [],
+        },
+    },
+    {
+        "name": "get_personal_records",
+        "description": (
+            "Liefert persoenliche Bestleistungen: schnellste Pace, "
+            "laengster Lauf, hoechstes Wochenvolumen. "
+            "Nutze dieses Tool fuer Fragen nach Bestleistungen oder Rekorden."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    },
+    {
+        "name": "get_exercises",
+        "description": (
+            "Durchsucht die Uebungsdatenbank nach Muskelgruppe, Kategorie, "
+            "Equipment oder Level. "
+            "Nutze dieses Tool fuer Fragen wie 'Welche Core-Uebungen gibt es?', "
+            "'Uebungen ohne Geraete'."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string",
+                    "description": "Kategorie: push, pull, legs, core, cardio",
+                    "enum": ["push", "pull", "legs", "core", "cardio"],
+                },
+                "muscle_group": {
+                    "type": "string",
+                    "description": "Muskelgruppe (z.B. 'chest', 'quadriceps', 'abdominals')",
+                },
+                "equipment": {
+                    "type": "string",
+                    "description": "Equipment (z.B. 'body only', 'dumbbell', 'barbell')",
+                },
+                "level": {
+                    "type": "string",
+                    "description": "Schwierigkeitsgrad",
+                    "enum": ["beginner", "intermediate", "expert"],
+                },
+                "search": {
+                    "type": "string",
+                    "description": "Freitext-Suche im Uebungsnamen",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max. Ergebnisse (Standard: 20)",
+                },
+            },
+            "required": [],
+        },
+    },
+    {
+        "name": "get_ai_recommendations",
+        "description": (
+            "Laedt bisherige KI-Empfehlungen aus Session-Analysen: "
+            "Typ, Prioritaet, Begruendung, Status. "
+            "Nutze dieses Tool fuer Fragen wie 'Was wurde mir empfohlen?', "
+            "'Habe ich die Empfehlungen umgesetzt?'."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "period": {
+                    "type": "string",
+                    "description": "Zeitraum: 1w, 2w, 4w, 3m",
+                    "enum": ["1w", "2w", "4w", "3m"],
+                },
+                "status": {
+                    "type": "string",
+                    "description": "Filter nach Status",
+                    "enum": ["pending", "applied", "dismissed"],
+                },
+            },
+            "required": [],
+        },
+    },
+    {
+        "name": "get_weekly_review",
+        "description": (
+            "Laedt den KI-Wochenrueckblick mit Zusammenfassung, "
+            "Highlights, Verbesserungen, Empfehlungen fuer naechste Woche. "
+            "Nutze dieses Tool fuer Fragen wie 'Wie war meine letzte Woche?'."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "week_offset": {
+                    "type": "integer",
+                    "description": "Wochen-Offset (0 = aktuelle, -1 = letzte)",
+                },
+            },
+            "required": [],
+        },
+    },
+    {
+        "name": "search_conversations",
+        "description": (
+            "Durchsucht fruehere Chat-Konversationen nach Stichworten. "
+            "Nutze dieses Tool wenn der User sich auf etwas bezieht, "
+            "das in einem frueheren Gespraech besprochen wurde."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Suchbegriff(e)",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max. Ergebnisse (Standard: 5)",
+                },
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "get_plan_change_log",
+        "description": (
+            "Laedt die Aenderungshistorie des Trainingsplans: "
+            "was wurde wann geaendert und warum. "
+            "Nutze dieses Tool fuer Fragen wie 'Warum wurde mein Plan geaendert?'."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "period": {
+                    "type": "string",
+                    "description": "Zeitraum: 1w, 2w, 4w, 3m",
+                    "enum": ["1w", "2w", "4w", "3m"],
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max. Ergebnisse (Standard: 20)",
+                },
+            },
+            "required": [],
+        },
+    },
+]

--- a/frontend/src/api/chat.ts
+++ b/frontend/src/api/chat.ts
@@ -43,10 +43,11 @@ export interface ConversationListResponse {
 }
 
 export interface StreamEvent {
-  type: 'start' | 'token' | 'done' | 'error';
+  type: 'start' | 'token' | 'done' | 'error' | 'tool_call';
   conversation_id?: number;
   content?: string;
   message?: string;
+  name?: string;
 }
 
 // --- API Functions ---

--- a/frontend/src/components/chat/ChatMessageBubble.tsx
+++ b/frontend/src/components/chat/ChatMessageBubble.tsx
@@ -2,7 +2,7 @@ import type { ComponentPropsWithoutRef } from 'react';
 import { Link } from 'react-router-dom';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { Bot, User } from 'lucide-react';
+import { Bot, Search, User } from 'lucide-react';
 
 function TypingDots() {
   return (
@@ -17,6 +17,20 @@ function TypingDots() {
           }}
         />
       ))}
+    </div>
+  );
+}
+
+function ToolIndicator({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-2 text-xs text-[var(--color-text-muted)]">
+      <Search
+        className="w-3 h-3 motion-reduce:animate-none"
+        style={{
+          animation: 'typing-dot 1.4s ease-in-out infinite',
+        }}
+      />
+      <span>{label}...</span>
     </div>
   );
 }
@@ -40,11 +54,17 @@ interface ChatMessageBubbleProps {
   role: 'user' | 'assistant';
   content: string;
   timestamp?: string;
+  toolStatus?: string | null;
 }
 
-export function ChatMessageBubble({ role, content, timestamp }: ChatMessageBubbleProps) {
+export function ChatMessageBubble({
+  role,
+  content,
+  timestamp,
+  toolStatus,
+}: ChatMessageBubbleProps) {
   const isUser = role === 'user';
-  const isWaiting = !isUser && content === '';
+  const isWaiting = !isUser && content === '' && !toolStatus;
 
   return (
     <div className={`flex gap-3 ${isUser ? 'flex-row-reverse' : 'flex-row'}`}>
@@ -66,11 +86,16 @@ export function ChatMessageBubble({ role, content, timestamp }: ChatMessageBubbl
       >
         {isWaiting ? (
           <TypingDots />
+        ) : toolStatus && !content ? (
+          <ToolIndicator label={toolStatus} />
         ) : (
-          <div className="chat-markdown">
-            <Markdown remarkPlugins={[remarkGfm]} components={{ a: ChatLink }}>
-              {content}
-            </Markdown>
+          <div className="space-y-2">
+            {toolStatus && <ToolIndicator label={toolStatus} />}
+            <div className="chat-markdown">
+              <Markdown remarkPlugins={[remarkGfm]} components={{ a: ChatLink }}>
+                {content}
+              </Markdown>
+            </div>
           </div>
         )}
         {timestamp && (

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -17,6 +17,20 @@ function replaceStreamingId(msgs: ChatMessageDetail[], newId: number): ChatMessa
   return msgs.map((m) => (m.id === STREAMING_MSG_ID ? { ...m, id: newId } : m));
 }
 
+const TOOL_LABELS: Record<string, string> = {
+  get_session_details: 'Lade Session-Details',
+  search_sessions: 'Suche Sessions',
+  get_training_stats: 'Berechne Statistiken',
+  get_plan_details: 'Lade Trainingsplan',
+  get_plan_compliance: 'Prüfe Soll/Ist',
+  get_personal_records: 'Lade Bestleistungen',
+  get_exercises: 'Durchsuche Übungen',
+  get_ai_recommendations: 'Lade Empfehlungen',
+  get_weekly_review: 'Lade Wochenrückblick',
+  search_conversations: 'Durchsuche Gespräche',
+  get_plan_change_log: 'Lade Planänderungen',
+};
+
 interface UseChatReturn {
   messages: ChatMessageDetail[];
   conversations: ConversationSummary[];
@@ -24,6 +38,7 @@ interface UseChatReturn {
   sending: boolean;
   loading: boolean;
   error: string | null;
+  toolStatus: string | null;
   sendMessage: (text: string) => Promise<void>;
   cancelStream: () => void;
   selectConversation: (id: number) => Promise<void>;
@@ -40,6 +55,7 @@ export function useChat(): UseChatReturn {
   const [sending, setSending] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [toolStatus, setToolStatus] = useState<string | null>(null);
   const idRef = useRef(0);
   const abortRef = useRef<AbortController | null>(null);
 
@@ -82,16 +98,21 @@ export function useChat(): UseChatReturn {
       if (event.type === 'start' && event.conversation_id) {
         setActiveConversationId(event.conversation_id);
       } else if (event.type === 'token' && event.content) {
+        setToolStatus(null);
         setMessages((prev) =>
           prev.map((m) =>
             m.id === STREAMING_MSG_ID ? { ...m, content: m.content + event.content } : m,
           ),
         );
+      } else if (event.type === 'tool_call' && event.name) {
+        setToolStatus(TOOL_LABELS[event.name] ?? event.name);
       } else if (event.type === 'done') {
+        setToolStatus(null);
         idRef.current -= 1;
         setMessages((prev) => replaceStreamingId(prev, idRef.current));
         void loadConversations();
       } else if (event.type === 'error') {
+        setToolStatus(null);
         setError(event.message ?? 'Streaming-Fehler');
         setMessages((prev) => prev.filter((m) => m.id !== STREAMING_MSG_ID));
       }
@@ -161,6 +182,7 @@ export function useChat(): UseChatReturn {
     sending,
     loading,
     error,
+    toolStatus,
     sendMessage,
     cancelStream,
     selectConversation,

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -34,6 +34,7 @@ interface ChatAreaProps {
   loading: boolean;
   sending: boolean;
   error: string | null;
+  toolStatus: string | null;
   onSend: (text: string) => void;
   onCancel: () => void;
   sidebarOpen: boolean;
@@ -44,6 +45,7 @@ function ChatArea({
   loading,
   sending,
   error,
+  toolStatus,
   onSend,
   onCancel,
   sidebarOpen,
@@ -67,12 +69,13 @@ function ChatArea({
               </div>
             )}
             {!loading && messages.length === 0 && <EmptyState onQuickAction={onSend} />}
-            {messages.map((msg) => (
+            {messages.map((msg, idx) => (
               <ChatMessageBubble
                 key={msg.id}
                 role={msg.role}
                 content={msg.content}
                 timestamp={msg.created_at}
+                toolStatus={idx === messages.length - 1 && sending ? toolStatus : null}
               />
             ))}
             {error && (
@@ -97,6 +100,7 @@ export function ChatPage() {
     sending,
     loading,
     error,
+    toolStatus,
     sendMessage,
     cancelStream,
     selectConversation,
@@ -173,6 +177,7 @@ export function ChatPage() {
           loading={loading}
           sending={sending}
           error={error}
+          toolStatus={toolStatus}
           onSend={handleSend}
           onCancel={cancelStream}
           sidebarOpen={sidebarOpen}


### PR DESCRIPTION
## Summary
- KI-Chat nutzt jetzt Claude Tool Use um Trainingsdaten on-demand nachzuladen
- 11 Tools implementiert: Session-Details, Suche, Statistiken, Plandetails, Soll/Ist, Bestleistungen, Übungen, KI-Empfehlungen, Wochenrückblick, Konversationssuche, Planänderungen
- Frontend zeigt Tool-Call-Status an (z.B. "🔍 Lade Session-Details...")

## Test plan
- [ ] Chat öffnen, Frage stellen die Tool braucht ("Wie waren meine Splits gestern?")
- [ ] Tool-Indikator erscheint in der Bubble
- [ ] Antwort enthält konkrete Daten aus der Session
- [ ] Einfache Fragen (ohne Tool) funktionieren weiterhin
- [ ] Streaming funktioniert mit und ohne Tool-Calls
- [ ] Abbrechen während Tool-Call funktioniert

🤖 Generated with [Claude Code](https://claude.com/claude-code)