### PR TITLE
feat: Laktatschwellen-Test Datenmodell, API & Friel-Zonen

### DIFF
--- a/backend/alembic/versions/c041_add_threshold_tests.py
+++ b/backend/alembic/versions/c041_add_threshold_tests.py
@@ -1,0 +1,45 @@
+"""Add threshold_tests table for lactate threshold field tests.
+
+Stores results from 30-min Friel tests (LTHR, max HR, pace)
+with optional reference to imported workout session.
+
+Revision ID: c041
+Revises: c040
+Create Date: 2026-03-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "c041"
+down_revision = "c040"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "threshold_tests",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("test_date", sa.Date(), nullable=False),
+        sa.Column("lthr", sa.Integer(), nullable=False),
+        sa.Column("max_hr_measured", sa.Integer(), nullable=True),
+        sa.Column("avg_pace_sec", sa.Float(), nullable=True),
+        sa.Column(
+            "session_id",
+            sa.Integer(),
+            sa.ForeignKey("workouts.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("threshold_tests")

--- a/backend/app/api/v1/athlete.py
+++ b/backend/app/api/v1/athlete.py
@@ -4,10 +4,10 @@ from fastapi import APIRouter, Depends
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.infrastructure.database.models import AthleteModel
+from app.infrastructure.database.models import AthleteModel, ThresholdTestModel
 from app.infrastructure.database.session import get_db
 from app.models.athlete import AthleteSettingsRequest, AthleteSettingsResponse
-from app.services.hr_zone_calculator import calculate_karvonen_zones
+from app.services.hr_zone_calculator import calculate_friel_zones, calculate_karvonen_zones
 
 router = APIRouter(prefix="/athlete", tags=["athlete"])
 
@@ -24,19 +24,40 @@ async def _get_or_create_athlete(db: AsyncSession) -> AthleteModel:
     return athlete
 
 
+async def _get_latest_lthr(db: AsyncSession) -> int | None:
+    """Holt die LTHR aus dem neuesten Schwellentest."""
+    result = await db.execute(
+        select(ThresholdTestModel.lthr).order_by(ThresholdTestModel.test_date.desc()).limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+async def _build_settings_response(
+    athlete: AthleteModel, db: AsyncSession
+) -> AthleteSettingsResponse:
+    """Erstellt AthleteSettingsResponse mit Zonen (Friel bevorzugt)."""
+    karvonen_zones = None
+    if athlete.resting_hr and athlete.max_hr:
+        karvonen_zones = calculate_karvonen_zones(athlete.resting_hr, athlete.max_hr)
+
+    lthr = await _get_latest_lthr(db)
+    friel_zones = calculate_friel_zones(lthr) if lthr else None
+
+    return AthleteSettingsResponse.from_db(
+        athlete,
+        zones=karvonen_zones,
+        lthr=lthr,
+        friel_zones=friel_zones,
+    )
+
+
 @router.get("/settings", response_model=AthleteSettingsResponse)
 async def get_settings(
     db: AsyncSession = Depends(get_db),
 ) -> AthleteSettingsResponse:
-    """Gibt aktuelle Athleten-Einstellungen zurueck."""
+    """Gibt aktuelle Athleten-Einstellungen zurück."""
     athlete = await _get_or_create_athlete(db)
-    zones = None
-    if athlete.resting_hr and athlete.max_hr:
-        zones = calculate_karvonen_zones(
-            athlete.resting_hr,
-            athlete.max_hr,
-        )
-    return AthleteSettingsResponse.from_db(athlete, zones)
+    return await _build_settings_response(athlete, db)
 
 
 @router.put("/settings", response_model=AthleteSettingsResponse)
@@ -58,11 +79,4 @@ async def update_settings(
 
     await db.commit()
     await db.refresh(athlete)
-
-    zones = None
-    if athlete.resting_hr and athlete.max_hr:
-        zones = calculate_karvonen_zones(
-            athlete.resting_hr,
-            athlete.max_hr,
-        )
-    return AthleteSettingsResponse.from_db(athlete, zones)
+    return await _build_settings_response(athlete, db)

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -11,6 +11,7 @@ from app.api.v1 import (
     sessions,
     streak,
     strength,
+    threshold_tests,
     training_balance,
     training_plans,
     trends,
@@ -27,6 +28,7 @@ api_router.include_router(workouts.router, tags=["workouts"])
 api_router.include_router(strength.router, tags=["strength"])
 api_router.include_router(sessions.router, tags=["sessions"])
 api_router.include_router(athlete.router, tags=["athlete"])
+api_router.include_router(threshold_tests.router, tags=["threshold-tests"])
 api_router.include_router(goals.router, tags=["goals"])
 api_router.include_router(ai.router, tags=["ai"])
 api_router.include_router(ai_log.router, tags=["ai-log"])

--- a/backend/app/api/v1/threshold_tests.py
+++ b/backend/app/api/v1/threshold_tests.py
@@ -1,0 +1,93 @@
+"""Laktatschwellen-Test API Endpoints."""
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.athlete import _get_or_create_athlete
+from app.infrastructure.database.models import ThresholdTestModel
+from app.infrastructure.database.session import get_db
+from app.models.threshold_test import (
+    ThresholdTestCreate,
+    ThresholdTestListResponse,
+    ThresholdTestResponse,
+)
+from app.services.hr_zone_calculator import calculate_friel_zones
+
+router = APIRouter(prefix="/threshold-tests", tags=["threshold-tests"])
+
+
+def _build_response(test: ThresholdTestModel) -> ThresholdTestResponse:
+    """Erstellt ThresholdTestResponse inkl. Friel-Zonen."""
+    zones = calculate_friel_zones(test.lthr)
+    return ThresholdTestResponse.from_db(test, friel_zones=zones)
+
+
+@router.get("", response_model=ThresholdTestListResponse)
+async def list_tests(
+    db: AsyncSession = Depends(get_db),
+) -> ThresholdTestListResponse:
+    """Gibt alle Schwellentests zurück (neueste zuerst)."""
+    result = await db.execute(
+        select(ThresholdTestModel).order_by(ThresholdTestModel.test_date.desc())
+    )
+    tests = result.scalars().all()
+    return ThresholdTestListResponse(
+        tests=[_build_response(t) for t in tests],
+        total=len(tests),
+    )
+
+
+@router.get("/latest", response_model=ThresholdTestResponse)
+async def get_latest_test(
+    db: AsyncSession = Depends(get_db),
+) -> ThresholdTestResponse:
+    """Gibt den neuesten Schwellentest zurück."""
+    result = await db.execute(
+        select(ThresholdTestModel).order_by(ThresholdTestModel.test_date.desc()).limit(1)
+    )
+    test = result.scalar_one_or_none()
+    if not test:
+        raise HTTPException(status_code=404, detail="Kein Schwellentest vorhanden")
+    return _build_response(test)
+
+
+@router.post("", response_model=ThresholdTestResponse, status_code=201)
+async def create_test(
+    body: ThresholdTestCreate,
+    db: AsyncSession = Depends(get_db),
+) -> ThresholdTestResponse:
+    """Erstellt einen neuen Schwellentest und aktualisiert das Athletenprofil."""
+    test = ThresholdTestModel(
+        test_date=body.test_date,
+        lthr=body.lthr,
+        max_hr_measured=body.max_hr_measured,
+        avg_pace_sec=body.avg_pace_sec,
+        session_id=body.session_id,
+        notes=body.notes,
+    )
+    db.add(test)
+
+    # Max-HR im Athletenprofil aktualisieren wenn höher als bisheriger Wert
+    if body.max_hr_measured:
+        athlete = await _get_or_create_athlete(db)
+        if athlete.max_hr is None or body.max_hr_measured > athlete.max_hr:
+            athlete.max_hr = body.max_hr_measured
+
+    await db.commit()
+    await db.refresh(test)
+    return _build_response(test)
+
+
+@router.delete("/{test_id}", status_code=204)
+async def delete_test(
+    test_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Löscht einen Schwellentest."""
+    result = await db.execute(select(ThresholdTestModel).where(ThresholdTestModel.id == test_id))
+    test = result.scalar_one_or_none()
+    if not test:
+        raise HTTPException(status_code=404, detail="Schwellentest nicht gefunden")
+    await db.delete(test)
+    await db.commit()

--- a/backend/app/infrastructure/database/models.py
+++ b/backend/app/infrastructure/database/models.py
@@ -112,6 +112,29 @@ class AthleteModel(Base):
     )
 
 
+class ThresholdTestModel(Base):
+    """Ergebnis eines Laktatschwellen-Feldtests (z.B. 30-Min-Friel-Test)."""
+
+    __tablename__ = "threshold_tests"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    test_date: Mapped[date] = mapped_column(Date, nullable=False)
+
+    # Kern-Ergebnisse
+    lthr: Mapped[int] = mapped_column(nullable=False)  # Laktatschwellen-HF (bpm)
+    max_hr_measured: Mapped[int | None] = mapped_column(default=None)  # Gemessene Max-HF
+    avg_pace_sec: Mapped[float | None] = mapped_column(Float, default=None)  # Ø Pace (sec/km)
+
+    # Optionale Referenz zur importierten Session
+    session_id: Mapped[int | None] = mapped_column(
+        ForeignKey("workouts.id", ondelete="SET NULL"), default=None
+    )
+
+    notes: Mapped[str | None] = mapped_column(Text, default=None)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
 class ExerciseModel(Base):
     __tablename__ = "exercises"
 

--- a/backend/app/models/athlete.py
+++ b/backend/app/models/athlete.py
@@ -32,11 +32,29 @@ class AthleteSettingsResponse(BaseModel):
     elevation_gain_factor: float = 10.0
     elevation_loss_factor: float = 5.0
     karvonen_zones: Optional[list[dict]] = None
+    lthr: Optional[int] = None
+    zone_method: str = "none"  # "friel" | "karvonen" | "none"
+    hr_zones: Optional[list[dict]] = None  # Aktive Zonen (Friel oder Karvonen)
 
     @classmethod
     def from_db(
-        cls, model: AthleteModel, zones: Optional[list[dict]] = None
+        cls,
+        model: AthleteModel,
+        zones: Optional[list[dict]] = None,
+        lthr: Optional[int] = None,
+        friel_zones: Optional[list[dict]] = None,
     ) -> AthleteSettingsResponse:
+        # Bestimme aktive Zonen und Methode
+        if friel_zones:
+            zone_method = "friel"
+            active_zones = friel_zones
+        elif zones:
+            zone_method = "karvonen"
+            active_zones = zones
+        else:
+            zone_method = "none"
+            active_zones = None
+
         return cls(
             id=model.id,
             resting_hr=model.resting_hr if model.resting_hr else None,
@@ -48,4 +66,7 @@ class AthleteSettingsResponse(BaseModel):
             if model.elevation_loss_factor
             else 5.0,
             karvonen_zones=zones,
+            lthr=lthr,
+            zone_method=zone_method,
+            hr_zones=active_zones,
         )

--- a/backend/app/models/threshold_test.py
+++ b/backend/app/models/threshold_test.py
@@ -1,0 +1,63 @@
+"""Pydantic Schemas für Laktatschwellen-Tests."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import TYPE_CHECKING, Optional
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from app.infrastructure.database.models import ThresholdTestModel
+
+
+class ThresholdTestCreate(BaseModel):
+    """Request zum Anlegen eines Schwellentests."""
+
+    test_date: date = Field(..., description="Datum des Tests")
+    lthr: int = Field(..., ge=100, le=220, description="Laktatschwellen-HF (bpm)")
+    max_hr_measured: Optional[int] = Field(
+        None, ge=120, le=230, description="Gemessene Max-HF (bpm)"
+    )
+    avg_pace_sec: Optional[float] = Field(None, ge=120, le=900, description="Ø Pace in sec/km")
+    session_id: Optional[int] = Field(None, description="Referenz zur importierten Session")
+    notes: Optional[str] = Field(None, max_length=500, description="Notizen zum Test")
+
+
+class ThresholdTestResponse(BaseModel):
+    """Response für einen einzelnen Schwellentest."""
+
+    id: int
+    test_date: date
+    lthr: int
+    max_hr_measured: Optional[int] = None
+    avg_pace_sec: Optional[float] = None
+    session_id: Optional[int] = None
+    notes: Optional[str] = None
+    created_at: datetime
+    friel_zones: Optional[list[dict]] = None
+
+    @classmethod
+    def from_db(
+        cls,
+        model: ThresholdTestModel,
+        friel_zones: Optional[list[dict]] = None,
+    ) -> ThresholdTestResponse:
+        return cls(
+            id=model.id,
+            test_date=model.test_date,
+            lthr=model.lthr,
+            max_hr_measured=model.max_hr_measured,
+            avg_pace_sec=model.avg_pace_sec,
+            session_id=model.session_id,
+            notes=model.notes,
+            created_at=model.created_at,
+            friel_zones=friel_zones,
+        )
+
+
+class ThresholdTestListResponse(BaseModel):
+    """Response für die Testhistorie."""
+
+    tests: list[ThresholdTestResponse]
+    total: int

--- a/backend/app/services/hr_zone_calculator.py
+++ b/backend/app/services/hr_zone_calculator.py
@@ -1,12 +1,16 @@
-"""HR Zone Calculator mit Karvonen-Formel."""
+"""HR Zone Calculator — Karvonen- und Friel-Modell.
+
+Karvonen: Zonen basierend auf Herzfrequenzreserve (HRR = Max-HR - Ruhe-HR).
+Friel: Zonen basierend auf Laktatschwellen-HR (LTHR) aus dem 30-Min-Test.
+"""
 
 from dataclasses import dataclass
 from typing import Optional
 
 
 @dataclass(frozen=True)
-class KarvonenZoneDef:
-    """Definition einer Karvonen-Zone."""
+class HRZoneDef:
+    """Definition einer HR-Zone (fuer Karvonen und Friel)."""
 
     zone: int
     name: str
@@ -16,13 +20,26 @@ class KarvonenZoneDef:
 
 
 # Karvonen 5-Zone Intensitaeten (% der Herzfrequenzreserve)
-KARVONEN_ZONES: list[KarvonenZoneDef] = [
-    KarvonenZoneDef(1, "Recovery", 0.50, 0.60, "#94a3b8"),
-    KarvonenZoneDef(2, "Base", 0.60, 0.70, "#10b981"),
-    KarvonenZoneDef(3, "Tempo", 0.70, 0.80, "#f59e0b"),
-    KarvonenZoneDef(4, "Threshold", 0.80, 0.90, "#f97316"),
-    KarvonenZoneDef(5, "VO2max", 0.90, 1.00, "#ef4444"),
+KARVONEN_ZONES: list[HRZoneDef] = [
+    HRZoneDef(1, "Recovery", 0.50, 0.60, "#94a3b8"),
+    HRZoneDef(2, "Base", 0.60, 0.70, "#10b981"),
+    HRZoneDef(3, "Tempo", 0.70, 0.80, "#f59e0b"),
+    HRZoneDef(4, "Threshold", 0.80, 0.90, "#f97316"),
+    HRZoneDef(5, "VO2max", 0.90, 1.00, "#ef4444"),
 ]
+
+# Friel 5-Zone Intensitaeten (% der Laktatschwellen-HR)
+# Basiert auf Joe Friel, The Triathlete's Training Bible
+FRIEL_ZONES: list[HRZoneDef] = [
+    HRZoneDef(1, "Recovery", 0.00, 0.85, "#94a3b8"),
+    HRZoneDef(2, "Aerobic", 0.85, 0.90, "#10b981"),
+    HRZoneDef(3, "Tempo", 0.90, 0.95, "#f59e0b"),
+    HRZoneDef(4, "Sub-Threshold", 0.95, 1.00, "#f97316"),
+    HRZoneDef(5, "Supra-Threshold", 1.00, 1.06, "#ef4444"),
+]
+
+# Compat alias fuer bestehenden Import in test_hr_zones.py
+KarvonenZoneDef = HRZoneDef
 
 
 def karvonen_bpm(resting_hr: int, max_hr: int, intensity: float) -> int:
@@ -50,73 +67,98 @@ def calculate_karvonen_zones(resting_hr: int, max_hr: int) -> list[dict]:
     return zones
 
 
+def calculate_friel_zones(lthr: int) -> list[dict]:
+    """Berechnet 5-Zonen Grenzen via Friel-Modell (% der LTHR)."""
+    zones = []
+    for z in FRIEL_ZONES:
+        lower = round(lthr * z.pct_min) if z.pct_min > 0 else 0
+        upper = round(lthr * z.pct_max)
+        zones.append(
+            {
+                "zone": z.zone,
+                "name": z.name,
+                "lower_bpm": lower,
+                "upper_bpm": upper,
+                "color": z.color,
+                "pct_min": z.pct_min,
+                "pct_max": z.pct_max,
+            }
+        )
+    return zones
+
+
+def _distribute_hr_across_zones(hr_values: list[int], zones: list[dict]) -> dict:
+    """Verteilt HR-Werte auf definierte Zonen und berechnet Anteile."""
+    total = len(hr_values)
+    counts = [0] * len(zones)
+
+    for hr in hr_values:
+        for i, z in enumerate(zones):
+            if i == len(zones) - 1:
+                if hr >= z["lower_bpm"]:
+                    counts[i] += 1
+                    break
+            elif z["lower_bpm"] <= hr < z["upper_bpm"]:
+                counts[i] += 1
+                break
+        else:
+            counts[0] += 1
+
+    result = {}
+    for i, z in enumerate(zones):
+        key = f"zone_{z['zone']}_{z['name'].lower().replace('-', '_')}"
+        result[key] = {
+            "seconds": counts[i],
+            "percentage": round(counts[i] / total * 100, 1) if total > 0 else 0,
+            "label": f"{z['lower_bpm']}-{z['upper_bpm']} bpm",
+            "zone": z["zone"],
+            "name": z["name"],
+            "color": z["color"],
+        }
+    return result
+
+
+def _fallback_3zone(hr_values: list[int]) -> dict:
+    """3-Zonen Fallback ohne Athleten-Daten."""
+    total = len(hr_values)
+    zone1 = sum(1 for hr in hr_values if hr < 150)
+    zone2 = sum(1 for hr in hr_values if 150 <= hr < 160)
+    zone3 = sum(1 for hr in hr_values if hr >= 160)
+
+    return {
+        "zone_1_recovery": {
+            "seconds": zone1,
+            "percentage": round(zone1 / total * 100, 1) if total > 0 else 0,
+            "label": "< 150 bpm",
+        },
+        "zone_2_base": {
+            "seconds": zone2,
+            "percentage": round(zone2 / total * 100, 1) if total > 0 else 0,
+            "label": "150-160 bpm",
+        },
+        "zone_3_tempo": {
+            "seconds": zone3,
+            "percentage": round(zone3 / total * 100, 1) if total > 0 else 0,
+            "label": "> 160 bpm",
+        },
+    }
+
+
 def calculate_zone_distribution(
     hr_values: list[int],
     resting_hr: Optional[int] = None,
     max_hr: Optional[int] = None,
+    lthr: Optional[int] = None,
 ) -> dict:
     """Berechnet Zeit in jeder Zone.
 
-    Wenn resting_hr und max_hr gesetzt: 5-Zonen Karvonen.
-    Sonst: 3-Zonen Fallback.
+    Prioritaet: LTHR (Friel) > Karvonen > 3-Zonen Fallback.
     """
     if not hr_values:
         return {}
 
-    use_karvonen = resting_hr is not None and max_hr is not None
-    total = len(hr_values)
-
-    if use_karvonen:
-        assert resting_hr is not None and max_hr is not None
-        zones = calculate_karvonen_zones(resting_hr, max_hr)
-        counts = [0] * len(zones)
-
-        for hr in hr_values:
-            for i, z in enumerate(zones):
-                if i == len(zones) - 1:
-                    # Letzte Zone: alles ab lower_bpm
-                    if hr >= z["lower_bpm"]:
-                        counts[i] += 1
-                        break
-                elif z["lower_bpm"] <= hr < z["upper_bpm"]:
-                    counts[i] += 1
-                    break
-            else:
-                # HR unter Zone 1 → zaehle zu Zone 1
-                counts[0] += 1
-
-        result = {}
-        for i, z in enumerate(zones):
-            key = f"zone_{z['zone']}_{z['name'].lower()}"
-            result[key] = {
-                "seconds": counts[i],
-                "percentage": round(counts[i] / total * 100, 1) if total > 0 else 0,
-                "label": f"{z['lower_bpm']}-{z['upper_bpm']} bpm",
-                "zone": z["zone"],
-                "name": z["name"],
-                "color": z["color"],
-            }
-        return result
-    else:
-        # 3-Zone Fallback
-        zone1 = sum(1 for hr in hr_values if hr < 150)
-        zone2 = sum(1 for hr in hr_values if 150 <= hr < 160)
-        zone3 = sum(1 for hr in hr_values if hr >= 160)
-
-        return {
-            "zone_1_recovery": {
-                "seconds": zone1,
-                "percentage": round(zone1 / total * 100, 1) if total > 0 else 0,
-                "label": "< 150 bpm",
-            },
-            "zone_2_base": {
-                "seconds": zone2,
-                "percentage": round(zone2 / total * 100, 1) if total > 0 else 0,
-                "label": "150-160 bpm",
-            },
-            "zone_3_tempo": {
-                "seconds": zone3,
-                "percentage": round(zone3 / total * 100, 1) if total > 0 else 0,
-                "label": "> 160 bpm",
-            },
-        }
+    if lthr is not None:
+        return _distribute_hr_across_zones(hr_values, calculate_friel_zones(lthr))
+    if resting_hr is not None and max_hr is not None:
+        return _distribute_hr_across_zones(hr_values, calculate_karvonen_zones(resting_hr, max_hr))
+    return _fallback_3zone(hr_values)

--- a/backend/app/tests/test_threshold_tests.py
+++ b/backend/app/tests/test_threshold_tests.py
@@ -1,0 +1,238 @@
+"""Tests für Laktatschwellen-Test API."""
+
+import pytest
+from httpx import AsyncClient
+
+from app.services.hr_zone_calculator import calculate_friel_zones
+
+# --- Unit Tests: Friel-Zonenberechnung ---
+
+
+def test_friel_zones_count() -> None:
+    """Friel berechnet 5 Zonen."""
+    zones = calculate_friel_zones(170)
+    assert len(zones) == 5
+
+
+def test_friel_zones_boundaries() -> None:
+    """Friel-Zonen haben korrekte LTHR-basierte Grenzen."""
+    lthr = 170
+    zones = calculate_friel_zones(lthr)
+
+    # Zone 1 Recovery: 0-85% LTHR
+    assert zones[0]["zone"] == 1
+    assert zones[0]["name"] == "Recovery"
+    assert zones[0]["lower_bpm"] == 0
+    assert zones[0]["upper_bpm"] == round(170 * 0.85)  # 145
+
+    # Zone 4 Sub-Threshold: 95-100% LTHR
+    assert zones[3]["zone"] == 4
+    assert zones[3]["lower_bpm"] == round(170 * 0.95)  # 162
+    assert zones[3]["upper_bpm"] == 170  # 100% LTHR
+
+    # Zone 5 Supra-Threshold: 100-106% LTHR
+    assert zones[4]["zone"] == 5
+    assert zones[4]["lower_bpm"] == 170  # 100% LTHR
+    assert zones[4]["upper_bpm"] == round(170 * 1.06)  # 180
+
+
+def test_friel_zones_have_colors() -> None:
+    """Jede Friel-Zone hat eine Farbe."""
+    zones = calculate_friel_zones(165)
+    for z in zones:
+        assert z["color"].startswith("#")
+
+
+def test_friel_zone_distribution() -> None:
+    """Zonenverteilung mit LTHR bevorzugt Friel-Modell."""
+    from app.services.hr_zone_calculator import calculate_zone_distribution
+
+    hr_values = [130, 145, 155, 165, 175]
+    result = calculate_zone_distribution(hr_values, lthr=170)
+    assert len(result) == 5
+    # Friel-Zonennamen statt Karvonen
+    assert "zone_1_recovery" in result
+    assert "zone_2_aerobic" in result
+    assert "zone_3_tempo" in result
+    assert "zone_4_sub_threshold" in result
+    assert "zone_5_supra_threshold" in result
+
+
+def test_friel_takes_precedence_over_karvonen() -> None:
+    """LTHR hat Vorrang vor Karvonen wenn beides vorhanden."""
+    from app.services.hr_zone_calculator import calculate_zone_distribution
+
+    hr_values = [130, 145, 155, 165, 175]
+    # Beide Parameter gesetzt — Friel soll gewinnen
+    result = calculate_zone_distribution(hr_values, resting_hr=50, max_hr=190, lthr=170)
+    assert "zone_2_aerobic" in result  # Friel-Name, nicht "base"
+
+
+# --- Integration Tests: Threshold Test API ---
+
+
+class TestThresholdTestAPI:
+    """Integration tests for threshold test endpoints."""
+
+    async def test_list_empty(self, client: AsyncClient) -> None:
+        """GET /threshold-tests gibt leere Liste wenn keine Tests."""
+        response = await client.get("/api/v1/threshold-tests")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 0
+        assert data["tests"] == []
+
+    async def test_latest_not_found(self, client: AsyncClient) -> None:
+        """GET /threshold-tests/latest gibt 404 ohne Tests."""
+        response = await client.get("/api/v1/threshold-tests/latest")
+        assert response.status_code == 404
+
+    async def test_create_test(self, client: AsyncClient) -> None:
+        """POST /threshold-tests erstellt einen Test mit Friel-Zonen."""
+        response = await client.post(
+            "/api/v1/threshold-tests",
+            json={
+                "test_date": "2026-03-15",
+                "lthr": 170,
+                "max_hr_measured": 192,
+                "avg_pace_sec": 300.0,
+                "notes": "Friel 30-Min-Test auf Bahn",
+            },
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["lthr"] == 170
+        assert data["max_hr_measured"] == 192
+        assert data["avg_pace_sec"] == 300.0
+        assert data["notes"] == "Friel 30-Min-Test auf Bahn"
+        assert len(data["friel_zones"]) == 5
+
+    async def test_create_updates_athlete_max_hr(self, client: AsyncClient) -> None:
+        """Test mit höherer Max-HR aktualisiert Athletenprofil."""
+        # Athlete mit max_hr=185
+        await client.put(
+            "/api/v1/athlete/settings",
+            json={"max_hr": 185, "resting_hr": 50},
+        )
+
+        # Test mit max_hr=192 → soll Athlete aktualisieren
+        await client.post(
+            "/api/v1/threshold-tests",
+            json={"test_date": "2026-03-16", "lthr": 170, "max_hr_measured": 192},
+        )
+
+        settings = await client.get("/api/v1/athlete/settings")
+        assert settings.json()["max_hr"] == 192
+
+    async def test_create_does_not_lower_max_hr(self, client: AsyncClient) -> None:
+        """Test mit niedrigerer Max-HR ändert Athletenprofil nicht."""
+        await client.put(
+            "/api/v1/athlete/settings",
+            json={"max_hr": 195, "resting_hr": 50},
+        )
+
+        await client.post(
+            "/api/v1/threshold-tests",
+            json={"test_date": "2026-03-17", "lthr": 168, "max_hr_measured": 188},
+        )
+
+        settings = await client.get("/api/v1/athlete/settings")
+        assert settings.json()["max_hr"] == 195
+
+    async def test_list_returns_chronological(self, client: AsyncClient) -> None:
+        """Tests werden neueste zuerst zurückgegeben."""
+        await client.post(
+            "/api/v1/threshold-tests",
+            json={"test_date": "2026-01-15", "lthr": 165},
+        )
+        await client.post(
+            "/api/v1/threshold-tests",
+            json={"test_date": "2026-03-15", "lthr": 170},
+        )
+
+        response = await client.get("/api/v1/threshold-tests")
+        data = response.json()
+        assert data["total"] == 2
+        assert data["tests"][0]["lthr"] == 170  # neuester zuerst
+        assert data["tests"][1]["lthr"] == 165
+
+    async def test_latest_returns_most_recent(self, client: AsyncClient) -> None:
+        """GET /latest gibt den neuesten Test."""
+        await client.post(
+            "/api/v1/threshold-tests",
+            json={"test_date": "2026-01-15", "lthr": 165},
+        )
+        await client.post(
+            "/api/v1/threshold-tests",
+            json={"test_date": "2026-03-15", "lthr": 170},
+        )
+
+        response = await client.get("/api/v1/threshold-tests/latest")
+        assert response.status_code == 200
+        assert response.json()["lthr"] == 170
+
+    async def test_delete_test(self, client: AsyncClient) -> None:
+        """DELETE /threshold-tests/{id} löscht den Test."""
+        create_resp = await client.post(
+            "/api/v1/threshold-tests",
+            json={"test_date": "2026-03-15", "lthr": 170},
+        )
+        test_id = create_resp.json()["id"]
+
+        response = await client.delete(f"/api/v1/threshold-tests/{test_id}")
+        assert response.status_code == 204
+
+        # Verify deleted
+        list_resp = await client.get("/api/v1/threshold-tests")
+        assert list_resp.json()["total"] == 0
+
+    async def test_delete_not_found(self, client: AsyncClient) -> None:
+        """DELETE auf nicht-existenten Test gibt 404."""
+        response = await client.delete("/api/v1/threshold-tests/99999")
+        assert response.status_code == 404
+
+    async def test_athlete_settings_show_lthr(self, client: AsyncClient) -> None:
+        """Athlete-Settings zeigen LTHR und Friel-Zonen nach Test."""
+        await client.put(
+            "/api/v1/athlete/settings",
+            json={"resting_hr": 50, "max_hr": 190},
+        )
+        await client.post(
+            "/api/v1/threshold-tests",
+            json={"test_date": "2026-03-15", "lthr": 170},
+        )
+
+        response = await client.get("/api/v1/athlete/settings")
+        data = response.json()
+        assert data["lthr"] == 170
+        assert data["zone_method"] == "friel"
+        assert data["hr_zones"] is not None
+        assert len(data["hr_zones"]) == 5
+        # Karvonen-Zonen bleiben auch verfügbar
+        assert data["karvonen_zones"] is not None
+
+    async def test_athlete_settings_without_test_uses_karvonen(self, client: AsyncClient) -> None:
+        """Ohne Test nutzt Athlete-Settings Karvonen-Zonen."""
+        await client.put(
+            "/api/v1/athlete/settings",
+            json={"resting_hr": 50, "max_hr": 190},
+        )
+
+        response = await client.get("/api/v1/athlete/settings")
+        data = response.json()
+        assert data["lthr"] is None
+        assert data["zone_method"] == "karvonen"
+        assert data["hr_zones"] is not None
+
+    @pytest.mark.parametrize(
+        "lthr",
+        [99, 221],
+        ids=["too_low", "too_high"],
+    )
+    async def test_create_validates_lthr_range(self, client: AsyncClient, lthr: int) -> None:
+        """LTHR außerhalb 100-220 wird abgelehnt."""
+        response = await client.post(
+            "/api/v1/threshold-tests",
+            json={"test_date": "2026-03-15", "lthr": lthr},
+        )
+        assert response.status_code == 422


### PR DESCRIPTION
## Summary
- Neues `ThresholdTestModel` für Schwellentests (30-Min-Friel-Test)
- API: `POST/GET/DELETE /api/v1/threshold-tests` + `/latest`
- Friel 5-Zonen-Berechnung aus LTHR (% der Laktatschwellen-HR)
- Athlete-Settings erweitert: `lthr`, `zone_method` (friel/karvonen/none), `hr_zones`
- Zonenberechnung priorisiert automatisch: LTHR (Friel) > Karvonen > 3-Zonen-Fallback
- Max-HR aus Test wird automatisch ins Athletenprofil übernommen (wenn höher)

Fixes #443

## Test plan
- [x] Ruff + Mypy bestehen
- [x] 791 Backend-Tests grün (18 neue Tests)
- [x] Unit: Friel-Zonenberechnung (Grenzen, Farben, Vorrang vor Karvonen)
- [x] Integration: CRUD Threshold-Tests, Athlete-Settings mit LTHR
- [ ] Manuell: POST threshold-test → GET athlete/settings zeigt Friel-Zonen

🤖 Generated with [Claude Code](https://claude.com/claude-code)