### PR TITLE
feat: KI-Chat FAB im Mobile-Layout (#463)

### DIFF
--- a/frontend/src/components/ChatFAB.tsx
+++ b/frontend/src/components/ChatFAB.tsx
@@ -1,0 +1,20 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+import { MessageCircle } from 'lucide-react';
+
+export function ChatFAB() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  // Auf der Chat-Seite ausblenden
+  if (location.pathname.startsWith('/chat')) return null;
+
+  return (
+    <button
+      onClick={() => navigate('/chat')}
+      aria-label="KI-Chat öffnen"
+      className="fixed right-4 bottom-[calc(62px+env(safe-area-inset-bottom)+var(--spacing-sm))] z-[201] flex h-12 w-12 items-center justify-center rounded-full bg-[var(--color-interactive-primary)] text-[var(--color-text-on-primary)] shadow-[var(--shadow-md)] transition-transform duration-150 active:scale-95 motion-reduce:transition-none lg:hidden"
+    >
+      <MessageCircle className="h-5 w-5" />
+    </button>
+  );
+}

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -16,6 +16,7 @@ import {
   Bot,
 } from 'lucide-react';
 import { getChatNotifications } from '@/api/chat';
+import { ChatFAB } from '@/components/ChatFAB';
 import { BottomNav } from './BottomNav';
 
 interface NavItem {
@@ -205,6 +206,7 @@ export function AppLayout() {
         </div>
       </main>
 
+      <ChatFAB />
       <BottomNav />
     </div>
   );


### PR DESCRIPTION
## Summary
- Floating Action Button (MessageCircle-Icon) unten-rechts über der BottomNav
- Nur auf Mobile sichtbar (`lg:hidden`), auf Desktop gibt es den Sidebar-Eintrag
- Wird auf `/chat` automatisch ausgeblendet
- 48×48px Touch-Target, Nordlig DS Tokens, `motion-reduce:transition-none`

## Test plan
- [ ] Mobile (375px): FAB sichtbar auf Dashboard, Sessions, Analyse, Plan, Profil
- [ ] Mobile: FAB nicht sichtbar auf `/chat`
- [ ] Desktop: FAB nicht sichtbar (Sidebar hat KI-Chat)
- [ ] Klick auf FAB navigiert zu `/chat`

Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)