### PR TITLE
fix: Chat-Textarea Padding + Viewport-Höhe Mobile

### DIFF
--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -59,7 +59,7 @@ export function ChatInput({
       {contextBadge}
       {error && <p className="text-xs text-[var(--color-text-error)]">{error}</p>}
       <div className="flex gap-2 items-end">
-        <div className="flex-1 [&>div>div:last-child]:hidden">
+        <div className="flex-1 [&>div>div:last-child]:hidden [&_textarea]:!pb-3">
           <Textarea
             value={value}
             onChange={(e) => setValue(e.target.value)}
@@ -69,7 +69,7 @@ export function ChatInput({
             rows={1}
             autoResize
             inputSize="sm"
-            className="!min-h-[44px] max-h-[150px] !pb-2.5"
+            className="!min-h-[44px] max-h-[150px]"
           />
         </div>
         {isSupported && !streaming && (

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -219,14 +219,14 @@ export function ChatPage() {
   );
 
   return (
-    <div className="flex flex-col p-4 pt-6 md:p-6 md:pt-8 max-w-5xl mx-auto h-[calc(100dvh-64px)] lg:h-[calc(100dvh)] overflow-hidden">
+    <div className="flex flex-col p-4 pt-6 md:p-6 md:pt-8 max-w-5xl mx-auto h-[calc(100dvh-64px-82px)] lg:h-[calc(100dvh)] overflow-hidden">
       <ChatHeader
         sheetOpen={sheetOpen}
         onSheetChange={setSheetOpen}
         sidebarContent={sidebarContent}
       />
 
-      <div className="flex gap-4 flex-1 min-h-0 pb-[82px] lg:pb-0">
+      <div className="flex gap-4 flex-1 min-h-0">
         <div className="hidden lg:block w-64 shrink-0 overflow-y-auto">
           <Card elevation="flat">
             <CardBody>{sidebarContent}</CardBody>


### PR DESCRIPTION
## Summary
- Textarea Bottom-Padding über Wrapper-Selektor `[&_textarea]:!pb-3` setzen (umgeht tw-merge Konflikt mit NDS-Textarea-Variants)
- Viewport-Höhe auf `h-[calc(100dvh-64px-82px)]` korrigiert — berücksichtigt TopBar (64px) + BottomNav (82px), Header bleibt beim Tippen sichtbar
- Doppeltes `pb-[82px]` entfernt

Closes #469

## Test plan
- [ ] Mobile (375px): Textarea mit umbrechendem Text hat sichtbares Bottom-Padding
- [ ] Mobile: Header/Breadcrumbs bleiben beim Tippen sichtbar
- [ ] Desktop: Layout unverändert funktional
- [ ] ESLint + TSC grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)