### PR TITLE
feat: Pacing-Strategie Generator

### DIFF
--- a/backend/app/api/v1/pacing.py
+++ b/backend/app/api/v1/pacing.py
@@ -1,0 +1,127 @@
+"""Pacing-Strategie Generator API — km-genaue Pace-Empfehlungen."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.infrastructure.database.models import RaceGoalModel
+from app.infrastructure.database.session import get_db
+from app.infrastructure.external.http_client import ExternalAPIClient
+from app.models.enrichment import wmo_to_label
+from app.models.pacing import (
+    PacingRequest,
+    PacingResponse,
+    RaceDayWeatherResponse,
+)
+from app.services.pacing_strategy import generate_pacing_strategy
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/pacing", tags=["pacing"])
+
+# Open-Meteo Client (wiederverwendet das bestehende Pattern)
+_weather_client = ExternalAPIClient(
+    base_url="https://api.open-meteo.com/v1",
+    timeout=settings.open_meteo_timeout,
+)
+
+
+@router.post("/generate", response_model=PacingResponse)
+async def generate_pacing(
+    body: PacingRequest,
+    db: AsyncSession = Depends(get_db),
+) -> PacingResponse:
+    """Generiert eine Pacing-Strategie basierend auf Zielzeit, Hoehenprofil und Wetter."""
+    # Wenn goal_id angegeben: Distanz und Zielzeit aus dem Goal laden
+    if body.goal_id is not None:
+        result = await db.execute(select(RaceGoalModel).where(RaceGoalModel.id == body.goal_id))
+        goal = result.scalar_one_or_none()
+        if goal is None:
+            raise HTTPException(status_code=404, detail="Ziel nicht gefunden")
+        body = body.model_copy(
+            update={
+                "distance_km": goal.distance_km,
+                "target_time_seconds": goal.target_time_seconds,
+            }
+        )
+
+    return generate_pacing_strategy(body)
+
+
+@router.get("/weather-forecast", response_model=RaceDayWeatherResponse)
+async def get_weather_forecast(
+    lat: float = Query(..., ge=-90, le=90),
+    lng: float = Query(..., ge=-180, le=180),
+    forecast_date: str = Query(..., alias="date", description="YYYY-MM-DD"),
+) -> RaceDayWeatherResponse:
+    """Holt Wetter-Forecast fuer einen bestimmten Tag und Ort (Open-Meteo)."""
+    try:
+        target_date = date.fromisoformat(forecast_date)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail="Ungültiges Datum (YYYY-MM-DD)") from e
+
+    days_ahead = (target_date - date.today()).days
+    if days_ahead < 0:
+        raise HTTPException(status_code=400, detail="Datum liegt in der Vergangenheit")
+    if days_ahead > 16:
+        raise HTTPException(
+            status_code=400,
+            detail="Vorhersage nur bis 16 Tage im Voraus verfügbar",
+        )
+
+    data = await _weather_client.get(
+        "/forecast",
+        params={
+            "latitude": lat,
+            "longitude": lng,
+            "daily": (
+                "temperature_2m_min,temperature_2m_max,"
+                "weather_code,precipitation_sum,"
+                "wind_speed_10m_max,wind_direction_10m_dominant,"
+                "relative_humidity_2m_mean"
+            ),
+            "start_date": target_date.isoformat(),
+            "end_date": target_date.isoformat(),
+            "timezone": "auto",
+        },
+    )
+
+    if not data or "daily" not in data:
+        raise HTTPException(status_code=502, detail="Wetter-Daten nicht verfügbar")
+
+    daily = data["daily"]
+    try:
+        t_min = float(daily["temperature_2m_min"][0])
+        t_max = float(daily["temperature_2m_max"][0])
+        code = int(daily["weather_code"][0] or 0)
+
+        return RaceDayWeatherResponse(
+            date=target_date.isoformat(),
+            temperature_min=t_min,
+            temperature_max=t_max,
+            temperature_avg=round((t_min + t_max) / 2, 1),
+            wind_speed_max_kmh=float(daily["wind_speed_10m_max"][0] or 0),
+            wind_direction_deg=_safe_float(daily.get("wind_direction_10m_dominant", [None])[0]),
+            precipitation_mm=float(daily["precipitation_sum"][0] or 0),
+            humidity_percent=_safe_float(daily.get("relative_humidity_2m_mean", [None])[0]),
+            weather_label=wmo_to_label(code),
+        )
+    except (IndexError, TypeError, ValueError) as e:
+        logger.warning("Fehler beim Parsen des Wetter-Forecasts: %s", e)
+        raise HTTPException(status_code=502, detail="Wetter-Daten nicht parsbar") from e
+
+
+def _safe_float(value: object) -> float | None:
+    """Konvertiert einen Wert sicher zu float oder gibt None zurueck."""
+    if value is None:
+        return None
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -7,6 +7,7 @@ from app.api.v1 import (
     exercise_library,
     goals,
     health,
+    pacing,
     session_templates,
     sessions,
     streak,
@@ -30,6 +31,7 @@ api_router.include_router(sessions.router, tags=["sessions"])
 api_router.include_router(athlete.router, tags=["athlete"])
 api_router.include_router(threshold_tests.router, tags=["threshold-tests"])
 api_router.include_router(goals.router, tags=["goals"])
+api_router.include_router(pacing.router, tags=["pacing"])
 api_router.include_router(ai.router, tags=["ai"])
 api_router.include_router(ai_log.router, tags=["ai-log"])
 api_router.include_router(trends.router, tags=["trends"])

--- a/backend/app/models/pacing.py
+++ b/backend/app/models/pacing.py
@@ -1,0 +1,114 @@
+"""Pydantic Schemas fuer Pacing-Strategie Generator API."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Request
+# ---------------------------------------------------------------------------
+
+
+class ElevationSegment(BaseModel):
+    """Hoehenprofil-Daten fuer einen Kilometer."""
+
+    km: int = Field(..., ge=1, description="Kilometer-Nummer (1-basiert)")
+    gain_m: float = Field(0.0, ge=0, description="Hoehengewinn in Metern")
+    loss_m: float = Field(0.0, ge=0, description="Hoehenverlust in Metern")
+
+
+class PacingRequest(BaseModel):
+    """Request-Schema: Pacing-Strategie generieren."""
+
+    target_time_seconds: int = Field(..., gt=0, description="Zielzeit in Sekunden")
+    distance_km: float = Field(..., gt=0, description="Distanz in Kilometern")
+    strategy: Literal["even", "negative", "effort_based"] = Field(
+        "even", description="Pacing-Strategie"
+    )
+    elevation_preset: Literal["flat", "rolling", "hilly"] | None = Field(
+        None, description="Hoehenprofil-Preset (alternativ zu elevation_segments)"
+    )
+    elevation_segments: list[ElevationSegment] | None = Field(
+        None, description="Manuelles Hoehenprofil pro km"
+    )
+    temperature_celsius: float | None = Field(None, description="Temperatur in Grad Celsius")
+    wind_speed_kmh: float | None = Field(None, ge=0, description="Windgeschwindigkeit in km/h")
+    humidity_percent: float | None = Field(
+        None, ge=0, le=100, description="Luftfeuchtigkeit in Prozent"
+    )
+    goal_id: int | None = Field(
+        None, description="Optional: Race-Goal-ID zum Vorladen von Distanz/Zielzeit"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Response
+# ---------------------------------------------------------------------------
+
+
+class KmPacingSplit(BaseModel):
+    """Pace-Empfehlung fuer einen Kilometer."""
+
+    km: int
+    distance_km: float = Field(description="1.0 fuer volle km, <1.0 fuer letzten Abschnitt")
+    target_pace_sec_per_km: float
+    target_pace_formatted: str  # "5:41"
+    cumulative_seconds: int
+    cumulative_formatted: str  # "1:14:23"
+    elevation_gain_m: float = 0.0
+    elevation_loss_m: float = 0.0
+    adjustment_note: str | None = None  # z.B. "Bergauf +8s", "Hitze +6s/km"
+
+
+class WeatherAdjustment(BaseModel):
+    """Zusammenfassung der Wetter-Anpassungen."""
+
+    temperature_celsius: float | None = None
+    wind_speed_kmh: float | None = None
+    humidity_percent: float | None = None
+    penalty_sec_per_km: float = 0.0
+    description: str = ""  # "Hitze (+6s/km), Gegenwind (+3s/km)"
+
+
+class PacingResponse(BaseModel):
+    """Response-Schema: Generierte Pacing-Strategie."""
+
+    strategy: str
+    strategy_label: str  # "Gleichmaessig", "Negative Splits", "Effort-Based"
+    distance_km: float
+    target_time_seconds: int
+    target_time_formatted: str
+    avg_pace_sec_per_km: float
+    avg_pace_formatted: str
+    splits: list[KmPacingSplit]
+    weather_adjustment: WeatherAdjustment | None = None
+    notes: list[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Weather Forecast
+# ---------------------------------------------------------------------------
+
+
+class WeatherForecastRequest(BaseModel):
+    """Query-Parameter fuer Wetter-Abfrage."""
+
+    lat: float = Field(..., ge=-90, le=90)
+    lng: float = Field(..., ge=-180, le=180)
+    date: str = Field(..., description="Datum im Format YYYY-MM-DD")
+
+
+class RaceDayWeatherResponse(BaseModel):
+    """Response-Schema: Wetter-Forecast fuer den Wettkampftag."""
+
+    date: str
+    temperature_min: float
+    temperature_max: float
+    temperature_avg: float
+    wind_speed_max_kmh: float
+    wind_direction_deg: float | None = None
+    precipitation_mm: float
+    humidity_percent: float | None = None
+    weather_label: str

--- a/backend/app/services/pacing_strategy.py
+++ b/backend/app/services/pacing_strategy.py
@@ -1,0 +1,378 @@
+"""Pacing-Strategie Generator: Berechnet km-genaue Pace-Empfehlungen."""
+
+from __future__ import annotations
+
+import math
+
+from app.models.pacing import (
+    ElevationSegment,
+    KmPacingSplit,
+    PacingRequest,
+    PacingResponse,
+    WeatherAdjustment,
+)
+from app.services.km_split_calculator import (
+    DEFAULT_ELEV_GAIN_SEC_PER_100M,
+    DEFAULT_ELEV_LOSS_SEC_PER_100M,
+)
+
+# ---------------------------------------------------------------------------
+# Strategie-Labels (deutsch)
+# ---------------------------------------------------------------------------
+
+STRATEGY_LABELS: dict[str, str] = {
+    "even": "Gleichmäßig",
+    "negative": "Negative Splits",
+    "effort_based": "Effort-Based",
+}
+
+# ---------------------------------------------------------------------------
+# Wetter-Konstanten (sportwissenschaftliche Richtwerte)
+# ---------------------------------------------------------------------------
+
+# Temperatur: ~0.5% Leistungsverlust pro Grad ueber 15°C
+_TEMP_THRESHOLD_C = 15.0
+_TEMP_PENALTY_PCT_PER_DEGREE = 0.5
+_TEMP_PENALTY_MAX_PCT = 20.0
+
+# Wind: ~0.3 sec/km pro km/h Gegenwind (vereinfacht, ohne Richtung)
+_WIND_PENALTY_SEC_PER_KMH = 0.3
+
+# Luftfeuchtigkeit: zusaetzlich ~0.1% pro Prozentpunkt ueber 70%
+_HUMIDITY_THRESHOLD = 70.0
+_HUMIDITY_PENALTY_PCT_PER_POINT = 0.1
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def generate_pacing_strategy(request: PacingRequest) -> PacingResponse:
+    """Generiert eine komplette Pacing-Strategie aus den Request-Parametern."""
+    distance = request.distance_km
+    target_secs = request.target_time_seconds
+    num_full_km = int(distance)
+    partial_km = distance - num_full_km
+
+    base_pace_sec = target_secs / distance
+
+    # 1) Elevation-Profil erstellen
+    elevation = _get_elevation_profile(
+        distance, request.elevation_preset, request.elevation_segments
+    )
+
+    # 2) Strategie-Modifier anwenden
+    raw_paces = _apply_strategy(base_pace_sec, distance, request.strategy)
+
+    # 3) Hoehen-Anpassung pro km
+    elevation_adjustments = _calc_elevation_adjustments(elevation)
+    for i, adj in enumerate(elevation_adjustments):
+        raw_paces[i] += adj
+
+    # 4) Wetter-Anpassung (gleichmaessig auf alle km)
+    weather_adj = _calc_weather_adjustment(
+        base_pace_sec,
+        request.temperature_celsius,
+        request.wind_speed_kmh,
+        request.humidity_percent,
+    )
+    if weather_adj and weather_adj.penalty_sec_per_km > 0:
+        for i in range(len(raw_paces)):
+            raw_paces[i] += weather_adj.penalty_sec_per_km
+
+    # 5) Normalisierung: Summe der Zeiten == Zielzeit exakt
+    #    Beruecksichtigt partielle letzte km
+    distances = [1.0] * num_full_km
+    if partial_km > 0.01:
+        distances.append(partial_km)
+    raw_paces = _normalize_to_target(raw_paces, distances, target_secs)
+
+    # 6) Splits bauen
+    splits: list[KmPacingSplit] = []
+    cumulative_sec = 0.0
+
+    for i, pace_sec in enumerate(raw_paces):
+        km_num = i + 1
+        km_dist = distances[i]
+        km_time = pace_sec * km_dist
+        cumulative_sec += km_time
+        cum_int = round(cumulative_sec)
+
+        elev = (
+            elevation[i] if i < len(elevation) else ElevationSegment(km=km_num, gain_m=0, loss_m=0)
+        )
+        note = _build_adjustment_note(
+            elevation_adjustments[i] if i < len(elevation_adjustments) else 0.0
+        )
+
+        splits.append(
+            KmPacingSplit(
+                km=km_num,
+                distance_km=round(km_dist, 2),
+                target_pace_sec_per_km=round(pace_sec, 1),
+                target_pace_formatted=_format_pace_sec(pace_sec),
+                cumulative_seconds=cum_int,
+                cumulative_formatted=_format_duration(cum_int),
+                elevation_gain_m=round(elev.gain_m, 1),
+                elevation_loss_m=round(elev.loss_m, 1),
+                adjustment_note=note,
+            )
+        )
+
+    # 7) Notizen
+    notes = _build_notes(request.strategy, weather_adj, elevation)
+
+    return PacingResponse(
+        strategy=request.strategy,
+        strategy_label=STRATEGY_LABELS.get(request.strategy, request.strategy),
+        distance_km=distance,
+        target_time_seconds=target_secs,
+        target_time_formatted=_format_duration(target_secs),
+        avg_pace_sec_per_km=round(base_pace_sec, 1),
+        avg_pace_formatted=_format_pace_sec(base_pace_sec),
+        splits=splits,
+        weather_adjustment=weather_adj,
+        notes=notes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Strategie-Modifier
+# ---------------------------------------------------------------------------
+
+
+def _apply_strategy(
+    base_pace_sec: float,
+    distance_km: float,
+    strategy: str,
+) -> list[float]:
+    """Erzeugt eine Liste von Pace-Werten (sec/km) basierend auf der Strategie."""
+    num_full_km = int(distance_km)
+    partial_km = distance_km - num_full_km
+    total_splits = num_full_km + (1 if partial_km > 0.01 else 0)
+
+    if strategy == "negative":
+        return _negative_split_paces(base_pace_sec, total_splits)
+    # even und effort_based starten beide mit gleichmaessiger Pace
+    # (effort_based wird durch Hoehen-Anpassung differenziert)
+    return [base_pace_sec] * total_splits
+
+
+def _negative_split_paces(base_pace: float, num_splits: int) -> list[float]:
+    """Negative Split: erste Haelfte ~3% langsamer, zweite ~3% schneller.
+
+    Linearer Uebergang von +3% bei km 1 zu -3% bei letzter km.
+    """
+    if num_splits <= 1:
+        return [base_pace] * num_splits
+
+    paces: list[float] = []
+    for i in range(num_splits):
+        # t geht von 0.0 (erste km) bis 1.0 (letzte km)
+        t = i / (num_splits - 1)
+        # modifier: +0.03 bei t=0, -0.03 bei t=1
+        modifier = 0.03 * (1.0 - 2.0 * t)
+        paces.append(base_pace * (1.0 + modifier))
+    return paces
+
+
+# ---------------------------------------------------------------------------
+# Hoehenprofil
+# ---------------------------------------------------------------------------
+
+
+def _get_elevation_profile(
+    distance_km: float,
+    preset: str | None,
+    segments: list[ElevationSegment] | None,
+) -> list[ElevationSegment]:
+    """Erstellt Hoehenprofil: entweder aus manuellen Segmenten oder Preset."""
+    num_full_km = int(distance_km)
+    partial_km = distance_km - num_full_km
+    total_splits = num_full_km + (1 if partial_km > 0.01 else 0)
+
+    if segments:
+        # Auffuellen oder kuerzen auf korrekte Laenge
+        result = list(segments[:total_splits])
+        while len(result) < total_splits:
+            result.append(ElevationSegment(km=len(result) + 1, gain_m=0, loss_m=0))
+        return result
+
+    if preset == "rolling":
+        return _preset_rolling(total_splits)
+    if preset == "hilly":
+        return _preset_hilly(total_splits)
+
+    # flat (default)
+    return [ElevationSegment(km=i + 1, gain_m=0, loss_m=0) for i in range(total_splits)]
+
+
+def _preset_rolling(num_splits: int) -> list[ElevationSegment]:
+    """Wellig: Sinuswelle ~15m gain/loss pro km, netto ~0."""
+    result: list[ElevationSegment] = []
+    for i in range(num_splits):
+        phase = math.sin(2 * math.pi * i / max(num_splits, 1) * 2)
+        gain = max(0.0, phase * 15.0)
+        loss = max(0.0, -phase * 15.0)
+        result.append(ElevationSegment(km=i + 1, gain_m=round(gain, 1), loss_m=round(loss, 1)))
+    return result
+
+
+def _preset_hilly(num_splits: int) -> list[ElevationSegment]:
+    """Huegelig: groessere Anstiege, Hauptanstieg im mittleren Drittel."""
+    result: list[ElevationSegment] = []
+    third = max(1, num_splits // 3)
+    for i in range(num_splits):
+        if third <= i < 2 * third:
+            # Mittleres Drittel: starker Anstieg
+            gain, loss = 35.0, 5.0
+        elif i >= 2 * third:
+            # Letztes Drittel: Abstieg
+            gain, loss = 5.0, 35.0
+        else:
+            # Erstes Drittel: leicht wellig
+            gain, loss = 10.0, 10.0
+        result.append(ElevationSegment(km=i + 1, gain_m=gain, loss_m=loss))
+    return result
+
+
+def _calc_elevation_adjustments(elevation: list[ElevationSegment]) -> list[float]:
+    """Berechnet Hoehen-Anpassung in Sekunden pro km (positiv = langsamer)."""
+    adjustments: list[float] = []
+    for seg in elevation:
+        gain_penalty = (seg.gain_m / 100.0) * DEFAULT_ELEV_GAIN_SEC_PER_100M
+        loss_benefit = (seg.loss_m / 100.0) * DEFAULT_ELEV_LOSS_SEC_PER_100M
+        adjustments.append(gain_penalty - loss_benefit)
+    return adjustments
+
+
+# ---------------------------------------------------------------------------
+# Wetter-Anpassung
+# ---------------------------------------------------------------------------
+
+
+def _calc_weather_adjustment(
+    base_pace_sec: float,
+    temperature: float | None,
+    wind_speed: float | None,
+    humidity: float | None,
+) -> WeatherAdjustment | None:
+    """Berechnet Wetter-bedingte Pace-Anpassung."""
+    if temperature is None and wind_speed is None:
+        return None
+
+    penalty = 0.0
+    parts: list[str] = []
+
+    # Temperatur
+    if temperature is not None and temperature > _TEMP_THRESHOLD_C:
+        temp_pct = min(
+            (temperature - _TEMP_THRESHOLD_C) * _TEMP_PENALTY_PCT_PER_DEGREE,
+            _TEMP_PENALTY_MAX_PCT,
+        )
+        temp_penalty = base_pace_sec * (temp_pct / 100.0)
+        penalty += temp_penalty
+        parts.append(f"Hitze {temperature:.0f}°C (+{temp_penalty:.0f}s/km)")
+
+    # Wind
+    if wind_speed is not None and wind_speed > 0:
+        wind_penalty = wind_speed * _WIND_PENALTY_SEC_PER_KMH
+        penalty += wind_penalty
+        parts.append(f"Wind {wind_speed:.0f} km/h (+{wind_penalty:.0f}s/km)")
+
+    # Luftfeuchtigkeit
+    if humidity is not None and humidity > _HUMIDITY_THRESHOLD:
+        hum_pct = (humidity - _HUMIDITY_THRESHOLD) * _HUMIDITY_PENALTY_PCT_PER_POINT
+        hum_penalty = base_pace_sec * (hum_pct / 100.0)
+        penalty += hum_penalty
+        parts.append(f"Feuchte {humidity:.0f}% (+{hum_penalty:.0f}s/km)")
+
+    if penalty == 0.0:
+        return None
+
+    return WeatherAdjustment(
+        temperature_celsius=temperature,
+        wind_speed_kmh=wind_speed,
+        humidity_percent=humidity,
+        penalty_sec_per_km=round(penalty, 1),
+        description=", ".join(parts),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Normalisierung
+# ---------------------------------------------------------------------------
+
+
+def _normalize_to_target(
+    paces: list[float],
+    distances: list[float],
+    target_total_sec: int,
+) -> list[float]:
+    """Skaliert alle Paces proportional, sodass die Gesamtzeit exakt der Zielzeit entspricht."""
+    current_total = sum(p * d for p, d in zip(paces, distances))
+    if current_total <= 0:
+        return paces
+
+    scale = target_total_sec / current_total
+    return [p * scale for p in paces]
+
+
+# ---------------------------------------------------------------------------
+# Formatierung
+# ---------------------------------------------------------------------------
+
+
+def _format_pace_sec(pace_sec: float) -> str:
+    """Formatiert Pace (Sekunden/km) als M:SS String."""
+    pace_min = pace_sec / 60.0
+    mins = int(pace_min)
+    secs = int(round((pace_min - mins) * 60))
+    if secs == 60:
+        mins += 1
+        secs = 0
+    return f"{mins}:{secs:02d}"
+
+
+def _format_duration(total_seconds: int) -> str:
+    """Formatiert Dauer in Sekunden als H:MM:SS oder MM:SS."""
+    hours = total_seconds // 3600
+    mins = (total_seconds % 3600) // 60
+    secs = total_seconds % 60
+    if hours > 0:
+        return f"{hours}:{mins:02d}:{secs:02d}"
+    return f"{mins}:{secs:02d}"
+
+
+def _build_adjustment_note(elevation_adj_sec: float) -> str | None:
+    """Erzeugt Hinweis-Text fuer Hoehen-Anpassung pro km."""
+    if abs(elevation_adj_sec) < 1.0:
+        return None
+    if elevation_adj_sec > 0:
+        return f"Bergauf +{elevation_adj_sec:.0f}s"
+    return f"Bergab {elevation_adj_sec:.0f}s"
+
+
+def _build_notes(
+    strategy: str,
+    weather: WeatherAdjustment | None,
+    elevation: list[ElevationSegment],
+) -> list[str]:
+    """Erzeugt allgemeine Tipps fuer die Pacing-Strategie."""
+    notes: list[str] = []
+
+    if strategy == "negative":
+        notes.append("Starte bewusst langsamer — die zweite Hälfte wird schneller.")
+    elif strategy == "effort_based":
+        notes.append("Pace variiert mit dem Höhenprofil — halte die Belastung konstant.")
+
+    total_gain = sum(s.gain_m for s in elevation)
+    if total_gain > 100:
+        notes.append(f"Gesamtanstieg: {total_gain:.0f}m — spare Energie für die Anstiege.")
+
+    if weather and weather.penalty_sec_per_km > 3:
+        notes.append(f"Wetter-Anpassung: {weather.description}")
+        notes.append("Trinke frühzeitig und regelmäßig bei diesen Bedingungen.")
+
+    return notes

--- a/backend/app/tests/test_pacing_strategy.py
+++ b/backend/app/tests/test_pacing_strategy.py
@@ -1,0 +1,322 @@
+"""Tests fuer den Pacing-Strategie Generator."""
+
+import pytest
+
+from app.models.pacing import ElevationSegment, PacingRequest, PacingResponse
+from app.services.pacing_strategy import generate_pacing_strategy
+
+# ---------------------------------------------------------------------------
+# Hilfsfunktionen
+# ---------------------------------------------------------------------------
+
+
+def _hm_request(**overrides: object) -> PacingRequest:
+    """Erzeugt einen Standard-HM-Request (21.1 km, 1:59:59 = 7199s)."""
+    defaults: dict[str, object] = {
+        "target_time_seconds": 7199,
+        "distance_km": 21.1,
+        "strategy": "even",
+    }
+    defaults.update(overrides)
+    return PacingRequest(**defaults)  # type: ignore[arg-type]
+
+
+def _total_time(response: PacingResponse) -> float:
+    """Berechnet die Gesamtzeit aus allen Splits."""
+    return sum(s.target_pace_sec_per_km * s.distance_km for s in response.splits)
+
+
+# ---------------------------------------------------------------------------
+# Even Split
+# ---------------------------------------------------------------------------
+
+
+class TestEvenSplit:
+    """Tests fuer die gleichmaessige Strategie."""
+
+    def test_flat_course_all_splits_equal(self) -> None:
+        """Flache Strecke: alle Splits haben die gleiche Pace."""
+        result = generate_pacing_strategy(_hm_request(elevation_preset="flat"))
+
+        paces = [s.target_pace_sec_per_km for s in result.splits]
+        # Alle vollen km sollten gleiche Pace haben (Rundungsdifferenz < 0.5s)
+        full_km_paces = paces[:-1]  # letzte km ist partial
+        for pace in full_km_paces:
+            assert abs(pace - full_km_paces[0]) < 0.5
+
+    def test_total_matches_target(self) -> None:
+        """Gesamtzeit muss exakt der Zielzeit entsprechen."""
+        result = generate_pacing_strategy(_hm_request(elevation_preset="flat"))
+        total = _total_time(result)
+        assert abs(total - 7199) < 1.0  # Max 1 Sekunde Abweichung
+
+    def test_correct_number_of_splits(self) -> None:
+        """21.1 km = 21 volle km + 1 partielle km = 22 Splits."""
+        result = generate_pacing_strategy(_hm_request())
+        assert len(result.splits) == 22
+
+    def test_last_split_is_partial(self) -> None:
+        """Letzter Split hat distance_km < 1.0."""
+        result = generate_pacing_strategy(_hm_request())
+        last = result.splits[-1]
+        assert last.distance_km == pytest.approx(0.1, abs=0.01)
+
+    def test_cumulative_time_monotonic(self) -> None:
+        """Kumulative Zeit muss streng monoton steigend sein."""
+        result = generate_pacing_strategy(_hm_request())
+        for i in range(1, len(result.splits)):
+            assert result.splits[i].cumulative_seconds > result.splits[i - 1].cumulative_seconds
+
+    def test_response_metadata(self) -> None:
+        """Response enthaelt korrekte Metadaten."""
+        result = generate_pacing_strategy(_hm_request())
+        assert result.strategy == "even"
+        assert result.strategy_label == "Gleichmäßig"
+        assert result.distance_km == 21.1
+        assert result.target_time_seconds == 7199
+        assert result.target_time_formatted == "1:59:59"
+
+
+# ---------------------------------------------------------------------------
+# Negative Split
+# ---------------------------------------------------------------------------
+
+
+class TestNegativeSplit:
+    """Tests fuer Negative-Split-Strategie."""
+
+    def test_second_half_faster(self) -> None:
+        """Zweite Haelfte muss schneller sein als erste."""
+        result = generate_pacing_strategy(_hm_request(strategy="negative"))
+        mid = len(result.splits) // 2
+        first_half_avg = sum(s.target_pace_sec_per_km for s in result.splits[:mid]) / mid
+        second_half_paces = [
+            s.target_pace_sec_per_km for s in result.splits[mid:] if s.distance_km >= 0.5
+        ]
+        second_half_avg = sum(second_half_paces) / len(second_half_paces)
+        assert second_half_avg < first_half_avg
+
+    def test_total_matches_target(self) -> None:
+        """Gesamtzeit muss auch bei Negative Split exakt stimmen."""
+        result = generate_pacing_strategy(_hm_request(strategy="negative"))
+        total = _total_time(result)
+        assert abs(total - 7199) < 1.0
+
+    def test_first_km_slowest(self) -> None:
+        """Erste km sollte die langsamste sein."""
+        result = generate_pacing_strategy(_hm_request(strategy="negative", elevation_preset="flat"))
+        paces = [s.target_pace_sec_per_km for s in result.splits if s.distance_km >= 0.5]
+        assert paces[0] == max(paces)
+
+
+# ---------------------------------------------------------------------------
+# Effort-Based
+# ---------------------------------------------------------------------------
+
+
+class TestEffortBased:
+    """Tests fuer die Effort-Based Strategie mit Hoehenanpassung."""
+
+    def test_uphill_slower_than_downhill(self) -> None:
+        """Bergauf-km muss langsamer sein als Bergab-km."""
+        segments = [
+            ElevationSegment(km=1, gain_m=0, loss_m=0),
+            ElevationSegment(km=2, gain_m=50, loss_m=0),  # bergauf
+            ElevationSegment(km=3, gain_m=0, loss_m=50),  # bergab
+        ]
+        req = _hm_request(
+            target_time_seconds=900,
+            distance_km=3.0,
+            strategy="effort_based",
+            elevation_segments=segments,
+        )
+        result = generate_pacing_strategy(req)
+        uphill = result.splits[1].target_pace_sec_per_km  # km 2
+        downhill = result.splits[2].target_pace_sec_per_km  # km 3
+        assert uphill > downhill
+
+    def test_total_matches_with_elevation(self) -> None:
+        """Gesamtzeit stimmt auch mit Hoehenprofil."""
+        result = generate_pacing_strategy(
+            _hm_request(strategy="effort_based", elevation_preset="hilly")
+        )
+        total = _total_time(result)
+        assert abs(total - 7199) < 1.0
+
+    def test_adjustment_notes_present(self) -> None:
+        """Bergauf/bergab-Splits haben Anpassungshinweise."""
+        segments = [
+            ElevationSegment(km=1, gain_m=50, loss_m=0),
+            ElevationSegment(km=2, gain_m=0, loss_m=50),
+        ]
+        req = _hm_request(
+            target_time_seconds=600,
+            distance_km=2.0,
+            strategy="effort_based",
+            elevation_segments=segments,
+        )
+        result = generate_pacing_strategy(req)
+        assert result.splits[0].adjustment_note is not None
+        assert "Bergauf" in result.splits[0].adjustment_note
+        assert result.splits[1].adjustment_note is not None
+        assert "Bergab" in result.splits[1].adjustment_note
+
+
+# ---------------------------------------------------------------------------
+# Elevation Presets
+# ---------------------------------------------------------------------------
+
+
+class TestElevationPresets:
+    """Tests fuer die Hoehenprofil-Presets."""
+
+    def test_flat_no_elevation(self) -> None:
+        """Flat-Preset: kein Hoehenunterschied."""
+        result = generate_pacing_strategy(_hm_request(elevation_preset="flat"))
+        for split in result.splits:
+            assert split.elevation_gain_m == 0.0
+            assert split.elevation_loss_m == 0.0
+
+    def test_rolling_has_variation(self) -> None:
+        """Rolling-Preset: hat sowohl gain als auch loss."""
+        result = generate_pacing_strategy(_hm_request(elevation_preset="rolling"))
+        gains = [s.elevation_gain_m for s in result.splits]
+        losses = [s.elevation_loss_m for s in result.splits]
+        assert any(g > 0 for g in gains)
+        assert any(lo > 0 for lo in losses)
+
+    def test_hilly_significant_elevation(self) -> None:
+        """Hilly-Preset: deutlich mehr Hoehenmeter als Rolling."""
+        rolling = generate_pacing_strategy(_hm_request(elevation_preset="rolling"))
+        hilly = generate_pacing_strategy(_hm_request(elevation_preset="hilly"))
+        rolling_total = sum(s.elevation_gain_m for s in rolling.splits)
+        hilly_total = sum(s.elevation_gain_m for s in hilly.splits)
+        assert hilly_total > rolling_total
+
+
+# ---------------------------------------------------------------------------
+# Wetter-Anpassung
+# ---------------------------------------------------------------------------
+
+
+class TestWeatherAdjustment:
+    """Tests fuer Wetter-bedingte Pace-Anpassung."""
+
+    def test_heat_produces_weather_adjustment(self) -> None:
+        """Hitze (30°C) erzeugt eine Wetter-Anpassung mit Penalty."""
+        result = generate_pacing_strategy(_hm_request(temperature_celsius=30.0))
+        assert result.weather_adjustment is not None
+        assert result.weather_adjustment.penalty_sec_per_km > 0
+        assert "Hitze" in result.weather_adjustment.description
+
+    def test_no_penalty_below_threshold(self) -> None:
+        """Unter 15°C kein Temperatur-Aufschlag."""
+        result = generate_pacing_strategy(_hm_request(temperature_celsius=10.0))
+        assert result.weather_adjustment is None
+
+    def test_wind_produces_weather_adjustment(self) -> None:
+        """Wind erzeugt eine Wetter-Anpassung."""
+        result = generate_pacing_strategy(_hm_request(wind_speed_kmh=20.0))
+        assert result.weather_adjustment is not None
+        assert result.weather_adjustment.penalty_sec_per_km > 0
+        assert "Wind" in result.weather_adjustment.description
+
+    def test_combined_weather_description(self) -> None:
+        """Kombinierte Wetter-Anpassung enthaelt beide Faktoren."""
+        result = generate_pacing_strategy(
+            _hm_request(temperature_celsius=30.0, wind_speed_kmh=15.0)
+        )
+        assert result.weather_adjustment is not None
+        assert "Hitze" in result.weather_adjustment.description
+        assert "Wind" in result.weather_adjustment.description
+
+    def test_total_still_matches_with_weather(self) -> None:
+        """Gesamtzeit stimmt auch mit Wetter-Anpassung (Normalisierung)."""
+        result = generate_pacing_strategy(
+            _hm_request(temperature_celsius=30.0, wind_speed_kmh=15.0)
+        )
+        total = _total_time(result)
+        assert abs(total - 7199) < 1.0
+
+
+# ---------------------------------------------------------------------------
+# Normalisierung
+# ---------------------------------------------------------------------------
+
+
+class TestNormalization:
+    """Tests fuer die Normalisierung auf exakte Zielzeit."""
+
+    def test_exact_target_even(self) -> None:
+        """Even: Summe == Zielzeit."""
+        result = generate_pacing_strategy(_hm_request())
+        assert abs(_total_time(result) - 7199) < 1.0
+
+    def test_exact_target_with_all_adjustments(self) -> None:
+        """Alle Anpassungen zusammen: Summe == Zielzeit."""
+        result = generate_pacing_strategy(
+            _hm_request(
+                strategy="negative",
+                elevation_preset="hilly",
+                temperature_celsius=28.0,
+                wind_speed_kmh=10.0,
+            )
+        )
+        assert abs(_total_time(result) - 7199) < 1.0
+
+
+# ---------------------------------------------------------------------------
+# Formatierung
+# ---------------------------------------------------------------------------
+
+
+class TestFormatting:
+    """Tests fuer Pace- und Zeit-Formatierung."""
+
+    def test_pace_format(self) -> None:
+        """Pace wird als M:SS formatiert."""
+        result = generate_pacing_strategy(_hm_request())
+        for split in result.splits:
+            assert ":" in split.target_pace_formatted
+            parts = split.target_pace_formatted.split(":")
+            assert len(parts) == 2
+            assert len(parts[1]) == 2  # Sekunden immer zweistellig
+
+    def test_cumulative_format(self) -> None:
+        """Kumulative Zeit wird als H:MM:SS oder MM:SS formatiert."""
+        result = generate_pacing_strategy(_hm_request())
+        last = result.splits[-1]
+        assert ":" in last.cumulative_formatted
+
+
+# ---------------------------------------------------------------------------
+# Edge Cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Tests fuer Randfaelle."""
+
+    def test_short_distance(self) -> None:
+        """1 km Distanz: genau 1 Split."""
+        result = generate_pacing_strategy(_hm_request(target_time_seconds=300, distance_km=1.0))
+        assert len(result.splits) == 1
+        assert result.splits[0].distance_km == 1.0
+
+    def test_exact_km_no_partial(self) -> None:
+        """Ganzzahlige Distanz: kein partieller Split."""
+        result = generate_pacing_strategy(_hm_request(target_time_seconds=3000, distance_km=10.0))
+        assert len(result.splits) == 10
+        assert all(s.distance_km == 1.0 for s in result.splits)
+
+    def test_marathon_distance(self) -> None:
+        """Marathon (42.195 km): korrekte Anzahl Splits."""
+        result = generate_pacing_strategy(
+            _hm_request(target_time_seconds=14400, distance_km=42.195)
+        )
+        assert len(result.splits) == 43  # 42 volle + 1 partielle
+
+    def test_notes_for_negative_split(self) -> None:
+        """Negative-Split Strategie bekommt passenden Hinweis."""
+        result = generate_pacing_strategy(_hm_request(strategy="negative"))
+        assert any("langsamer" in n for n in result.notes)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -102,6 +102,7 @@ const WeeklyPlanPage = lazy(() =>
   import('./pages/WeeklyPlan').then((m) => ({ default: m.WeeklyPlanPage })),
 );
 const GoalsPage = lazy(() => import('./pages/Goals').then((m) => ({ default: m.GoalsPage })));
+const PacingPage = lazy(() => import('./pages/Pacing').then((m) => ({ default: m.PacingPage })));
 const AthleteProfilePage = lazy(() =>
   import('./pages/AthleteProfile').then((m) => ({ default: m.AthleteProfilePage })),
 );
@@ -150,6 +151,7 @@ function App() {
                   <Route path="/plan" element={<PlanLayout />}>
                     <Route index element={<WeeklyPlanPage />} />
                     <Route path="goals" element={<GoalsPage />} />
+                    <Route path="pacing" element={<PacingPage />} />
                     <Route path="programs" element={<TrainingPlansPage />} />
                     <Route path="programs/new" element={<TrainingPlanEditorPage />} />
                     <Route path="programs/:planId" element={<TrainingPlanEditorPage />} />

--- a/frontend/src/api/pacing.ts
+++ b/frontend/src/api/pacing.ts
@@ -1,0 +1,92 @@
+import { apiClient } from './client';
+
+// ---------------------------------------------------------------------------
+// Request Types
+// ---------------------------------------------------------------------------
+
+export interface ElevationSegment {
+  km: number;
+  gain_m: number;
+  loss_m: number;
+}
+
+export interface PacingRequest {
+  target_time_seconds: number;
+  distance_km: number;
+  strategy: 'even' | 'negative' | 'effort_based';
+  elevation_preset?: 'flat' | 'rolling' | 'hilly' | null;
+  elevation_segments?: ElevationSegment[] | null;
+  temperature_celsius?: number | null;
+  wind_speed_kmh?: number | null;
+  humidity_percent?: number | null;
+  goal_id?: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Response Types
+// ---------------------------------------------------------------------------
+
+export interface KmPacingSplit {
+  km: number;
+  distance_km: number;
+  target_pace_sec_per_km: number;
+  target_pace_formatted: string;
+  cumulative_seconds: number;
+  cumulative_formatted: string;
+  elevation_gain_m: number;
+  elevation_loss_m: number;
+  adjustment_note: string | null;
+}
+
+export interface WeatherAdjustment {
+  temperature_celsius: number | null;
+  wind_speed_kmh: number | null;
+  humidity_percent: number | null;
+  penalty_sec_per_km: number;
+  description: string;
+}
+
+export interface PacingResponse {
+  strategy: string;
+  strategy_label: string;
+  distance_km: number;
+  target_time_seconds: number;
+  target_time_formatted: string;
+  avg_pace_sec_per_km: number;
+  avg_pace_formatted: string;
+  splits: KmPacingSplit[];
+  weather_adjustment: WeatherAdjustment | null;
+  notes: string[];
+}
+
+export interface RaceDayWeatherResponse {
+  date: string;
+  temperature_min: number;
+  temperature_max: number;
+  temperature_avg: number;
+  wind_speed_max_kmh: number;
+  wind_direction_deg: number | null;
+  precipitation_mm: number;
+  humidity_percent: number | null;
+  weather_label: string;
+}
+
+// ---------------------------------------------------------------------------
+// API Functions
+// ---------------------------------------------------------------------------
+
+export async function generatePacing(params: PacingRequest): Promise<PacingResponse> {
+  const response = await apiClient.post<PacingResponse>('/api/v1/pacing/generate', params);
+  return response.data;
+}
+
+export async function getWeatherForecast(
+  lat: number,
+  lng: number,
+  date: string,
+): Promise<RaceDayWeatherResponse> {
+  const response = await apiClient.get<RaceDayWeatherResponse>('/api/v1/pacing/weather-forecast', {
+    params: { lat, lng, date },
+  });
+  return response.data;
+}

--- a/frontend/src/components/pacing/DistanceTimeInputs.tsx
+++ b/frontend/src/components/pacing/DistanceTimeInputs.tsx
@@ -1,0 +1,72 @@
+import { Input, Label } from '@nordlig/components';
+
+interface DistanceTimeInputsProps {
+  distance: string;
+  timeH: string;
+  timeM: string;
+  timeS: string;
+  onDistanceChange: (val: string) => void;
+  onTimeHChange: (val: string) => void;
+  onTimeMChange: (val: string) => void;
+  onTimeSChange: (val: string) => void;
+}
+
+export function DistanceTimeInputs({
+  distance,
+  timeH,
+  timeM,
+  timeS,
+  onDistanceChange,
+  onTimeHChange,
+  onTimeMChange,
+  onTimeSChange,
+}: DistanceTimeInputsProps) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div>
+        <Label htmlFor="distance">Distanz (km)</Label>
+        <Input
+          id="distance"
+          type="number"
+          inputSize="sm"
+          value={distance}
+          onChange={(e) => onDistanceChange(e.target.value)}
+          placeholder="21.1"
+          min="0.1"
+          step="0.1"
+        />
+      </div>
+      <div>
+        <Label>Zielzeit</Label>
+        <div className="grid grid-cols-3 gap-2">
+          <Input
+            inputSize="sm"
+            type="number"
+            value={timeH}
+            onChange={(e) => onTimeHChange(e.target.value)}
+            placeholder="Std"
+            min="0"
+          />
+          <Input
+            inputSize="sm"
+            type="number"
+            value={timeM}
+            onChange={(e) => onTimeMChange(e.target.value)}
+            placeholder="Min"
+            min="0"
+            max="59"
+          />
+          <Input
+            inputSize="sm"
+            type="number"
+            value={timeS}
+            onChange={(e) => onTimeSChange(e.target.value)}
+            placeholder="Sek"
+            min="0"
+            max="59"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/pacing/PacingChart.tsx
+++ b/frontend/src/components/pacing/PacingChart.tsx
@@ -1,0 +1,103 @@
+import {
+  ResponsiveContainer,
+  ComposedChart,
+  Bar,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+} from 'recharts';
+import { Card, CardBody } from '@nordlig/components';
+import type { PacingResponse } from '@/api/pacing';
+
+interface PacingChartProps {
+  result: PacingResponse;
+}
+
+function formatPace(sec: number): string {
+  const mins = Math.floor(sec / 60);
+  const secs = Math.round(sec % 60);
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+
+export function PacingChart({ result }: PacingChartProps) {
+  const data = result.splits.map((s) => ({
+    km: s.distance_km < 1 ? `${s.km}*` : String(s.km),
+    pace: s.target_pace_sec_per_km,
+    gain: s.elevation_gain_m,
+    loss: s.elevation_loss_m,
+  }));
+
+  const paces = data.map((d) => d.pace);
+  const minPace = Math.floor(Math.min(...paces) / 10) * 10 - 10;
+  const maxPace = Math.ceil(Math.max(...paces) / 10) * 10 + 10;
+
+  return (
+    <Card elevation="raised">
+      <CardBody>
+        <h3 className="text-sm font-semibold text-[var(--color-text-base)] mb-3">Pace-Verlauf</h3>
+        <div className="h-48 md:h-64">
+          <ResponsiveContainer width="100%" height="100%">
+            <ComposedChart data={data} margin={{ top: 5, right: 10, left: -10, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-muted)" />
+              <XAxis
+                dataKey="km"
+                tick={{ fontSize: 11, fill: 'var(--color-text-muted)' }}
+                tickLine={false}
+              />
+              <YAxis
+                yAxisId="pace"
+                domain={[minPace, maxPace]}
+                reversed
+                tick={{ fontSize: 11, fill: 'var(--color-text-muted)' }}
+                tickFormatter={formatPace}
+                tickLine={false}
+                axisLine={false}
+              />
+              <YAxis
+                yAxisId="elev"
+                orientation="right"
+                tick={{ fontSize: 11, fill: 'var(--color-text-muted)' }}
+                tickLine={false}
+                axisLine={false}
+                hide
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: 'var(--color-bg-elevated)',
+                  border: '1px solid var(--color-border-default)',
+                  borderRadius: 'var(--radius-md)',
+                  fontSize: '12px',
+                }}
+                formatter={(value, name) => {
+                  const v = Number(value);
+                  if (name === 'pace') return [formatPace(v) + '/km', 'Pace'];
+                  if (name === 'gain') return [v.toFixed(0) + 'm', 'Anstieg'];
+                  if (name === 'loss') return [v.toFixed(0) + 'm', 'Abstieg'];
+                  return [String(value), String(name)];
+                }}
+              />
+              <Bar
+                yAxisId="elev"
+                dataKey="gain"
+                fill="var(--color-chart-2)"
+                opacity={0.3}
+                radius={[2, 2, 0, 0]}
+              />
+              <Line
+                yAxisId="pace"
+                type="monotone"
+                dataKey="pace"
+                stroke="var(--color-chart-1)"
+                strokeWidth={2}
+                dot={{ r: 3, fill: 'var(--color-chart-1)' }}
+                activeDot={{ r: 5 }}
+              />
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}

--- a/frontend/src/components/pacing/PacingForm.test.tsx
+++ b/frontend/src/components/pacing/PacingForm.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@/test/test-utils';
+import { PacingForm } from './PacingForm';
+import type { RaceGoal } from '@/api/goals';
+
+const mockGoal: RaceGoal = {
+  id: 1,
+  title: 'HM Sub-2h',
+  race_date: '2026-05-10',
+  distance_km: 21.1,
+  target_time_seconds: 7199,
+  target_time_formatted: '1:59:59',
+  target_pace_formatted: '5:41',
+  is_active: true,
+  days_until: 49,
+  training_plan_id: null,
+  training_plan_summary: null,
+  created_at: '2026-03-01T00:00:00',
+  updated_at: '2026-03-01T00:00:00',
+};
+
+describe('PacingForm', () => {
+  it('rendert alle Formularfelder', () => {
+    render(<PacingForm goals={[]} loading={false} onGenerate={vi.fn()} />);
+
+    expect(screen.getByLabelText('Distanz (km)')).toBeDefined();
+    expect(screen.getByText('Strategie')).toBeDefined();
+    expect(screen.getByText('Höhenprofil')).toBeDefined();
+    expect(screen.getByText('Strategie generieren')).toBeDefined();
+  });
+
+  it('zeigt Goal-Auswahl wenn aktive Ziele vorhanden', () => {
+    render(<PacingForm goals={[mockGoal]} loading={false} onGenerate={vi.fn()} />);
+
+    expect(screen.getByText('Wettkampfziel')).toBeDefined();
+  });
+
+  it('zeigt keine Goal-Auswahl ohne aktive Ziele', () => {
+    const inactiveGoal = { ...mockGoal, is_active: false };
+    render(<PacingForm goals={[inactiveGoal]} loading={false} onGenerate={vi.fn()} />);
+
+    expect(screen.queryByText('Wettkampfziel')).toBeNull();
+  });
+
+  it('zeigt Fehlermeldung bei fehlender Distanz', () => {
+    const onGenerate = vi.fn();
+    render(<PacingForm goals={[]} loading={false} onGenerate={onGenerate} />);
+
+    fireEvent.click(screen.getByText('Strategie generieren'));
+
+    expect(screen.getByText(/gültige Distanz/)).toBeDefined();
+    expect(onGenerate).not.toHaveBeenCalled();
+  });
+
+  it('deaktiviert Button während Laden', () => {
+    render(<PacingForm goals={[]} loading={true} onGenerate={vi.fn()} />);
+
+    const button = screen.getByText('Berechne…');
+    expect(button.closest('button')?.disabled).toBe(true);
+  });
+});

--- a/frontend/src/components/pacing/PacingForm.tsx
+++ b/frontend/src/components/pacing/PacingForm.tsx
@@ -1,0 +1,193 @@
+import { useState, useEffect } from 'react';
+import { Button, Label, Select, Alert, AlertDescription } from '@nordlig/components';
+import { Play } from 'lucide-react';
+import type { RaceGoal } from '@/api/goals';
+import type { PacingRequest } from '@/api/pacing';
+import { DistanceTimeInputs } from './DistanceTimeInputs';
+import { WeatherInputs } from './WeatherInputs';
+
+interface PacingFormProps {
+  goals: RaceGoal[];
+  loading: boolean;
+  onGenerate: (params: PacingRequest) => void;
+}
+
+type Strategy = 'even' | 'negative' | 'effort_based';
+type ElevationPreset = 'flat' | 'rolling' | 'hilly';
+
+const STRATEGY_OPTIONS = [
+  { value: 'even', label: 'Gleichmäßig (Even Split)' },
+  { value: 'negative', label: 'Negative Splits' },
+  { value: 'effort_based', label: 'Effort-Based (konstante Belastung)' },
+];
+
+const ELEVATION_OPTIONS = [
+  { value: 'flat', label: 'Flach' },
+  { value: 'rolling', label: 'Wellig (~15m/km)' },
+  { value: 'hilly', label: 'Hügelig (~30m/km)' },
+];
+
+function usePacingForm(goals: RaceGoal[]) {
+  const [goalId, setGoalId] = useState<number | null>(null);
+  const [distance, setDistance] = useState('');
+  const [timeH, setTimeH] = useState('');
+  const [timeM, setTimeM] = useState('');
+  const [timeS, setTimeS] = useState('');
+  const [strategy, setStrategy] = useState<Strategy>('even');
+  const [elevationPreset, setElevationPreset] = useState<ElevationPreset>('flat');
+  const [temperature, setTemperature] = useState('');
+  const [windSpeed, setWindSpeed] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!goalId) return;
+    const goal = goals.find((g) => g.id === goalId);
+    if (!goal) return;
+    setDistance(String(goal.distance_km));
+    const secs = goal.target_time_seconds;
+    setTimeH(String(Math.floor(secs / 3600)));
+    setTimeM(String(Math.floor((secs % 3600) / 60)));
+    setTimeS(String(secs % 60));
+  }, [goalId, goals]);
+
+  const validate = (): PacingRequest | null => {
+    setError(null);
+    const dist = parseFloat(distance);
+    if (!dist || dist <= 0) {
+      setError('Bitte eine gültige Distanz eingeben.');
+      return null;
+    }
+    const h = parseInt(timeH || '0', 10);
+    const m = parseInt(timeM || '0', 10);
+    const s = parseInt(timeS || '0', 10);
+    const totalSec = h * 3600 + m * 60 + s;
+    if (totalSec <= 0) {
+      setError('Bitte eine gültige Zielzeit eingeben.');
+      return null;
+    }
+    const params: PacingRequest = {
+      target_time_seconds: totalSec,
+      distance_km: dist,
+      strategy,
+      elevation_preset: elevationPreset,
+      goal_id: goalId,
+    };
+    const temp = parseFloat(temperature);
+    if (!isNaN(temp)) params.temperature_celsius = temp;
+    const wind = parseFloat(windSpeed);
+    if (!isNaN(wind)) params.wind_speed_kmh = wind;
+    return params;
+  };
+
+  return {
+    goalId,
+    setGoalId,
+    distance,
+    setDistance,
+    timeH,
+    setTimeH,
+    timeM,
+    setTimeM,
+    timeS,
+    setTimeS,
+    strategy,
+    setStrategy,
+    elevationPreset,
+    setElevationPreset,
+    temperature,
+    setTemperature,
+    windSpeed,
+    setWindSpeed,
+    error,
+    validate,
+  };
+}
+
+export function PacingForm({ goals, loading, onGenerate }: PacingFormProps) {
+  const form = usePacingForm(goals);
+  const activeGoals = goals.filter((g) => g.is_active);
+  const goalOptions = [
+    { value: '', label: 'Manuell eingeben' },
+    ...activeGoals.map((g) => ({
+      value: String(g.id),
+      label: `${g.title} — ${g.distance_km} km in ${g.target_time_formatted}`,
+    })),
+  ];
+
+  const handleSubmit = () => {
+    const params = form.validate();
+    if (params) onGenerate(params);
+  };
+
+  return (
+    <div className="space-y-5">
+      {activeGoals.length > 0 && (
+        <div>
+          <Label>Wettkampfziel</Label>
+          <Select
+            options={goalOptions}
+            value={form.goalId ? String(form.goalId) : ''}
+            onChange={(val) => form.setGoalId(val ? Number(val) : null)}
+          />
+        </div>
+      )}
+
+      <DistanceTimeInputs
+        distance={form.distance}
+        timeH={form.timeH}
+        timeM={form.timeM}
+        timeS={form.timeS}
+        onDistanceChange={form.setDistance}
+        onTimeHChange={form.setTimeH}
+        onTimeMChange={form.setTimeM}
+        onTimeSChange={form.setTimeS}
+      />
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <Label>Strategie</Label>
+          <Select
+            options={STRATEGY_OPTIONS}
+            value={form.strategy}
+            onChange={(val) => {
+              if (val) form.setStrategy(val as Strategy);
+            }}
+          />
+        </div>
+        <div>
+          <Label>Höhenprofil</Label>
+          <Select
+            options={ELEVATION_OPTIONS}
+            value={form.elevationPreset}
+            onChange={(val) => {
+              if (val) form.setElevationPreset(val as ElevationPreset);
+            }}
+          />
+        </div>
+      </div>
+
+      <WeatherInputs
+        temperature={form.temperature}
+        windSpeed={form.windSpeed}
+        onTemperatureChange={form.setTemperature}
+        onWindSpeedChange={form.setWindSpeed}
+      />
+
+      {form.error && (
+        <Alert variant="error">
+          <AlertDescription>{form.error}</AlertDescription>
+        </Alert>
+      )}
+
+      <Button variant="primary" onClick={handleSubmit} disabled={loading}>
+        {loading ? (
+          'Berechne…'
+        ) : (
+          <>
+            <Play size={16} /> Strategie generieren
+          </>
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/pacing/PacingTable.tsx
+++ b/frontend/src/components/pacing/PacingTable.tsx
@@ -1,0 +1,94 @@
+import { Badge, Card, CardBody } from '@nordlig/components';
+import type { PacingResponse } from '@/api/pacing';
+
+interface PacingTableProps {
+  result: PacingResponse;
+}
+
+export function PacingTable({ result }: PacingTableProps) {
+  return (
+    <Card elevation="raised">
+      <CardBody className="p-0">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[var(--color-border-muted)] text-left text-xs text-[var(--color-text-muted)]">
+                <th className="px-3 py-2 font-medium">km</th>
+                <th className="px-3 py-2 font-medium">Pace</th>
+                <th className="px-3 py-2 font-medium hidden sm:table-cell">Kumuliert</th>
+                <th className="px-3 py-2 font-medium hidden md:table-cell">Höhe</th>
+                <th className="px-3 py-2 font-medium">Hinweis</th>
+              </tr>
+            </thead>
+            <tbody>
+              {result.splits.map((split) => (
+                <tr
+                  key={split.km}
+                  className="border-b border-[var(--color-border-muted)] last:border-0 hover:bg-[var(--color-bg-muted)] transition-colors duration-150 motion-reduce:transition-none"
+                >
+                  <td className="px-3 py-2 font-medium tabular-nums">
+                    {split.distance_km < 1
+                      ? `${split.km} (${(split.distance_km * 1000).toFixed(0)}m)`
+                      : split.km}
+                  </td>
+                  <td className="px-3 py-2 tabular-nums font-semibold">
+                    {split.target_pace_formatted}/km
+                  </td>
+                  <td className="px-3 py-2 tabular-nums hidden sm:table-cell text-[var(--color-text-muted)]">
+                    {split.cumulative_formatted}
+                  </td>
+                  <td className="px-3 py-2 hidden md:table-cell">
+                    <ElevationCell gain={split.elevation_gain_m} loss={split.elevation_loss_m} />
+                  </td>
+                  <td className="px-3 py-2">
+                    {split.adjustment_note && (
+                      <Badge
+                        variant={
+                          split.adjustment_note.startsWith('Bergauf')
+                            ? 'accent-bold'
+                            : 'primary-bold'
+                        }
+                        size="sm"
+                      >
+                        {split.adjustment_note}
+                      </Badge>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr className="border-t-2 border-[var(--color-border-default)] font-semibold text-sm">
+                <td className="px-3 py-2">Gesamt</td>
+                <td className="px-3 py-2 tabular-nums">{result.avg_pace_formatted}/km</td>
+                <td className="px-3 py-2 tabular-nums hidden sm:table-cell">
+                  {result.target_time_formatted}
+                </td>
+                <td className="px-3 py-2 hidden md:table-cell">
+                  <ElevationCell
+                    gain={result.splits.reduce((s, sp) => s + sp.elevation_gain_m, 0)}
+                    loss={result.splits.reduce((s, sp) => s + sp.elevation_loss_m, 0)}
+                  />
+                </td>
+                <td className="px-3 py-2" />
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}
+
+function ElevationCell({ gain, loss }: { gain: number; loss: number }) {
+  if (gain === 0 && loss === 0) {
+    return <span className="text-[var(--color-text-muted)]">—</span>;
+  }
+  return (
+    <span className="text-xs tabular-nums text-[var(--color-text-muted)]">
+      {gain > 0 && <span className="text-[var(--color-text-warning)]">↑{gain.toFixed(0)}m</span>}
+      {gain > 0 && loss > 0 && ' '}
+      {loss > 0 && <span className="text-[var(--color-text-success)]">↓{loss.toFixed(0)}m</span>}
+    </span>
+  );
+}

--- a/frontend/src/components/pacing/WeatherInputs.tsx
+++ b/frontend/src/components/pacing/WeatherInputs.tsx
@@ -1,0 +1,52 @@
+import { Input, Label } from '@nordlig/components';
+import { CloudSun } from 'lucide-react';
+
+interface WeatherInputsProps {
+  temperature: string;
+  windSpeed: string;
+  onTemperatureChange: (val: string) => void;
+  onWindSpeedChange: (val: string) => void;
+}
+
+export function WeatherInputs({
+  temperature,
+  windSpeed,
+  onTemperatureChange,
+  onWindSpeedChange,
+}: WeatherInputsProps) {
+  return (
+    <div>
+      <div className="flex items-center gap-1.5 mb-1.5">
+        <CloudSun size={14} className="text-[var(--color-text-muted)]" />
+        <span className="text-sm font-medium text-[var(--color-text-muted)]">
+          Wetter (optional)
+        </span>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <Label htmlFor="temperature">Temperatur (°C)</Label>
+          <Input
+            id="temperature"
+            type="number"
+            inputSize="sm"
+            value={temperature}
+            onChange={(e) => onTemperatureChange(e.target.value)}
+            placeholder="20"
+          />
+        </div>
+        <div>
+          <Label htmlFor="wind">Wind (km/h)</Label>
+          <Input
+            id="wind"
+            type="number"
+            inputSize="sm"
+            value={windSpeed}
+            onChange={(e) => onWindSpeedChange(e.target.value)}
+            placeholder="10"
+            min="0"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/layouts/PlanLayout.tsx
+++ b/frontend/src/layouts/PlanLayout.tsx
@@ -7,6 +7,7 @@ import { Outlet, NavLink, useLocation } from 'react-router-dom';
 const tabs = [
   { to: '/plan', label: 'Woche', end: true },
   { to: '/plan/goals', label: 'Ziele', end: false },
+  { to: '/plan/pacing', label: 'Pacing', end: false },
   { to: '/plan/programs', label: 'Programme', end: false },
   { to: '/plan/templates', label: 'Vorlagen', end: false },
   { to: '/plan/exercises', label: 'Übungen', end: false },

--- a/frontend/src/pages/Pacing.tsx
+++ b/frontend/src/pages/Pacing.tsx
@@ -1,0 +1,127 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Alert,
+  AlertDescription,
+  Badge,
+  Button,
+  Card,
+  CardBody,
+  useToast,
+} from '@nordlig/components';
+import { Printer, Info } from 'lucide-react';
+import { listGoals } from '@/api/goals';
+import type { RaceGoal } from '@/api/goals';
+import { generatePacing } from '@/api/pacing';
+import type { PacingRequest, PacingResponse } from '@/api/pacing';
+import { PacingForm } from '@/components/pacing/PacingForm';
+import { PacingTable } from '@/components/pacing/PacingTable';
+import { PacingChart } from '@/components/pacing/PacingChart';
+
+const PRINT_STYLES = `
+@media print {
+  body * { visibility: hidden; }
+  .pacing-result, .pacing-result * { visibility: visible; }
+  .pacing-result { position: absolute; left: 0; top: 0; width: 100%; }
+  .print\\:hidden { display: none !important; }
+}`;
+
+function PacingResult({ result }: { result: PacingResponse }) {
+  return (
+    <div className="space-y-4 pacing-result">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <h2 className="text-lg font-semibold text-[var(--color-text-base)]">
+            {result.strategy_label}
+          </h2>
+          <Badge variant="primary" size="sm">
+            {result.distance_km} km
+          </Badge>
+          <Badge variant="neutral" size="sm">
+            {result.target_time_formatted}
+          </Badge>
+          <Badge variant="neutral" size="sm">
+            &#x2300; {result.avg_pace_formatted}/km
+          </Badge>
+        </div>
+        <Button variant="ghost" size="sm" onClick={() => window.print()} className="print:hidden">
+          <Printer size={16} />
+          Drucken
+        </Button>
+      </div>
+
+      {result.weather_adjustment && (
+        <Alert variant="info">
+          <AlertDescription>
+            <strong>Wetter-Anpassung:</strong> {result.weather_adjustment.description} (+
+            {result.weather_adjustment.penalty_sec_per_km.toFixed(0)}s/km auf Zielzeit)
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <PacingChart result={result} />
+      <PacingTable result={result} />
+
+      {result.notes.length > 0 && (
+        <Card elevation="flat">
+          <CardBody>
+            <div className="flex items-start gap-2">
+              <Info size={16} className="text-[var(--color-text-muted)] mt-0.5 shrink-0" />
+              <ul className="text-sm text-[var(--color-text-muted)] space-y-1">
+                {result.notes.map((note, i) => (
+                  <li key={i}>{note}</li>
+                ))}
+              </ul>
+            </div>
+          </CardBody>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+export function PacingPage() {
+  const { toast } = useToast();
+  const [goals, setGoals] = useState<RaceGoal[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<PacingResponse | null>(null);
+
+  const loadGoals = useCallback(async () => {
+    try {
+      const res = await listGoals();
+      setGoals(res.goals);
+    } catch {
+      // Goals sind optional — kein harter Fehler
+    }
+  }, []);
+
+  useEffect(() => {
+    loadGoals();
+  }, [loadGoals]);
+
+  const handleGenerate = async (params: PacingRequest) => {
+    setLoading(true);
+    try {
+      setResult(await generatePacing(params));
+    } catch {
+      toast({ title: 'Fehler beim Generieren der Pacing-Strategie', variant: 'error' });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card elevation="raised" padding="spacious">
+        <CardBody>
+          <h2 className="text-lg font-semibold text-[var(--color-text-base)] mb-4">
+            Pacing-Strategie erstellen
+          </h2>
+          <PacingForm goals={goals} loading={loading} onGenerate={handleGenerate} />
+        </CardBody>
+      </Card>
+
+      {result && <PacingResult result={result} />}
+      <style>{PRINT_STYLES}</style>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Km-genaue Pace-Empfehlungen für Wettkämpfe mit 3 Strategien (Even, Negative Split, Effort-Based)
- Berücksichtigt Höhenprofil (flach/wellig/hügelig) und Wetterbedingungen (Temperatur, Wind)
- Frontend: Formular mit Goal-Übernahme, Splits-Tabelle und Recharts-Diagramm unter /plan/pacing

## Backend
- `POST /api/v1/pacing/generate` — Pacing-Strategie berechnen
- `GET /api/v1/pacing/weather-forecast` — Open-Meteo Wetter-Abfrage für Renntag
- Höhenanpassung via GAP-Formel (bestehende Konstanten aus km_split_calculator)
- Normalisierung: Gesamtzeit entspricht exakt der Zielzeit
- 28 Unit-Tests

## Frontend
- PacingForm: Goal-Auswahl, Distanz/Zeit, Strategie, Höhenprofil, Wetter (optional)
- PacingTable: Splits pro km mit Pace, kumulativer Zeit, Höhe, Hinweisen
- PacingChart: Recharts ComposedChart (Pace-Linie + Höhen-Balken)
- 5 Komponenten-Tests

## Test plan
- [x] Backend: 28 Tests (Strategien, Höhenprofile, Wetter, Normalisierung, Edge Cases)
- [x] Frontend: 5 Tests (Form-Rendering, Goal-Auswahl, Validierung, Loading-State)
- [x] ESLint, Prettier, TSC, Ruff, Mypy alle grün
- [ ] CI-Pipeline grün
- [ ] Manueller Test auf Staging

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)