### PR TITLE
fix: Race Condition beim Goal-Löschen

### DIFF
--- a/frontend/src/pages/Goals.tsx
+++ b/frontend/src/pages/Goals.tsx
@@ -165,11 +165,12 @@ export function GoalsPage() {
   };
 
   const handleDelete = async () => {
-    if (!deletingGoal) return;
+    const goal = deletingGoal;
+    if (!goal) return;
     setDeleting(true);
     try {
-      await deleteGoal(deletingGoal.id);
-      toast({ title: `„${deletingGoal.title}" gelöscht`, variant: 'success' });
+      await deleteGoal(goal.id);
+      toast({ title: `„${goal.title}" gelöscht`, variant: 'success' });
       setDeletingGoal(null);
       await loadGoals();
     } catch {
@@ -294,7 +295,7 @@ export function GoalsPage() {
       <AlertDialog
         open={!!deletingGoal}
         onOpenChange={(open) => {
-          if (!open) setDeletingGoal(null);
+          if (!open && !deleting) setDeletingGoal(null);
         }}
       >
         <AlertDialogContent>


### PR DESCRIPTION
## Summary
- Race Condition zwischen `AlertDialogAction` und `onOpenChange` gefixt
- Radix `AlertDialogAction` schloss den Dialog automatisch, dabei wurde `deletingGoal` auf `null` gesetzt bevor `handleDelete` den DELETE API-Call absetzen konnte
- Goal verschwand aus der UI (wegen Re-Render), wurde aber nie in der DB gelöscht

## Fix
- `onOpenChange` setzt `deletingGoal` nur auf `null` wenn kein Delete aktiv ist (`!deleting`)
- `handleDelete` sichert `deletingGoal` in lokaler Variable bevor async Operationen starten

## Test plan
- [x] ESLint, Prettier, TSC grün
- [x] Vitest 187/187 grün
- [ ] CI grün
- [ ] Manuell: Goal löschen → DB prüfen ob wirklich gelöscht

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)