### PR TITLE
fix: Sheet z-index über TopBar/BottomNav (#467)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -118,6 +118,11 @@
   margin: 0.75em 0;
 }
 
+/* Sheet z-index override — über MobileTopBar (z-90) und BottomNav (z-200) */
+[data-radix-dialog-overlay][data-state] {
+  z-index: 299 !important;
+}
+
 @keyframes typing-dot {
   0%,
   80%,

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -155,11 +155,11 @@ function ChatHeader({ sheetOpen, onSheetChange, sidebarContent }: ChatHeaderProp
               <PanelLeftOpen className="w-5 h-5" />
             </Button>
           </SheetTrigger>
-          <SheetContent side="left">
+          <SheetContent side="left" className="!z-[300] flex flex-col">
             <SheetHeader>
               <SheetTitle>Unterhaltungen</SheetTitle>
             </SheetHeader>
-            {sidebarContent}
+            <div className="flex-1 overflow-y-auto mt-2">{sidebarContent}</div>
           </SheetContent>
         </Sheet>
       </div>


### PR DESCRIPTION
## Summary
- Sheet z-index auf 300 (Content) und 299 (Overlay) erhöht — überdeckt TopBar (z-90) und BottomNav (z-200)
- Konversationsliste im Sheet scrollbar mit `overflow-y-auto`
- Spacing zwischen Title und Inhalt mit `mt-2`

## Test plan
- [ ] Mobile: Sheet öffnen → Title "Unterhaltungen" sichtbar, TopBar verdeckt
- [ ] Mobile: Bei vielen Konversationen scrollbar
- [ ] Desktop: Keine Regression (Sheet wird nicht verwendet)

Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)