### PR TITLE
feat: Schwellentest-Flow — Session-Analyse & ThresholdTestCard UI

### DIFF
--- a/backend/app/api/v1/threshold_tests.py
+++ b/backend/app/api/v1/threshold_tests.py
@@ -1,18 +1,28 @@
 """Laktatschwellen-Test API Endpoints."""
 
+import json
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.v1.athlete import _get_or_create_athlete
-from app.infrastructure.database.models import ThresholdTestModel
+from app.infrastructure.database.models import ThresholdTestModel, WorkoutModel
 from app.infrastructure.database.session import get_db
 from app.models.threshold_test import (
+    ThresholdAnalysisResponse,
     ThresholdTestCreate,
     ThresholdTestListResponse,
     ThresholdTestResponse,
 )
 from app.services.hr_zone_calculator import calculate_friel_zones
+
+logger = logging.getLogger(__name__)
+
+# Friel-Test: Ø HR der letzten 20 Min eines 30-Min-Maximaltests
+_ANALYSIS_WINDOW_SEC = 20 * 60  # 1200 Sekunden
+_MIN_SESSION_DURATION_SEC = 25 * 60  # Mindestens 25 Min Session
 
 router = APIRouter(prefix="/threshold-tests", tags=["threshold-tests"])
 
@@ -77,6 +87,87 @@ async def create_test(
     await db.commit()
     await db.refresh(test)
     return _build_response(test)
+
+
+@router.get("/analyze/{session_id}", response_model=ThresholdAnalysisResponse)
+async def analyze_session(
+    session_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> ThresholdAnalysisResponse:
+    """Berechnet LTHR aus einer Session (Ø HR der letzten 20 Min).
+
+    Basiert auf dem 30-Min-Friel-Test: Der Athlet läuft 30 Min maximal,
+    die Durchschnitts-HR der letzten 20 Min entspricht der LTHR.
+    """
+    result = await db.execute(select(WorkoutModel).where(WorkoutModel.id == session_id))
+    workout = result.scalar_one_or_none()
+    if not workout:
+        raise HTTPException(status_code=404, detail="Session nicht gefunden")
+
+    # HR-Werte extrahieren (per-Sekunde)
+    hr_values = _extract_hr_from_workout(workout)
+    if not hr_values:
+        raise HTTPException(status_code=400, detail="Keine HR-Daten in dieser Session vorhanden")
+
+    total_seconds = len(hr_values)
+    if total_seconds < _MIN_SESSION_DURATION_SEC:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Session zu kurz ({total_seconds // 60} Min). Mindestens 25 Min erforderlich.",
+        )
+
+    # Letzte 20 Min für LTHR-Berechnung
+    analysis_window = hr_values[-_ANALYSIS_WINDOW_SEC:]
+    lthr = round(sum(analysis_window) / len(analysis_window))
+    max_hr = max(hr_values)
+
+    # Pace aus Session extrahieren (wenn vorhanden)
+    avg_pace_sec = _extract_avg_pace(workout)
+
+    duration_minutes = round(total_seconds / 60.0, 1)
+    friel_zones = calculate_friel_zones(lthr)
+
+    return ThresholdAnalysisResponse(
+        session_id=session_id,
+        session_date=workout.date,
+        duration_minutes=duration_minutes,
+        lthr=lthr,
+        max_hr_measured=max_hr,
+        avg_pace_sec=avg_pace_sec,
+        friel_zones=friel_zones,
+        hr_sample_count=len(analysis_window),
+    )
+
+
+def _extract_hr_from_workout(workout: WorkoutModel) -> list[int]:
+    """Extrahiert per-Sekunde HR-Werte aus einer Session."""
+    # 1. GPS Track (beste Qualität — per-Sekunde)
+    if workout.gps_track_json:
+        track = json.loads(str(workout.gps_track_json))
+        points = track.get("points", [])
+        hr_values = [int(p["hr"]) for p in points if p.get("hr") is not None]
+        if hr_values:
+            return hr_values
+
+    # 2. HR Timeseries (FIT ohne GPS)
+    if workout.hr_timeseries_json:
+        ts = json.loads(str(workout.hr_timeseries_json))
+        hr_values = [int(p["hr_bpm"]) for p in ts if p.get("hr_bpm")]
+        if hr_values:
+            return hr_values
+
+    return []
+
+
+def _extract_avg_pace(workout: WorkoutModel) -> float | None:
+    """Extrahiert Durchschnittspace aus Session-Daten."""
+    if workout.gps_track_json:
+        track = json.loads(str(workout.gps_track_json))
+        total_dist = track.get("total_distance_km")
+        total_time = track.get("total_duration_sec")
+        if total_dist and total_time and total_dist > 0:
+            return round(total_time / total_dist, 1)
+    return None
 
 
 @router.delete("/{test_id}", status_code=204)

--- a/backend/app/models/threshold_test.py
+++ b/backend/app/models/threshold_test.py
@@ -61,3 +61,16 @@ class ThresholdTestListResponse(BaseModel):
 
     tests: list[ThresholdTestResponse]
     total: int
+
+
+class ThresholdAnalysisResponse(BaseModel):
+    """Ergebnis der automatischen LTHR-Berechnung aus einer Session."""
+
+    session_id: int
+    session_date: date
+    duration_minutes: float
+    lthr: int = Field(description="Berechnete LTHR (Ø HR der letzten 20 Min)")
+    max_hr_measured: int = Field(description="Höchste gemessene HR")
+    avg_pace_sec: Optional[float] = Field(None, description="Ø Pace in sec/km")
+    friel_zones: list[dict]
+    hr_sample_count: int = Field(description="Anzahl HR-Datenpunkte in der Analyse")

--- a/frontend/src/api/athlete.ts
+++ b/frontend/src/api/athlete.ts
@@ -17,6 +17,9 @@ export interface AthleteSettings {
   elevation_gain_factor: number;
   elevation_loss_factor: number;
   karvonen_zones: KarvonenZone[] | null;
+  lthr: number | null;
+  zone_method: 'friel' | 'karvonen' | 'none';
+  hr_zones: KarvonenZone[] | null;
 }
 
 export async function getAthleteSettings(): Promise<AthleteSettings> {

--- a/frontend/src/api/threshold-tests.ts
+++ b/frontend/src/api/threshold-tests.ts
@@ -1,0 +1,65 @@
+import { apiClient } from './client';
+import type { KarvonenZone } from './athlete';
+
+export interface ThresholdTest {
+  id: number;
+  test_date: string;
+  lthr: number;
+  max_hr_measured: number | null;
+  avg_pace_sec: number | null;
+  session_id: number | null;
+  notes: string | null;
+  created_at: string;
+  friel_zones: KarvonenZone[] | null;
+}
+
+export interface ThresholdTestListResponse {
+  tests: ThresholdTest[];
+  total: number;
+}
+
+export interface ThresholdAnalysis {
+  session_id: number;
+  session_date: string;
+  duration_minutes: number;
+  lthr: number;
+  max_hr_measured: number;
+  avg_pace_sec: number | null;
+  friel_zones: KarvonenZone[];
+  hr_sample_count: number;
+}
+
+export interface ThresholdTestCreate {
+  test_date: string;
+  lthr: number;
+  max_hr_measured?: number | null;
+  avg_pace_sec?: number | null;
+  session_id?: number | null;
+  notes?: string | null;
+}
+
+export async function listThresholdTests(): Promise<ThresholdTestListResponse> {
+  const response = await apiClient.get<ThresholdTestListResponse>('/api/v1/threshold-tests');
+  return response.data;
+}
+
+export async function getLatestThresholdTest(): Promise<ThresholdTest> {
+  const response = await apiClient.get<ThresholdTest>('/api/v1/threshold-tests/latest');
+  return response.data;
+}
+
+export async function analyzeSession(sessionId: number): Promise<ThresholdAnalysis> {
+  const response = await apiClient.get<ThresholdAnalysis>(
+    `/api/v1/threshold-tests/analyze/${sessionId}`,
+  );
+  return response.data;
+}
+
+export async function createThresholdTest(data: ThresholdTestCreate): Promise<ThresholdTest> {
+  const response = await apiClient.post<ThresholdTest>('/api/v1/threshold-tests', data);
+  return response.data;
+}
+
+export async function deleteThresholdTest(testId: number): Promise<void> {
+  await apiClient.delete(`/api/v1/threshold-tests/${testId}`);
+}

--- a/frontend/src/components/threshold-test/ThresholdTestCard.tsx
+++ b/frontend/src/components/threshold-test/ThresholdTestCard.tsx
@@ -1,0 +1,314 @@
+import { useState, useEffect } from 'react';
+import {
+  Card,
+  CardHeader,
+  CardBody,
+  Button,
+  Input,
+  Label,
+  Alert,
+  AlertDescription,
+  Spinner,
+  useToast,
+} from '@nordlig/components';
+import { Activity, Plus } from 'lucide-react';
+import {
+  listThresholdTests,
+  createThresholdTest,
+  type ThresholdTest,
+  type ThresholdTestCreate,
+} from '@/api/threshold-tests';
+import type { KarvonenZone } from '@/api/athlete';
+
+// --- Sub-Components ---
+
+function ZoneRow({ zone }: { zone: KarvonenZone }) {
+  return (
+    <div
+      className="flex items-center justify-between py-1.5 px-3 rounded-[var(--radius-component-sm)]"
+      style={{ backgroundColor: `${zone.color}15` }}
+    >
+      <div className="flex items-center gap-2">
+        <div
+          className="w-2.5 h-2.5 rounded-full shrink-0"
+          style={{ backgroundColor: zone.color }}
+        />
+        <span className="text-xs font-medium text-[var(--color-text-base)]">
+          Zone {zone.zone}: {zone.name}
+        </span>
+      </div>
+      <span className="text-xs text-[var(--color-text-muted)]">
+        {zone.lower_bpm}–{zone.upper_bpm} bpm
+      </span>
+    </div>
+  );
+}
+
+function TestHistoryItem({ test }: { test: ThresholdTest }) {
+  const dateStr = new Date(test.test_date).toLocaleDateString('de-DE', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+  return (
+    <div className="flex items-center justify-between py-2 border-b border-[var(--color-border-default)] last:border-b-0">
+      <div>
+        <span className="text-sm font-medium text-[var(--color-text-base)]">{dateStr}</span>
+        {test.notes && (
+          <p className="text-xs text-[var(--color-text-muted)] mt-0.5">{test.notes}</p>
+        )}
+      </div>
+      <div className="text-right">
+        <span className="text-sm font-semibold text-[var(--color-text-primary)]">
+          {test.lthr} bpm
+        </span>
+        {test.max_hr_measured && (
+          <p className="text-xs text-[var(--color-text-muted)]">Max: {test.max_hr_measured} bpm</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface ManualEntryFormProps {
+  onSave: (data: ThresholdTestCreate) => Promise<void>;
+  saving: boolean;
+}
+
+function ManualEntryForm({ onSave, saving }: ManualEntryFormProps) {
+  const [lthr, setLthr] = useState('');
+  const [maxHr, setMaxHr] = useState('');
+  const [notes, setNotes] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    const lthrVal = parseInt(lthr, 10);
+    if (isNaN(lthrVal) || lthrVal < 100 || lthrVal > 220) {
+      setError('LTHR muss zwischen 100 und 220 bpm liegen');
+      return;
+    }
+
+    const maxHrVal = maxHr ? parseInt(maxHr, 10) : null;
+    if (maxHrVal !== null && (maxHrVal < 120 || maxHrVal > 230)) {
+      setError('Max-HF muss zwischen 120 und 230 bpm liegen');
+      return;
+    }
+
+    setError(null);
+    await onSave({
+      test_date: new Date().toISOString().split('T')[0],
+      lthr: lthrVal,
+      max_hr_measured: maxHrVal,
+      notes: notes || null,
+    });
+
+    setLthr('');
+    setMaxHr('');
+    setNotes('');
+  };
+
+  return (
+    <div className="space-y-3 pt-3 border-t border-[var(--color-border-default)]">
+      <h4 className="text-xs font-semibold text-[var(--color-text-base)]">
+        Testergebnis eintragen
+      </h4>
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1">
+          <Label className="text-[10px]">LTHR (bpm) *</Label>
+          <Input
+            type="number"
+            min={100}
+            max={220}
+            placeholder="z.B. 170"
+            value={lthr}
+            onChange={(e) => setLthr(e.target.value)}
+            inputSize="sm"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label className="text-[10px]">Max-HF (bpm)</Label>
+          <Input
+            type="number"
+            min={120}
+            max={230}
+            placeholder="z.B. 192"
+            value={maxHr}
+            onChange={(e) => setMaxHr(e.target.value)}
+            inputSize="sm"
+          />
+        </div>
+      </div>
+      <div className="space-y-1">
+        <Label className="text-[10px]">Notiz</Label>
+        <Input
+          type="text"
+          placeholder="z.B. Bahn, 30-Min-Test"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          inputSize="sm"
+        />
+      </div>
+      {error && (
+        <Alert variant="error" closeable onClose={() => setError(null)}>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+      <Button
+        variant="primary"
+        size="sm"
+        onClick={handleSubmit}
+        disabled={saving || !lthr}
+        className="w-full"
+      >
+        {saving ? <Spinner size="sm" aria-hidden="true" /> : 'Ergebnis speichern'}
+      </Button>
+    </div>
+  );
+}
+
+function TestResultView({ latest, tests }: { latest: ThresholdTest; tests: ThresholdTest[] }) {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-baseline gap-3">
+        <span className="text-3xl font-bold text-[var(--color-text-primary)]">{latest.lthr}</span>
+        <span className="text-sm text-[var(--color-text-muted)]">bpm</span>
+        <span className="text-xs text-[var(--color-text-muted)] ml-auto">
+          {new Date(latest.test_date).toLocaleDateString('de-DE')}
+        </span>
+      </div>
+
+      {latest.friel_zones && (
+        <div className="space-y-1.5">
+          <h3 className="text-xs font-semibold text-[var(--color-text-muted)]">
+            Friel-Zonen (basierend auf LTHR)
+          </h3>
+          {latest.friel_zones.map((z) => (
+            <ZoneRow key={z.zone} zone={z} />
+          ))}
+        </div>
+      )}
+
+      {tests.length > 1 && (
+        <div className="pt-3 border-t border-[var(--color-border-default)]">
+          <h3 className="text-xs font-semibold text-[var(--color-text-muted)] mb-2">
+            Testhistorie
+          </h3>
+          {tests.slice(0, 5).map((t) => (
+            <TestHistoryItem key={t.id} test={t} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EmptyTestState() {
+  return (
+    <div className="text-center py-4">
+      <p className="text-sm text-[var(--color-text-muted)] mb-3">
+        Noch kein Schwellentest durchgeführt.
+      </p>
+      <div className="text-left bg-[var(--color-bg-surface-alt)] rounded-[var(--radius-component-sm)] p-3 space-y-2">
+        <h4 className="text-xs font-semibold text-[var(--color-text-base)]">30-Min-Friel-Test</h4>
+        <ol className="text-xs text-[var(--color-text-muted)] space-y-1 list-decimal list-inside">
+          <li>10 Min locker einlaufen</li>
+          <li>30 Min so schnell wie möglich laufen (gleichmäßig!)</li>
+          <li>Ø HF der letzten 20 Min = deine LTHR</li>
+          <li>Auslaufen</li>
+        </ol>
+        <p className="text-[10px] text-[var(--color-text-muted)] italic">
+          Empfehlung: Alle 6–8 Wochen wiederholen.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// --- Hooks ---
+
+function useThresholdTests() {
+  const { toast } = useToast();
+  const [tests, setTests] = useState<ThresholdTest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    loadTests();
+  }, []);
+
+  const loadTests = async () => {
+    try {
+      const data = await listThresholdTests();
+      setTests(data.tests);
+    } catch {
+      // Stille Fehlerbehandlung — Karte ist optional
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const saveTest = async (data: ThresholdTestCreate) => {
+    setSaving(true);
+    try {
+      await createThresholdTest(data);
+      await loadTests();
+      toast({ title: 'Schwellentest gespeichert', variant: 'success' });
+      return true;
+    } catch {
+      toast({ title: 'Fehler beim Speichern', variant: 'error' });
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return { tests, loading, saving, saveTest };
+}
+
+// --- Main Component ---
+
+export function ThresholdTestCard() {
+  const { tests, loading, saving, saveTest } = useThresholdTests();
+  const [showForm, setShowForm] = useState(false);
+  const latestTest = tests[0] ?? null;
+
+  const handleSave = async (data: ThresholdTestCreate) => {
+    const ok = await saveTest(data);
+    if (ok) setShowForm(false);
+  };
+
+  if (loading) {
+    return (
+      <Card elevation="raised" padding="spacious">
+        <CardBody className="flex justify-center py-8">
+          <Spinner size="sm" />
+        </CardBody>
+      </Card>
+    );
+  }
+
+  return (
+    <Card elevation="raised" padding="spacious">
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Activity className="w-4 h-4 text-[var(--color-text-primary)]" />
+            <h2 className="text-sm font-semibold text-[var(--color-text-base)]">
+              Laktatschwelle (LTHR)
+            </h2>
+          </div>
+          {!showForm && (
+            <Button variant="ghost" size="sm" onClick={() => setShowForm(true)}>
+              <Plus className="w-3.5 h-3.5 mr-1" />
+              Test eintragen
+            </Button>
+          )}
+        </div>
+      </CardHeader>
+      <CardBody>
+        {latestTest ? <TestResultView latest={latestTest} tests={tests} /> : <EmptyTestState />}
+        {showForm && <ManualEntryForm onSave={handleSave} saving={saving} />}
+      </CardBody>
+    </Card>
+  );
+}

--- a/frontend/src/pages/AthleteProfile.tsx
+++ b/frontend/src/pages/AthleteProfile.tsx
@@ -16,6 +16,7 @@ import {
 import { getAthleteSettings, updateAthleteSettings } from '@/api/athlete';
 import { useApiKeySettings } from '@/hooks/useApiKeySettings';
 import { ApiKeyCard } from '@/components/settings/ApiKeyCard';
+import { ThresholdTestCard } from '@/components/threshold-test/ThresholdTestCard';
 
 // Karvonen zone definitions — mirrors backend/app/services/hr_zone_calculator.py
 const KARVONEN_ZONES = [
@@ -259,6 +260,9 @@ export function AthleteProfilePage() {
           </Button>
         </CardFooter>
       </Card>
+
+      {/* Schwellentest / LTHR */}
+      <ThresholdTestCard />
 
       {/* Elevation Correction */}
       <Card elevation="raised" padding="spacious">


### PR DESCRIPTION
## Summary
- **Session-Analyse-Endpoint** (`GET /threshold-tests/analyze/{session_id}`): Berechnet LTHR aus den letzten 20 Min einer Session (Friel 30-Min-Test)
- **ThresholdTestCard** Frontend-Komponente: Zeigt LTHR, Friel-Zonen, Testhistorie, manuelle Eingabe, leerer Zustand mit Testanleitung
- **AthleteSettings** um `lthr`, `zone_method`, `hr_zones` erweitert für automatische Zonen-Priorisierung (Friel > Karvonen > Fallback)

Closes #445

## Test plan
- [ ] Athletenprofil öffnen → ThresholdTestCard wird angezeigt
- [ ] Leerer Zustand: Friel-Test-Anleitung sichtbar
- [ ] Manuellen Schwellentest eintragen → Friel-Zonen werden berechnet
- [ ] Testhistorie: Mehrere Tests eintragen → werden chronologisch angezeigt
- [ ] Session-Analyse: Endpunkt mit gültiger Session testen (≥25 Min, HR-Daten)
- [ ] Validierung: LTHR <100 oder >220 wird abgelehnt
- [ ] Backend-Tests: 791 passed, Frontend: 182 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)