### PR TITLE
feat: Schwellentest-Erinnerungen — Dashboard-Banner & Altersanzeige

### DIFF
--- a/frontend/src/components/threshold-test/ThresholdTestCard.tsx
+++ b/frontend/src/components/threshold-test/ThresholdTestCard.tsx
@@ -166,15 +166,25 @@ function ManualEntryForm({ onSave, saving }: ManualEntryFormProps) {
   );
 }
 
+function calcTestAge(testDate: string): { days: number; label: string; color: string } {
+  const diff = Math.floor((Date.now() - new Date(testDate).getTime()) / (24 * 60 * 60 * 1000));
+  const weeks = Math.floor(diff / 7);
+  const label = weeks < 1 ? `vor ${diff} Tagen` : `vor ${weeks} Wochen`;
+
+  if (diff <= 42) return { days: diff, label, color: 'text-[var(--color-text-success)]' };
+  if (diff <= 56) return { days: diff, label, color: 'text-[var(--color-text-warning)]' };
+  return { days: diff, label, color: 'text-[var(--color-text-error)]' };
+}
+
 function TestResultView({ latest, tests }: { latest: ThresholdTest; tests: ThresholdTest[] }) {
+  const age = calcTestAge(latest.test_date);
+
   return (
     <div className="space-y-4">
       <div className="flex items-baseline gap-3">
         <span className="text-3xl font-bold text-[var(--color-text-primary)]">{latest.lthr}</span>
         <span className="text-sm text-[var(--color-text-muted)]">bpm</span>
-        <span className="text-xs text-[var(--color-text-muted)] ml-auto">
-          {new Date(latest.test_date).toLocaleDateString('de-DE')}
-        </span>
+        <span className={`text-xs ml-auto font-medium ${age.color}`}>{age.label}</span>
       </div>
 
       {latest.friel_zones && (

--- a/frontend/src/components/threshold-test/ThresholdTestReminder.tsx
+++ b/frontend/src/components/threshold-test/ThresholdTestReminder.tsx
@@ -1,0 +1,74 @@
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@nordlig/components';
+import { Activity, X } from 'lucide-react';
+import { useThresholdReminder, type ReminderStatus } from '@/hooks/useThresholdReminder';
+
+const REMINDER_CONFIG: Record<
+  Exclude<ReminderStatus, 'fresh'>,
+  { bg: string; text: string; title: string; message: string }
+> = {
+  never_tested: {
+    bg: 'bg-[var(--color-bg-primary-subtle)]',
+    text: 'text-[var(--color-text-primary)]',
+    title: 'Schwellentest empfohlen',
+    message: 'Führe einen 30-Min-Schwellentest durch, um deine HR-Zonen präzise zu bestimmen.',
+  },
+  due: {
+    bg: 'bg-[var(--color-bg-warning-subtle)]',
+    text: 'text-[var(--color-text-warning)]',
+    title: 'Schwellentest fällig',
+    message: 'Dein letzter Schwellentest liegt über 6 Wochen zurück. Zeit für einen neuen Test!',
+  },
+  overdue: {
+    bg: 'bg-[var(--color-bg-error-subtle)]',
+    text: 'text-[var(--color-text-error)]',
+    title: 'Schwellentest überfällig',
+    message:
+      'Dein letzter Schwellentest liegt über 8 Wochen zurück. Deine HR-Zonen sind wahrscheinlich nicht mehr aktuell.',
+  },
+};
+
+/**
+ * Dashboard-Banner für Schwellentest-Erinnerung.
+ * Zeigt Hinweis wenn kein Test vorhanden oder Test veraltet ist.
+ * Kann für 1 Woche dismissed werden.
+ */
+export function ThresholdTestReminder() {
+  const navigate = useNavigate();
+  const { status, daysSinceTest, loading, dismissed, dismiss } = useThresholdReminder();
+
+  if (loading || dismissed || status === 'fresh') return null;
+
+  const config = REMINDER_CONFIG[status];
+
+  return (
+    <div
+      className={`flex items-start gap-3 rounded-[var(--radius-component-md)] px-4 py-3 ${config.bg}`}
+    >
+      <Activity className={`w-4 h-4 mt-0.5 shrink-0 ${config.text}`} />
+      <div className="flex-1 min-w-0">
+        <p className={`text-sm font-semibold ${config.text}`}>{config.title}</p>
+        <p className="text-xs text-[var(--color-text-muted)] mt-0.5">
+          {config.message}
+          {daysSinceTest !== null && <span className="ml-1">(vor {daysSinceTest} Tagen)</span>}
+        </p>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="mt-2 -ml-2"
+          onClick={() => navigate('/profile')}
+        >
+          Zum Schwellentest →
+        </Button>
+      </div>
+      <button
+        type="button"
+        onClick={dismiss}
+        className="shrink-0 p-1 rounded-[var(--radius-component-sm)] hover:bg-[var(--color-bg-surface-alt)] transition-colors motion-reduce:transition-none"
+        aria-label="Erinnerung ausblenden"
+      >
+        <X className="w-3.5 h-3.5 text-[var(--color-text-muted)]" />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useThresholdReminder.ts
+++ b/frontend/src/hooks/useThresholdReminder.ts
@@ -1,0 +1,76 @@
+import { useState, useEffect, useCallback } from 'react';
+import { getLatestThresholdTest } from '@/api/threshold-tests';
+
+/** Schwellentest gilt als veraltet nach 42 Tagen (6 Wochen). */
+const REMINDER_THRESHOLD_DAYS = 42;
+
+/** Dismiss-TTL: 7 Tage in Millisekunden. */
+const DISMISS_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+const DISMISS_KEY = 'threshold-test-reminder-dismissed';
+
+export type ReminderStatus = 'fresh' | 'due' | 'overdue' | 'never_tested';
+
+export interface ThresholdReminderState {
+  status: ReminderStatus;
+  daysSinceTest: number | null;
+  lastTestDate: string | null;
+  loading: boolean;
+  dismissed: boolean;
+  dismiss: () => void;
+}
+
+function isDismissed(): boolean {
+  const raw = localStorage.getItem(DISMISS_KEY);
+  if (!raw) return false;
+  const dismissedAt = parseInt(raw, 10);
+  if (isNaN(dismissedAt)) return false;
+  return Date.now() - dismissedAt < DISMISS_TTL_MS;
+}
+
+function calcDaysSince(dateStr: string): number {
+  const testDate = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - testDate.getTime();
+  return Math.floor(diffMs / (24 * 60 * 60 * 1000));
+}
+
+function calcStatus(daysSince: number): ReminderStatus {
+  if (daysSince <= REMINDER_THRESHOLD_DAYS) return 'fresh';
+  if (daysSince <= 56) return 'due'; // 6-8 Wochen
+  return 'overdue'; // > 8 Wochen
+}
+
+export function useThresholdReminder(): ThresholdReminderState {
+  const [status, setStatus] = useState<ReminderStatus>('fresh');
+  const [daysSinceTest, setDaysSinceTest] = useState<number | null>(null);
+  const [lastTestDate, setLastTestDate] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [dismissed, setDismissed] = useState(isDismissed);
+
+  useEffect(() => {
+    loadReminderStatus();
+  }, []);
+
+  const loadReminderStatus = async () => {
+    try {
+      const test = await getLatestThresholdTest();
+      const days = calcDaysSince(test.test_date);
+      setDaysSinceTest(days);
+      setLastTestDate(test.test_date);
+      setStatus(calcStatus(days));
+    } catch {
+      // 404 = kein Test vorhanden
+      setStatus('never_tested');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const dismiss = useCallback(() => {
+    localStorage.setItem(DISMISS_KEY, Date.now().toString());
+    setDismissed(true);
+  }, []);
+
+  return { status, daysSinceTest, lastTestDate, loading, dismissed, dismiss };
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -26,6 +26,7 @@ import {
   Dumbbell,
 } from 'lucide-react';
 import { listSessions } from '@/api/training';
+import { ThresholdTestReminder } from '@/components/threshold-test/ThresholdTestReminder';
 import type { SessionSummary } from '@/api/training';
 import { listGoals, getGoalProgress } from '@/api/goals';
 import type { GoalProgress } from '@/api/goals';
@@ -172,6 +173,9 @@ export function DashboardPage() {
           </DropdownMenuContent>
         </DropdownMenu>
       </header>
+
+      {/* Schwellentest-Erinnerung */}
+      <ThresholdTestReminder />
 
       {/* Stat Metrics — same pattern as SessionDetail */}
       <Card elevation="raised">


### PR DESCRIPTION
## Summary
- **Dashboard-Banner** mit 3 Stufen: „empfohlen" (kein Test), „fällig" (>6 Wochen), „überfällig" (>8 Wochen)
- **ThresholdTestCard** zeigt farbcodiertes Alter des letzten Tests (grün/gelb/rot)
- **Dismiss-Logik**: Banner kann für 1 Woche ausgeblendet werden (localStorage)
- Rein client-seitig — kein Backend-Änderung nötig

Closes #447

## Test plan
- [ ] Dashboard ohne Schwellentest → blaues Banner „Schwellentest empfohlen"
- [ ] Dashboard mit Test >6 Wochen alt → gelbes Banner „Schwellentest fällig"
- [ ] Dashboard mit Test >8 Wochen alt → rotes Banner „Schwellentest überfällig"
- [ ] Dashboard mit aktuellem Test (<6 Wochen) → kein Banner
- [ ] Banner dismiss → verschwindet, kommt nach 1 Woche wieder
- [ ] „Zum Schwellentest" Button navigiert zum Athletenprofil
- [ ] ThresholdTestCard: Alter grün/gelb/rot je nach Wochen

🤖 Generated with [Claude Code](https://claude.com/claude-code)