### PR TITLE
fix: Plan-Erstellung ohne Auto-Archiv, Draft-Status, neutrale Karte (#388)

### DIFF
--- a/backend/app/services/chat_tool_handlers.py
+++ b/backend/app/services/chat_tool_handlers.py
@@ -8,7 +8,7 @@ import json
 import logging
 from datetime import date, datetime, timedelta
 
-from sqlalchemy import delete, func, or_, select, update
+from sqlalchemy import delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.infrastructure.database.models import (
@@ -745,13 +745,6 @@ async def handle_generate_training_plan(args: dict, db: AsyncSession) -> dict:
     race_date = _parse_date_safe(race_date_str)
     goal_id = await _create_race_goal(db, goal_text, race_date)
 
-    # Bisherige aktive Pläne auf "archived" setzen
-    await db.execute(
-        update(TrainingPlanModel)
-        .where(TrainingPlanModel.status == "active")
-        .values(status="archived")
-    )
-
     rest_days = [0, 6]
     plan = await _create_plan_model(
         db,
@@ -793,9 +786,11 @@ async def handle_generate_training_plan(args: dict, db: AsyncSession) -> dict:
     db.add(changelog)
     await db.commit()
 
+    plan_status = str(plan.status)
     plan_data = {
         "plan_id": plan.id,
         "plan_name": goal_text,
+        "status": plan_status,
         "weeks": weeks,
         "weeks_generated": weeks_generated,
         "phases": phases_created,
@@ -806,11 +801,17 @@ async def handle_generate_training_plan(args: dict, db: AsyncSession) -> dict:
 
     plan_block = f"```plan-created\n{json.dumps(plan_data)}\n```"
 
+    draft_hint = (
+        " Der Plan wurde als Entwurf erstellt, da bereits ein aktiver Plan existiert. "
+        "Weise den User darauf hin, dass er den Plan unter Plandetails aktivieren kann."
+        if plan_status == "draft"
+        else ""
+    )
+
     return {
         **plan_data,
-        "status": "active",
         "instruction": (
-            "Der Plan wurde erfolgreich erstellt und ist sofort aktiv. "
+            f"Der Plan wurde erfolgreich erstellt (Status: {plan_status}).{draft_hint} "
             "Fasse den Plan kurz zusammen (Wochen, Phasen, Zeitraum). "
             "Bette dann GENAU diesen Block in deine Antwort ein, damit "
             "der User direkt zum Plan navigieren kann:\n\n"
@@ -859,7 +860,30 @@ async def _create_plan_model(
     rest_days: list[int],
     today: date,
 ) -> TrainingPlanModel:
-    """Erstellt das TrainingPlan-Modell in der DB."""
+    """Erstellt das TrainingPlan-Modell in der DB.
+
+    Abgelaufene aktive Pläne werden auf "completed" gesetzt.
+    Status wird nur auf "active" gesetzt wenn kein anderer aktiver Plan existiert,
+    sonst "draft".
+    """
+    # Abgelaufene aktive Pläne automatisch auf "completed" setzen
+    from sqlalchemy import update
+
+    await db.execute(
+        update(TrainingPlanModel)
+        .where(
+            TrainingPlanModel.status == "active",
+            TrainingPlanModel.end_date < today,
+        )
+        .values(status="completed")
+    )
+
+    active_count = await db.execute(
+        select(func.count(TrainingPlanModel.id)).where(TrainingPlanModel.status == "active")
+    )
+    has_active = (active_count.scalar() or 0) > 0
+    status = "draft" if has_active else "active"
+
     plan = TrainingPlanModel(
         name=goal_text,
         description=f"Generiert per KI-Chat am {today.strftime('%d.%m.%Y')}",
@@ -868,7 +892,7 @@ async def _create_plan_model(
         end_date=end_date,
         target_event_date=race_date,
         weekly_structure_json=json.dumps({"rest_days": rest_days}),
-        status="active",
+        status=status,
     )
     db.add(plan)
     await db.flush()

--- a/frontend/src/components/chat/PlanCreatedCard.tsx
+++ b/frontend/src/components/chat/PlanCreatedCard.tsx
@@ -1,10 +1,11 @@
 import { Link } from 'react-router-dom';
-import { CalendarCheck, ChevronRight } from 'lucide-react';
+import { CalendarPlus, ChevronRight } from 'lucide-react';
 import { Button } from '@nordlig/components';
 
 export interface PlanCreatedInfo {
   plan_id: number;
   plan_name: string;
+  status?: string;
   weeks: number;
   weeks_generated: number;
   phases: number;
@@ -30,16 +31,25 @@ function formatDate(dateStr: string): string {
 }
 
 export function PlanCreatedCard({ plan }: PlanCreatedCardProps) {
+  const isDraft = plan.status === 'draft';
+
   return (
-    <div className="my-2 rounded-[var(--radius-md)] border border-[var(--color-border-success)] bg-[var(--color-bg-success-subtle)] p-4 space-y-3">
+    <div className="my-2 rounded-[var(--radius-md)] border border-[var(--color-border-default)] bg-[var(--color-bg-base)] p-4 space-y-3">
       <div className="flex items-center gap-2">
-        <div className="w-8 h-8 rounded-full bg-[var(--color-bg-success-subtle)] flex items-center justify-center">
-          <CalendarCheck className="w-4 h-4 text-[var(--color-text-success)]" />
+        <div className="w-8 h-8 rounded-full bg-[var(--color-bg-primary-subtle)] flex items-center justify-center">
+          <CalendarPlus className="w-4 h-4 text-[var(--color-text-primary)]" />
         </div>
         <div>
-          <p className="text-sm font-semibold text-[var(--color-text-base)]">
-            Trainingsplan erstellt
-          </p>
+          <div className="flex items-center gap-2">
+            <p className="text-sm font-semibold text-[var(--color-text-base)]">
+              Trainingsplan erstellt
+            </p>
+            {isDraft && (
+              <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-[var(--color-bg-warning-subtle)] text-[var(--color-text-warning)]">
+                Entwurf
+              </span>
+            )}
+          </div>
           <p className="text-xs text-[var(--color-text-muted)]">{plan.plan_name}</p>
         </div>
       </div>
@@ -68,17 +78,19 @@ export function PlanCreatedCard({ plan }: PlanCreatedCardProps) {
       </div>
 
       <div className="flex gap-2 pt-1">
-        <Link to="/plan">
+        <Link to={`/plan/programs/${plan.plan_id}`}>
           <Button variant="primary" size="sm" className="!text-xs !px-3 !py-1.5 !min-h-0">
-            Zum Wochenplan
+            {isDraft ? 'Plan ansehen' : 'Zum Wochenplan'}
             <ChevronRight className="w-3 h-3 ml-1" />
           </Button>
         </Link>
-        <Link to={`/plan/programs/${plan.plan_id}`}>
-          <Button variant="ghost" size="sm" className="!text-xs !px-3 !py-1.5 !min-h-0">
-            Plandetails
-          </Button>
-        </Link>
+        {!isDraft && (
+          <Link to="/plan">
+            <Button variant="ghost" size="sm" className="!text-xs !px-3 !py-1.5 !min-h-0">
+              Wochenplan
+            </Button>
+          </Link>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- **Kein Auto-Archiv**: Bestehende Pläne bleiben unverändert bei Neuerstellung
- **Draft-Status**: Neuer Plan als "draft" wenn bereits ein aktiver Plan existiert
- **Auto-Completion**: Abgelaufene aktive Pläne werden auf "completed" gesetzt
- **Neutrale Karte**: PlanCreatedCard in neutralen Farben (kein grüner Success-Alert)
- **Draft-Badge**: Gelbes Warning-Badge bei Entwurf, kontextabhängige Buttons

## Test plan
- [ ] Plan erstellen ohne aktiven Plan → Status "active"
- [ ] Plan erstellen mit aktivem Plan → Status "draft" mit Badge
- [ ] Bestehende Pläne bleiben unverändert
- [ ] Karte zeigt neutrale Farben

🤖 Generated with [Claude Code](https://claude.com/claude-code)