### PR TITLE
fix: Höhen-Anpassung nur bei Effort-Based Strategie (#479)

### DIFF
--- a/backend/app/services/pacing_strategy.py
+++ b/backend/app/services/pacing_strategy.py
@@ -65,10 +65,13 @@ def generate_pacing_strategy(request: PacingRequest) -> PacingResponse:
     # 2) Strategie-Modifier anwenden
     raw_paces = _apply_strategy(base_pace_sec, distance, request.strategy)
 
-    # 3) Hoehen-Anpassung pro km
+    # 3) Hoehen-Anpassung pro km (nur bei effort_based — konstanter Effort)
+    #    Even/Negative = konstante Pace, Effort variiert mit Hoehe
+    #    Effort-Based  = konstanter Effort, Pace variiert mit Hoehe
     elevation_adjustments = _calc_elevation_adjustments(elevation)
-    for i, adj in enumerate(elevation_adjustments):
-        raw_paces[i] += adj
+    if request.strategy == "effort_based":
+        for i, adj in enumerate(elevation_adjustments):
+            raw_paces[i] += adj
 
     # 4) Wetter-Anpassung (gleichmaessig auf alle km)
     weather_adj = _calc_weather_adjustment(
@@ -102,8 +105,12 @@ def generate_pacing_strategy(request: PacingRequest) -> PacingResponse:
         elev = (
             elevation[i] if i < len(elevation) else ElevationSegment(km=km_num, gain_m=0, loss_m=0)
         )
-        note = _build_adjustment_note(
-            elevation_adjustments[i] if i < len(elevation_adjustments) else 0.0
+        note = (
+            _build_adjustment_note(
+                elevation_adjustments[i] if i < len(elevation_adjustments) else 0.0
+            )
+            if request.strategy == "effort_based"
+            else None
         )
 
         splits.append(
@@ -154,8 +161,8 @@ def _apply_strategy(
 
     if strategy == "negative":
         return _negative_split_paces(base_pace_sec, total_splits)
-    # even und effort_based starten beide mit gleichmaessiger Pace
-    # (effort_based wird durch Hoehen-Anpassung differenziert)
+    # even: konstante Pace (Hoehen-Anpassung wird NICHT angewendet)
+    # effort_based: startet gleichmaessig, Hoehen-Anpassung kommt in Schritt 3
     return [base_pace_sec] * total_splits
 
 

--- a/backend/app/tests/test_pacing_strategy.py
+++ b/backend/app/tests/test_pacing_strategy.py
@@ -44,6 +44,15 @@ class TestEvenSplit:
         for pace in full_km_paces:
             assert abs(pace - full_km_paces[0]) < 0.5
 
+    def test_hilly_course_all_splits_equal(self) -> None:
+        """Huegelige Strecke: Even Split hat trotzdem gleiche Pace."""
+        result = generate_pacing_strategy(_hm_request(elevation_preset="hilly"))
+
+        paces = [s.target_pace_sec_per_km for s in result.splits]
+        full_km_paces = paces[:-1]
+        for pace in full_km_paces:
+            assert abs(pace - full_km_paces[0]) < 0.5
+
     def test_total_matches_target(self) -> None:
         """Gesamtzeit muss exakt der Zielzeit entsprechen."""
         result = generate_pacing_strategy(_hm_request(elevation_preset="flat"))


### PR DESCRIPTION
## Summary
- Even Split und Effort-Based hatten identische Pace-Werte bei hügeligem Profil
- Höhen-Anpassung (bergauf langsamer, bergab schneller) wird jetzt nur bei `effort_based` angewendet
- Even Split = konstante Pace, Negative Split = progressive Pace — beide ohne Höhenkorrektur

## Test plan
- [x] Neuer Test: `test_hilly_course_all_splits_equal` — Even Split hat gleiche Pace auf hügeliger Strecke
- [x] Bestehender Test: `test_uphill_slower_than_downhill` — Effort-Based variiert weiterhin korrekt
- [x] Alle 29 Pacing-Tests grün
- [x] Alle 820 Backend-Tests grün
- [x] Ruff, Mypy bestanden

Fixes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)