### PR TITLE
fix: Übungen löschen — Soft-Delete für Default-Übungen

### DIFF
--- a/backend/alembic/versions/c040_add_exercise_is_hidden.py
+++ b/backend/alembic/versions/c040_add_exercise_is_hidden.py
@@ -1,0 +1,28 @@
+"""Add is_hidden column to exercises for soft-delete of default exercises.
+
+When users delete a seeded default exercise, it is marked as hidden
+instead of hard-deleted, so the seed function won't re-create it.
+
+Revision ID: c040
+Revises: c039
+Create Date: 2026-03-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "c040"
+down_revision = "c039"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "exercises",
+        sa.Column("is_hidden", sa.Boolean(), server_default="false", nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("exercises", "is_hidden")

--- a/backend/app/api/v1/exercise_library.py
+++ b/backend/app/api/v1/exercise_library.py
@@ -605,7 +605,7 @@ async def list_exercises(
     """Liste aller Übungen mit Filtern."""
     await _ensure_seed_data(db)
 
-    query = select(ExerciseModel)
+    query = select(ExerciseModel).where(ExerciseModel.is_hidden.is_(False))
 
     if category and category in VALID_CATEGORIES:
         query = query.where(ExerciseModel.category == category)
@@ -703,7 +703,12 @@ async def get_exercise(
     db: AsyncSession = Depends(get_db),
 ) -> ExerciseResponse:
     """Einzelne Übung mit allen Details."""
-    result = await db.execute(select(ExerciseModel).where(ExerciseModel.id == exercise_id))
+    result = await db.execute(
+        select(ExerciseModel).where(
+            ExerciseModel.id == exercise_id,
+            ExerciseModel.is_hidden.is_(False),
+        )
+    )
     exercise = result.scalar_one_or_none()
     if not exercise:
         raise HTTPException(status_code=404, detail="Übung nicht gefunden.")
@@ -834,13 +839,21 @@ async def delete_exercise(
     exercise_id: int,
     db: AsyncSession = Depends(get_db),
 ) -> None:
-    """Löscht eine Übung aus der Bibliothek."""
+    """Löscht eine Übung aus der Bibliothek.
+
+    Custom-Übungen werden hart gelöscht.
+    Default-Übungen werden soft-deleted (is_hidden=True), damit das Seeding
+    sie nicht sofort wieder erstellt.
+    """
     result = await db.execute(select(ExerciseModel).where(ExerciseModel.id == exercise_id))
     exercise = result.scalar_one_or_none()
     if not exercise:
         raise HTTPException(status_code=404, detail="Übung nicht gefunden.")
 
-    await db.delete(exercise)
+    if exercise.is_custom:
+        await db.delete(exercise)
+    else:
+        exercise.is_hidden = True
     await db.commit()
 
 

--- a/backend/app/infrastructure/database/models.py
+++ b/backend/app/infrastructure/database/models.py
@@ -120,6 +120,7 @@ class ExerciseModel(Base):
     category: Mapped[str] = mapped_column(String(20))
     is_favorite: Mapped[bool] = mapped_column(default=False, server_default="false")
     is_custom: Mapped[bool] = mapped_column(default=True, server_default="true")
+    is_hidden: Mapped[bool] = mapped_column(default=False, server_default="false")
     usage_count: Mapped[int] = mapped_column(default=0, server_default="0")
     last_used_at: Mapped[datetime | None] = mapped_column(DateTime, default=None)
 

--- a/backend/app/tests/test_exercise_library.py
+++ b/backend/app/tests/test_exercise_library.py
@@ -168,15 +168,21 @@ class TestExerciseLibraryAPI:
         list_response = await client.get("/api/v1/exercises?search=To Delete")
         assert list_response.json()["total"] == 0
 
-    async def test_delete_default_exercise_succeeds(self, client: AsyncClient) -> None:
-        """Deleting any exercise (including default) succeeds."""
+    async def test_delete_default_exercise_soft_deletes(self, client: AsyncClient) -> None:
+        """Deleting a default exercise soft-deletes it (is_hidden=True)."""
         # Seed
         await client.get("/api/v1/exercises")
         list_response = await client.get("/api/v1/exercises")
         default_ex = next(ex for ex in list_response.json()["exercises"] if not ex["is_custom"])
+        name = default_ex["name"]
 
         response = await client.delete(f"/api/v1/exercises/{default_ex['id']}")
         assert response.status_code == 204
+
+        # Should no longer appear in list (even after re-seeding)
+        list_after = await client.get(f"/api/v1/exercises?search={name}")
+        names = [ex["name"] for ex in list_after.json()["exercises"]]
+        assert name not in names
 
     async def test_exercise_not_found(self, client: AsyncClient) -> None:
         """Operations on non-existent exercise return 404."""


### PR DESCRIPTION
## Summary
- Default-Übungen (Steigerungslauf 80m etc.) wurden nach dem Löschen sofort wieder durch `_ensure_seed_data` neu erstellt
- Jetzt: Default-Übungen werden per `is_hidden=True` soft-deleted → Seeding erstellt sie nicht neu
- Custom-Übungen werden weiterhin hart gelöscht
- Neues DB-Feld `is_hidden` mit Migration `c040`
- List/Get-Endpoints filtern hidden Übungen aus

## Test plan
- [x] Backend-Tests bestanden (773 Tests)
- [ ] Default-Übung löschen → bleibt nach Seitenwechsel/Neuladen gelöscht
- [ ] Custom-Übung löschen → funktioniert wie bisher
- [ ] Neue Default-Übungen werden beim Seed korrekt erstellt

🤖 Generated with [Claude Code](https://claude.com/claude-code)