### PR TITLE
fix: ThresholdTestReminder auf Nordlig DS Alert umstellen

### DIFF
--- a/frontend/src/components/threshold-test/ThresholdTestReminder.tsx
+++ b/frontend/src/components/threshold-test/ThresholdTestReminder.tsx
@@ -1,27 +1,26 @@
 import { useNavigate } from 'react-router-dom';
-import { Button } from '@nordlig/components';
-import { Activity, X } from 'lucide-react';
+import { Alert, AlertDescription, Button } from '@nordlig/components';
+import { Activity } from 'lucide-react';
 import { useThresholdReminder, type ReminderStatus } from '@/hooks/useThresholdReminder';
+
+type AlertVariant = 'info' | 'warning' | 'error';
 
 const REMINDER_CONFIG: Record<
   Exclude<ReminderStatus, 'fresh'>,
-  { bg: string; text: string; title: string; message: string }
+  { variant: AlertVariant; title: string; message: string }
 > = {
   never_tested: {
-    bg: 'bg-[var(--color-bg-primary-subtle)]',
-    text: 'text-[var(--color-text-primary)]',
+    variant: 'info',
     title: 'Schwellentest empfohlen',
     message: 'Führe einen 30-Min-Schwellentest durch, um deine HR-Zonen präzise zu bestimmen.',
   },
   due: {
-    bg: 'bg-[var(--color-bg-warning-subtle)]',
-    text: 'text-[var(--color-text-warning)]',
+    variant: 'warning',
     title: 'Schwellentest fällig',
     message: 'Dein letzter Schwellentest liegt über 6 Wochen zurück. Zeit für einen neuen Test!',
   },
   overdue: {
-    bg: 'bg-[var(--color-bg-error-subtle)]',
-    text: 'text-[var(--color-text-error)]',
+    variant: 'error',
     title: 'Schwellentest überfällig',
     message:
       'Dein letzter Schwellentest liegt über 8 Wochen zurück. Deine HR-Zonen sind wahrscheinlich nicht mehr aktuell.',
@@ -42,33 +41,20 @@ export function ThresholdTestReminder() {
   const config = REMINDER_CONFIG[status];
 
   return (
-    <div
-      className={`flex items-start gap-3 rounded-[var(--radius-component-md)] px-4 py-3 ${config.bg}`}
-    >
-      <Activity className={`w-4 h-4 mt-0.5 shrink-0 ${config.text}`} />
-      <div className="flex-1 min-w-0">
-        <p className={`text-sm font-semibold ${config.text}`}>{config.title}</p>
-        <p className="text-xs text-[var(--color-text-muted)] mt-0.5">
-          {config.message}
-          {daysSinceTest !== null && <span className="ml-1">(vor {daysSinceTest} Tagen)</span>}
-        </p>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="mt-2 -ml-2"
-          onClick={() => navigate('/profile')}
-        >
-          Zum Schwellentest →
-        </Button>
-      </div>
-      <button
-        type="button"
-        onClick={dismiss}
-        className="shrink-0 p-1 rounded-[var(--radius-component-sm)] hover:bg-[var(--color-bg-surface-alt)] transition-colors motion-reduce:transition-none"
-        aria-label="Erinnerung ausblenden"
-      >
-        <X className="w-3.5 h-3.5 text-[var(--color-text-muted)]" />
-      </button>
-    </div>
+    <Alert variant={config.variant} closeable onClose={dismiss}>
+      <Activity className="w-4 h-4 shrink-0" />
+      <AlertDescription>
+        <div className="space-y-1.5">
+          <p className="font-semibold">{config.title}</p>
+          <p className="text-xs opacity-80">
+            {config.message}
+            {daysSinceTest !== null && <span className="ml-1">(vor {daysSinceTest} Tagen)</span>}
+          </p>
+          <Button variant="ghost" size="sm" className="-ml-2" onClick={() => navigate('/profile')}>
+            Zum Schwellentest →
+          </Button>
+        </div>
+      </AlertDescription>
+    </Alert>
   );
 }


### PR DESCRIPTION
## Summary
- Custom `<div>` + native `<button>` durch Nordlig `<Alert closeable>` ersetzt
- Varianten (info/warning/error) statt manueller Farbklassen
- Nordlig DS Compliance: keine eigenen Primitives

## Test plan
- [ ] Dashboard: Banner erscheint bei fehlendem/veraltetem Test
- [ ] Dismiss-Button schließt Banner (localStorage, 1 Woche)
- [ ] Varianten: blau (info), gelb (warning), rot (error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)