### PR TITLE
fix: Chat Mobile UX — Viewport-Layout, Sheet-Sidebar, Kontext-Picker (#465)

### DIFF
--- a/frontend/src/components/chat/ChatContextPicker.tsx
+++ b/frontend/src/components/chat/ChatContextPicker.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Pin } from 'lucide-react';
+import { Pin, X } from 'lucide-react';
 import { Button, Input } from '@nordlig/components';
 import type { ChatContext } from './ChatContextBadge';
 
@@ -10,7 +10,7 @@ interface ChatContextPickerProps {
 
 /**
  * Kompakter Kontext-Picker — User kann Session-ID oder Wochendatum eingeben.
- * Wird als Popover-artiges Dropdown über dem Chat-Input angezeigt.
+ * Auf Mobile vertikal gestackt, auf Desktop inline.
  */
 export function ChatContextPicker({ onSelect, disabled }: ChatContextPickerProps) {
   const [open, setOpen] = useState(false);
@@ -46,54 +46,59 @@ export function ChatContextPicker({ onSelect, disabled }: ChatContextPickerProps
   }
 
   return (
-    <div className="flex items-center gap-2 p-2 rounded-[var(--radius-md)] bg-[var(--color-bg-surface)] border border-[var(--color-border-default)]">
-      <div className="flex gap-1">
+    <div className="flex flex-col gap-2 p-2 rounded-[var(--radius-md)] bg-[var(--color-bg-surface)] border border-[var(--color-border-default)]">
+      <div className="flex items-center justify-between">
+        <div className="flex gap-1">
+          <Button
+            variant={mode === 'session' ? 'primary' : 'ghost'}
+            size="sm"
+            onClick={() => setMode('session')}
+            className="!text-xs !px-2 !py-1 !min-h-0"
+          >
+            Session
+          </Button>
+          <Button
+            variant={mode === 'week' ? 'primary' : 'ghost'}
+            size="sm"
+            onClick={() => setMode('week')}
+            className="!text-xs !px-2 !py-1 !min-h-0"
+          >
+            Woche
+          </Button>
+        </div>
         <Button
-          variant={mode === 'session' ? 'primary' : 'ghost'}
+          variant="ghost"
           size="sm"
-          onClick={() => setMode('session')}
-          className="!text-xs !px-2 !py-1 !min-h-0"
+          onClick={() => setOpen(false)}
+          aria-label="Schließen"
+          className="!p-1 !min-h-0 !min-w-0"
         >
-          Session
-        </Button>
-        <Button
-          variant={mode === 'week' ? 'primary' : 'ghost'}
-          size="sm"
-          onClick={() => setMode('week')}
-          className="!text-xs !px-2 !py-1 !min-h-0"
-        >
-          Woche
+          <X className="w-3.5 h-3.5" />
         </Button>
       </div>
-      <Input
-        value={inputValue}
-        onChange={(e) => setInputValue(e.target.value)}
-        placeholder={mode === 'session' ? 'Session-ID (z.B. 42)' : 'Datum (z.B. 2026-03-16)'}
-        inputSize="sm"
-        className="!min-h-[32px] !text-xs w-40"
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') handleSubmit();
-          if (e.key === 'Escape') setOpen(false);
-        }}
-        autoFocus
-      />
-      <Button
-        variant="primary"
-        size="sm"
-        onClick={handleSubmit}
-        disabled={!inputValue.trim()}
-        className="!text-xs !px-2 !py-1 !min-h-0"
-      >
-        Anheften
-      </Button>
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={() => setOpen(false)}
-        className="!text-xs !px-2 !py-1 !min-h-0"
-      >
-        ✕
-      </Button>
+      <div className="flex gap-2">
+        <Input
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          placeholder={mode === 'session' ? 'Session-ID (z.B. 42)' : 'Datum (z.B. 2026-03-16)'}
+          inputSize="sm"
+          className="!min-h-[32px] !text-xs flex-1"
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') handleSubmit();
+            if (e.key === 'Escape') setOpen(false);
+          }}
+          autoFocus
+        />
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={handleSubmit}
+          disabled={!inputValue.trim()}
+          className="!text-xs !px-3 !py-1 !min-h-0"
+        >
+          Anheften
+        </Button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -58,7 +58,7 @@ export function ChatInput({
     <div className="space-y-2">
       {contextBadge}
       {error && <p className="text-xs text-[var(--color-text-error)]">{error}</p>}
-      <div className="flex gap-2 items-start">
+      <div className="flex gap-2 items-end">
         <div className="flex-1 [&>div>div:last-child]:hidden">
           <Textarea
             value={value}
@@ -69,7 +69,7 @@ export function ChatInput({
             rows={1}
             autoResize
             inputSize="sm"
-            className="!min-h-[44px] max-h-[150px]"
+            className="!min-h-[44px] max-h-[150px] !pb-2.5"
           />
         </div>
         {isSupported && !streaming && (

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1,7 +1,18 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { Link } from 'react-router-dom';
-import { Bot, PanelLeftClose, PanelLeftOpen } from 'lucide-react';
-import { Button, Card, CardBody, Breadcrumbs, BreadcrumbItem } from '@nordlig/components';
+import { Bot, PanelLeftOpen } from 'lucide-react';
+import {
+  Button,
+  Card,
+  CardBody,
+  Breadcrumbs,
+  BreadcrumbItem,
+  Sheet,
+  SheetTrigger,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@nordlig/components';
 import { useChat } from '@/hooks/useChat';
 import { ChatMessageBubble } from '@/components/chat/ChatMessageBubble';
 import { ChatInput } from '@/components/chat/ChatInput';
@@ -44,7 +55,6 @@ interface ChatAreaProps {
   onCancel: () => void;
   onPinContext: (ctx: ChatContext) => void;
   onUnpinContext: () => void;
-  sidebarOpen: boolean;
 }
 
 function ChatArea({
@@ -58,66 +68,102 @@ function ChatArea({
   onCancel,
   onPinContext,
   onUnpinContext,
-  sidebarOpen,
 }: ChatAreaProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const lastMsg = messages[messages.length - 1];
 
-  // Auto-scroll bei neuen Nachrichten UND waehrend Streaming (content aendert sich)
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages.length, lastMsg?.content, sending]);
 
   return (
-    <div className={`flex-1 flex flex-col min-w-0 ${sidebarOpen ? 'hidden lg:flex' : 'flex'}`}>
-      <Card elevation="raised" className="flex-1 flex flex-col overflow-hidden">
-        <CardBody className="flex-1 flex flex-col overflow-hidden p-0">
-          <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
-            {loading && (
-              <div className="text-center text-sm text-[var(--color-text-muted)] py-8">
-                Lade Konversation...
-              </div>
-            )}
-            {!loading && messages.length === 0 && (
-              <>
-                <ChatNotifications onQuickAction={onSend} />
-                <EmptyState onQuickAction={onSend} />
-              </>
-            )}
-            {messages.map((msg, idx) => (
-              <ChatMessageBubble
-                key={msg.id}
-                role={msg.role}
-                content={msg.content}
-                timestamp={msg.created_at}
-                toolStatus={idx === messages.length - 1 && sending ? toolStatus : null}
-              />
-            ))}
-            {error && (
-              <div className="text-center text-sm text-[var(--color-text-error)] py-2">{error}</div>
-            )}
-            <div ref={messagesEndRef} />
-          </div>
-          <div className="px-4 py-3">
-            <ChatInput
-              onSend={onSend}
-              onCancel={onCancel}
-              disabled={sending}
-              streaming={sending}
-              contextBadge={
-                <div className="flex items-center gap-2">
-                  {pinnedContext ? (
-                    <ChatContextBadge context={pinnedContext} onRemove={onUnpinContext} />
-                  ) : (
-                    <ChatContextPicker onSelect={onPinContext} disabled={sending} />
-                  )}
-                </div>
-              }
+    <Card elevation="raised" className="flex-1 flex flex-col overflow-hidden min-h-0">
+      <CardBody className="flex-1 flex flex-col overflow-hidden p-0">
+        <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
+          {loading && (
+            <div className="text-center text-sm text-[var(--color-text-muted)] py-8">
+              Lade Konversation...
+            </div>
+          )}
+          {!loading && messages.length === 0 && (
+            <>
+              <ChatNotifications onQuickAction={onSend} />
+              <EmptyState onQuickAction={onSend} />
+            </>
+          )}
+          {messages.map((msg, idx) => (
+            <ChatMessageBubble
+              key={msg.id}
+              role={msg.role}
+              content={msg.content}
+              timestamp={msg.created_at}
+              toolStatus={idx === messages.length - 1 && sending ? toolStatus : null}
             />
-          </div>
-        </CardBody>
-      </Card>
-    </div>
+          ))}
+          {error && (
+            <div className="text-center text-sm text-[var(--color-text-error)] py-2">{error}</div>
+          )}
+          <div ref={messagesEndRef} />
+        </div>
+        <div className="shrink-0 px-4 py-3 border-t border-[var(--color-border-muted)]">
+          <ChatInput
+            onSend={onSend}
+            onCancel={onCancel}
+            disabled={sending}
+            streaming={sending}
+            contextBadge={
+              <div className="flex items-center gap-2">
+                {pinnedContext ? (
+                  <ChatContextBadge context={pinnedContext} onRemove={onUnpinContext} />
+                ) : (
+                  <ChatContextPicker onSelect={onPinContext} disabled={sending} />
+                )}
+              </div>
+            }
+          />
+        </div>
+      </CardBody>
+    </Card>
+  );
+}
+
+interface ChatHeaderProps {
+  sheetOpen: boolean;
+  onSheetChange: (open: boolean) => void;
+  sidebarContent: React.ReactNode;
+}
+
+function ChatHeader({ sheetOpen, onSheetChange, sidebarContent }: ChatHeaderProps) {
+  return (
+    <header className="shrink-0 space-y-2 pb-2">
+      <Breadcrumbs>
+        <BreadcrumbItem>
+          <Link to="/">Home</Link>
+        </BreadcrumbItem>
+        <BreadcrumbItem>KI-Chat</BreadcrumbItem>
+      </Breadcrumbs>
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-bold text-[var(--color-text-base)]">Trainingsplan-Assistent</h1>
+        <Sheet open={sheetOpen} onOpenChange={onSheetChange}>
+          <SheetTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              aria-label="Unterhaltungen anzeigen"
+              className="lg:hidden"
+            >
+              <PanelLeftOpen className="w-5 h-5" />
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="left">
+            <SheetHeader>
+              <SheetTitle>Unterhaltungen</SheetTitle>
+            </SheetHeader>
+            {sidebarContent}
+          </SheetContent>
+        </Sheet>
+      </div>
+    </header>
   );
 }
 
@@ -138,7 +184,7 @@ export function ChatPage() {
     removeConversation,
   } = useChat();
 
-  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [sheetOpen, setSheetOpen] = useState(false);
   const [pinnedContext, setPinnedContext] = useState<ChatContext | null>(null);
 
   useEffect(() => {
@@ -147,65 +193,43 @@ export function ChatPage() {
 
   const handleSend = useCallback(
     (text: string) => {
-      // Wenn Kontext angeheftet, als Prefix mitsenden
       const prefix = pinnedContext
         ? `[Kontext: ${pinnedContext.type === 'session' ? 'Session' : 'Woche'} ${pinnedContext.id}]\n\n`
         : '';
       void sendMessage(prefix + text);
-      setSidebarOpen(false);
+      setSheetOpen(false);
     },
     [pinnedContext, sendMessage],
   );
 
-  return (
-    <div className="p-4 pt-6 md:p-6 md:pt-8 max-w-5xl mx-auto">
-      <header className="space-y-2 pb-2">
-        <Breadcrumbs>
-          <BreadcrumbItem>
-            <Link to="/">Home</Link>
-          </BreadcrumbItem>
-          <BreadcrumbItem>KI-Chat</BreadcrumbItem>
-        </Breadcrumbs>
-        <div className="flex items-center justify-between">
-          <h1 className="text-xl font-bold text-[var(--color-text-base)]">
-            Trainingsplan-Assistent
-          </h1>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setSidebarOpen(!sidebarOpen)}
-            aria-label="Unterhaltungen anzeigen"
-            className="lg:hidden"
-          >
-            {sidebarOpen ? (
-              <PanelLeftClose className="w-5 h-5" />
-            ) : (
-              <PanelLeftOpen className="w-5 h-5" />
-            )}
-          </Button>
-        </div>
-      </header>
+  const sidebarContent = (
+    <ConversationList
+      conversations={conversations}
+      activeId={activeConversationId}
+      onSelect={(id) => {
+        void selectConversation(id);
+        setSheetOpen(false);
+      }}
+      onNew={() => {
+        startNewConversation();
+        setSheetOpen(false);
+      }}
+      onDelete={(id) => void removeConversation(id)}
+    />
+  );
 
-      <div className="flex gap-4" style={{ height: 'calc(100vh - 200px)' }}>
-        <div
-          className={`${sidebarOpen ? 'block' : 'hidden'} lg:block w-64 shrink-0 overflow-y-auto`}
-        >
+  return (
+    <div className="flex flex-col p-4 pt-6 md:p-6 md:pt-8 max-w-5xl mx-auto h-[calc(100dvh-64px)] lg:h-[calc(100dvh)] overflow-hidden">
+      <ChatHeader
+        sheetOpen={sheetOpen}
+        onSheetChange={setSheetOpen}
+        sidebarContent={sidebarContent}
+      />
+
+      <div className="flex gap-4 flex-1 min-h-0 pb-[82px] lg:pb-0">
+        <div className="hidden lg:block w-64 shrink-0 overflow-y-auto">
           <Card elevation="flat">
-            <CardBody>
-              <ConversationList
-                conversations={conversations}
-                activeId={activeConversationId}
-                onSelect={(id) => {
-                  void selectConversation(id);
-                  setSidebarOpen(false);
-                }}
-                onNew={() => {
-                  startNewConversation();
-                  setSidebarOpen(false);
-                }}
-                onDelete={(id) => void removeConversation(id)}
-              />
-            </CardBody>
+            <CardBody>{sidebarContent}</CardBody>
           </Card>
         </div>
 
@@ -220,7 +244,6 @@ export function ChatPage() {
           onCancel={cancelStream}
           onPinContext={setPinnedContext}
           onUnpinContext={() => setPinnedContext(null)}
-          sidebarOpen={sidebarOpen}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Chat-Bereich füllt den Viewport (`100dvh - TopBar`), **kein Page-Scroll** mehr — Breadcrumbs + Headline immer sichtbar
- Konversations-Sidebar: **NDS `Sheet` (side="left")** statt manueller show/hide Toggle
- ChatContextPicker: **vertikal gestackt** statt horizontale Leiste (passt jetzt auf 375px)
- ChatInput: `items-end` + explizites `pb-2.5` für korrektes Padding bei mehrzeiligem Text
- Input-Bereich mit `border-top` visuell vom Chat-Verlauf getrennt

## Test plan
- [ ] iPhone 16 Pro (393px): Breadcrumbs + Headline immer sichtbar, kein Page-Scroll
- [ ] Mobile: Sheet-Button öffnet Konversationsliste als Overlay von links
- [ ] Mobile: Kontext-Picker (Session/Woche) passt auf den Screen
- [ ] Mobile: Textarea mehrzeilig — Padding korrekt
- [ ] Desktop: Sidebar als permanente Spalte, kein Sheet-Button sichtbar

Closes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)