### PR TITLE
fix: Enrichment-Guard prüft Segment-Anzahl statt has_explicit_run_details

### DIFF
--- a/backend/app/services/plan_generator.py
+++ b/backend/app/services/plan_generator.py
@@ -433,8 +433,8 @@ def _enrich_sessions_for_week(
         for sess in entry.sessions:
             if sess.training_type != "running" or not sess.run_details:
                 continue
-            # Nur Sessions ohne explizite Segment-Daten anreichern
-            if _has_explicit_run_details(sess.run_details):
+            # Sessions mit bereits strukturierten Segmenten (>1) überspringen
+            if sess.run_details.segments and len(sess.run_details.segments) > 1:
                 continue
             rt = sess.run_details.run_type
             if rt == "easy":


### PR DESCRIPTION
## Summary
- Der Enrichment-Guard in `plan_generator.py` blockierte **alle** Sessions, weil nach der Volume-Distribution jede Session bereits `target_duration_minutes` und `target_pace` hatte
- Fix: Guard prüft jetzt `len(segments) > 1` statt `_has_explicit_run_details()` — nur Sessions mit bereits multi-segmentierten RunDetails werden übersprungen
- Damit greifen die Enrichment-Funktionen (Intervalle, Tempo, Easy+Extras) korrekt

## Test plan
- [x] Pytest 773 tests passed
- [x] Ruff + Mypy bestanden
- [ ] Nach Deploy: Neuen Plan im Chat erstellen und prüfen, dass Sessions strukturierte Segmente haben

🤖 Generated with [Claude Code](https://claude.com/claude-code)