### PR TITLE
fix: Quick-Action Buttons h-auto für mehrzeiligen Text

### DIFF
--- a/frontend/src/components/chat/ChatQuickActions.tsx
+++ b/frontend/src/components/chat/ChatQuickActions.tsx
@@ -28,6 +28,7 @@ export function ChatQuickActions({ onSelect, disabled }: ChatQuickActionsProps) 
             size="sm"
             onClick={() => onSelect(q)}
             disabled={disabled}
+            className="!h-auto"
           >
             {q}
           </Button>


### PR DESCRIPTION
## Summary
- NDS Button `size="sm"` hat fixe `height: 36px` — bei Textumbruch auf Mobile wird der Text gequetscht
- `!h-auto` auf Quick-Action Buttons, damit sie bei Umbruch mitwachsen

Closes #471

## Test plan
- [ ] Mobile (375px): Mehrzeilige Buttons ("Soll ich den Trainingsplan anpassen?") haben korrektes Padding
- [ ] Einzeilige Buttons unverändert
- [ ] Desktop: Layout unverändert

🤖 Generated with [Claude Code](https://claude.com/claude-code)