### PR TITLE
fix(#459): ThresholdTestCard Mobile-Layout & UX-Flow überarbeiten

### DIFF
--- a/frontend/src/components/threshold-test/ThresholdTestCard.tsx
+++ b/frontend/src/components/threshold-test/ThresholdTestCard.tsx
@@ -11,7 +11,7 @@ import {
   Spinner,
   useToast,
 } from '@nordlig/components';
-import { Activity, Plus, TrendingUp, TrendingDown, Minus, Upload, Download } from 'lucide-react';
+import { Activity, TrendingUp, TrendingDown, Minus, Upload, Download } from 'lucide-react';
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
 import {
   listThresholdTests,
@@ -74,12 +74,15 @@ function TestHistoryItem({ test }: { test: ThresholdTest }) {
   );
 }
 
+// --- Manual Entry ---
+
 interface ManualEntryFormProps {
   onSave: (data: ThresholdTestCreate) => Promise<void>;
+  onCancel: () => void;
   saving: boolean;
 }
 
-function ManualEntryForm({ onSave, saving }: ManualEntryFormProps) {
+function ManualEntryForm({ onSave, onCancel, saving }: ManualEntryFormProps) {
   const [lthr, setLthr] = useState('');
   const [maxHr, setMaxHr] = useState('');
   const [notes, setNotes] = useState('');
@@ -112,10 +115,15 @@ function ManualEntryForm({ onSave, saving }: ManualEntryFormProps) {
   };
 
   return (
-    <div className="space-y-3 pt-3 border-t border-[var(--color-border-default)]">
-      <h4 className="text-xs font-semibold text-[var(--color-text-base)]">
-        Testergebnis eintragen
-      </h4>
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h4 className="text-xs font-semibold text-[var(--color-text-base)]">
+          Testergebnis eintragen
+        </h4>
+        <Button variant="ghost" size="sm" onClick={onCancel}>
+          Abbrechen
+        </Button>
+      </div>
       <div className="grid grid-cols-2 gap-3">
         <div className="space-y-1">
           <Label className="text-[10px]">LTHR (bpm) *</Label>
@@ -240,10 +248,11 @@ function AnalysisPreview({
 
 interface FitImportFlowProps {
   onSave: (data: ThresholdTestCreate) => Promise<void>;
+  onCancel: () => void;
   saving: boolean;
 }
 
-function FitImportFlow({ onSave, saving }: FitImportFlowProps) {
+function FitImportFlow({ onSave, onCancel, saving }: FitImportFlowProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [analyzing, setAnalyzing] = useState(false);
   const [analysis, setAnalysis] = useState<ThresholdAnalysis | null>(null);
@@ -282,8 +291,15 @@ function FitImportFlow({ onSave, saving }: FitImportFlowProps) {
   };
 
   return (
-    <div className="space-y-3 pt-3 border-t border-[var(--color-border-default)]">
-      <h4 className="text-xs font-semibold text-[var(--color-text-base)]">FIT-Datei importieren</h4>
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h4 className="text-xs font-semibold text-[var(--color-text-base)]">
+          FIT-Datei importieren
+        </h4>
+        <Button variant="ghost" size="sm" onClick={onCancel}>
+          Abbrechen
+        </Button>
+      </div>
 
       {!analysis && (
         <>
@@ -469,6 +485,27 @@ function LthrTrendChart({ tests }: { tests: ThresholdTest[] }) {
   );
 }
 
+// --- Action Buttons ---
+
+interface ActionButtonsProps {
+  onFitImport: () => void;
+  onManualEntry: () => void;
+}
+
+function ActionButtons({ onFitImport, onManualEntry }: ActionButtonsProps) {
+  return (
+    <div className="grid grid-cols-2 gap-2">
+      <Button variant="secondary" size="sm" onClick={onFitImport} className="w-full">
+        <Upload className="w-3.5 h-3.5 mr-1.5" />
+        FIT importieren
+      </Button>
+      <Button variant="secondary" size="sm" onClick={onManualEntry} className="w-full">
+        Manuell eintragen
+      </Button>
+    </div>
+  );
+}
+
 // --- Result & Empty Views ---
 
 function TestResultView({ latest, tests }: { latest: ThresholdTest; tests: ThresholdTest[] }) {
@@ -477,11 +514,13 @@ function TestResultView({ latest, tests }: { latest: ThresholdTest; tests: Thres
 
   return (
     <div className="space-y-4">
-      <div className="flex items-baseline gap-3">
-        <span className="text-3xl font-bold text-[var(--color-text-primary)]">{latest.lthr}</span>
-        <span className="text-sm text-[var(--color-text-muted)]">bpm</span>
-        {previousTest && <LthrDelta current={latest.lthr} previous={previousTest.lthr} />}
-        <span className={`text-xs ml-auto font-medium ${age.color}`}>{age.label}</span>
+      <div className="flex items-baseline justify-between gap-2 flex-wrap">
+        <div className="flex items-baseline gap-2">
+          <span className="text-3xl font-bold text-[var(--color-text-primary)]">{latest.lthr}</span>
+          <span className="text-sm text-[var(--color-text-muted)]">bpm</span>
+          {previousTest && <LthrDelta current={latest.lthr} previous={previousTest.lthr} />}
+        </div>
+        <span className={`text-xs font-medium ${age.color}`}>{age.label}</span>
       </div>
 
       {latest.friel_zones && (
@@ -513,25 +552,14 @@ function TestResultView({ latest, tests }: { latest: ThresholdTest; tests: Thres
 
 function EmptyTestState() {
   return (
-    <div className="text-center py-4">
-      <p className="text-sm text-[var(--color-text-muted)] mb-3">
+    <div className="space-y-3">
+      <p className="text-sm text-[var(--color-text-muted)] text-center">
         Noch kein Schwellentest durchgeführt.
       </p>
-      <div className="text-left bg-[var(--color-bg-surface-alt)] rounded-[var(--radius-component-sm)] p-3 space-y-2">
-        <h4 className="text-xs font-semibold text-[var(--color-text-base)]">30-Min-Friel-Test</h4>
-        <ol className="text-xs text-[var(--color-text-muted)] space-y-1 list-decimal list-inside">
-          <li>10 Min locker einlaufen</li>
-          <li>30 Min so schnell wie möglich laufen (gleichmäßig!)</li>
-          <li>Ø HF der letzten 20 Min = deine LTHR</li>
-          <li>Auslaufen</li>
-        </ol>
-        <p className="text-[10px] text-[var(--color-text-muted)] italic">
-          Empfehlung: Alle 6–8 Wochen wiederholen.
-        </p>
-      </div>
-      <div className="mt-3">
-        <ProtocolDownloadButton />
-      </div>
+      <p className="text-xs text-[var(--color-text-muted)]">
+        Lauf 30 Min so schnell wie möglich (gleichmäßig). Ø HF der letzten 20 Min = deine LTHR.
+        <span className="italic"> Alle 6–8 Wochen wiederholen.</span>
+      </p>
     </div>
   );
 }
@@ -604,35 +632,41 @@ export function ThresholdTestCard() {
   return (
     <Card elevation="raised" padding="spacious">
       <CardHeader>
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <Activity className="w-4 h-4 text-[var(--color-text-primary)]" />
-            <h2 className="text-sm font-semibold text-[var(--color-text-base)]">
-              Laktatschwelle (LTHR)
-            </h2>
-          </div>
-          {inputMode === 'none' && (
-            <div className="flex items-center gap-1">
-              <Button variant="ghost" size="sm" onClick={() => setInputMode('fit')}>
-                <Upload className="w-3.5 h-3.5 mr-1" />
-                FIT importieren
-              </Button>
-              <Button variant="ghost" size="sm" onClick={() => setInputMode('manual')}>
-                <Plus className="w-3.5 h-3.5 mr-1" />
-                Manuell
-              </Button>
-            </div>
-          )}
+        <div className="flex items-center gap-2">
+          <Activity className="w-4 h-4 text-[var(--color-text-primary)]" />
+          <h2 className="text-sm font-semibold text-[var(--color-text-base)]">
+            Laktatschwelle (LTHR)
+          </h2>
         </div>
       </CardHeader>
-      <CardBody>
+      <CardBody className="space-y-4">
         {latestTest ? <TestResultView latest={latestTest} tests={tests} /> : <EmptyTestState />}
-        {inputMode === 'manual' && <ManualEntryForm onSave={handleSave} saving={saving} />}
-        {inputMode === 'fit' && <FitImportFlow onSave={handleSave} saving={saving} />}
-        {latestTest && inputMode === 'none' && (
-          <div className="pt-3 border-t border-[var(--color-border-default)]">
-            <ProtocolDownloadButton />
-          </div>
+
+        {inputMode === 'none' && (
+          <>
+            <ActionButtons
+              onFitImport={() => setInputMode('fit')}
+              onManualEntry={() => setInputMode('manual')}
+            />
+            <div className="flex justify-center">
+              <ProtocolDownloadButton />
+            </div>
+          </>
+        )}
+
+        {inputMode === 'manual' && (
+          <ManualEntryForm
+            onSave={handleSave}
+            onCancel={() => setInputMode('none')}
+            saving={saving}
+          />
+        )}
+        {inputMode === 'fit' && (
+          <FitImportFlow
+            onSave={handleSave}
+            onCancel={() => setInputMode('none')}
+            saving={saving}
+          />
         )}
       </CardBody>
     </Card>


### PR DESCRIPTION
## Summary
- Header enthält nur noch Titel + Icon — kein Umbruch auf 375px mehr
- Action-Buttons (FIT importieren / Manuell eintragen) als Grid im CardBody statt Header
- Empty State kompakt: ein Satz statt Testprotokoll-Textwall
- Protocol-Download zentriert als sekundäre Aktion
- Abbrechen-Button in FIT-Import und Manual-Entry Flows

## Test plan
- [ ] Mobile (375px): Karte komplett im Viewport, kein Header-Umbruch
- [ ] CTAs sofort sichtbar (above the fold)
- [ ] FIT-Import-Flow: Button → Abbrechen funktioniert
- [ ] Manual-Entry-Flow: Button → Abbrechen funktioniert
- [ ] Desktop: Layout passt sich an
- [ ] Touch-Targets ≥ 44×44px

Closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)