### PR TITLE
feat: KI-Empfehlung für Pacing-Strategie (#482)

### DIFF
--- a/backend/app/api/v1/pacing.py
+++ b/backend/app/api/v1/pacing.py
@@ -9,16 +9,20 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.api_key_resolver import resolve_claude_api_key
 from app.core.config import settings
 from app.infrastructure.database.models import RaceGoalModel
 from app.infrastructure.database.session import get_db
 from app.infrastructure.external.http_client import ExternalAPIClient
 from app.models.enrichment import wmo_to_label
 from app.models.pacing import (
+    PacingRecommendationRequest,
+    PacingRecommendationResponse,
     PacingRequest,
     PacingResponse,
     RaceDayWeatherResponse,
 )
+from app.services.pacing_recommendation import get_pacing_recommendation
 from app.services.pacing_strategy import generate_pacing_strategy
 
 logger = logging.getLogger(__name__)
@@ -115,6 +119,27 @@ async def get_weather_forecast(
     except (IndexError, TypeError, ValueError) as e:
         logger.warning("Fehler beim Parsen des Wetter-Forecasts: %s", e)
         raise HTTPException(status_code=502, detail="Wetter-Daten nicht parsbar") from e
+
+
+@router.post("/recommend", response_model=PacingRecommendationResponse)
+async def recommend_pacing(
+    body: PacingRecommendationRequest,
+    db: AsyncSession = Depends(get_db),
+) -> PacingRecommendationResponse:
+    """KI-Empfehlung fuer die optimale Pacing-Strategie."""
+    api_key = await resolve_claude_api_key(db)
+    if not api_key:
+        raise HTTPException(status_code=503, detail="Kein KI-Provider verfügbar")
+
+    try:
+        return await get_pacing_recommendation(body, api_key, db)
+    except ValueError as e:
+        raise HTTPException(status_code=502, detail=str(e)) from e
+    except Exception as e:
+        logger.error("Pacing-Empfehlung fehlgeschlagen: %s", e)
+        raise HTTPException(
+            status_code=502, detail="KI-Empfehlung konnte nicht generiert werden"
+        ) from e
 
 
 def _safe_float(value: object) -> float | None:

--- a/backend/app/models/pacing.py
+++ b/backend/app/models/pacing.py
@@ -112,3 +112,27 @@ class RaceDayWeatherResponse(BaseModel):
     precipitation_mm: float
     humidity_percent: float | None = None
     weather_label: str
+
+
+# ---------------------------------------------------------------------------
+# KI-Empfehlung
+# ---------------------------------------------------------------------------
+
+
+class PacingRecommendationRequest(BaseModel):
+    """Request-Schema: KI-Empfehlung fuer Pacing-Strategie."""
+
+    race_name: str | None = Field(None, description="Name des Rennens (z.B. Berlin Halbmarathon)")
+    distance_km: float = Field(..., gt=0, description="Distanz in Kilometern")
+    target_time_seconds: int = Field(..., gt=0, description="Zielzeit in Sekunden")
+    experience_level: Literal["beginner", "intermediate", "advanced"] | None = Field(
+        None, description="Erfahrungslevel"
+    )
+
+
+class PacingRecommendationResponse(BaseModel):
+    """Response-Schema: KI-Empfehlung mit Begruendung."""
+
+    strategy: Literal["even", "negative", "effort_based"]
+    elevation_preset: Literal["flat", "rolling", "hilly"]
+    reasoning: str = Field(description="Begruendung der Empfehlung")

--- a/backend/app/services/pacing_recommendation.py
+++ b/backend/app/services/pacing_recommendation.py
@@ -1,0 +1,117 @@
+"""KI-basierte Pacing-Strategie-Empfehlung via Claude API."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.infrastructure.ai.ai_service import ai_service
+from app.models.pacing import PacingRecommendationRequest, PacingRecommendationResponse
+from app.services.ai_log_service import AICallData, log_ai_call
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM_PROMPT = """\
+Du bist ein erfahrener Lauftrainer und Sportwissenschaftler.
+Der Athlet fragt dich, welche Pacing-Strategie er für ein Rennen wählen soll.
+
+Antworte NUR mit einem JSON-Objekt (kein Markdown, kein Text drumherum):
+{
+  "strategy": "even" | "negative" | "effort_based",
+  "elevation_preset": "flat" | "rolling" | "hilly",
+  "reasoning": "<2-3 Sätze Begründung auf Deutsch>"
+}
+
+Regeln für die Empfehlung:
+- even (Gleichmäßig): Gut für Anfänger und flache Strecken. Einfachste Strategie.
+- negative (Negative Splits): Für erfahrene Läufer. Konservativer Start, starkes Finish.
+- effort_based (Konstanter Effort): Für hügelige Strecken. Pace variiert, Belastung gleich.
+
+Höhenprofil:
+- flat: Flache Strecken (z.B. Berlin, Hamburg, Amsterdam)
+- rolling: Leicht wellige Strecken (z.B. Frankfurt, Köln)
+- hilly: Hügelige Strecken (z.B. Zürich, Jena)
+
+Berücksichtige:
+- Bekannte Rennstrecken und deren Profile
+- Erfahrungslevel des Athleten
+- Ambitionsniveau (Pace zur Distanz)
+"""
+
+
+async def get_pacing_recommendation(
+    request: PacingRecommendationRequest,
+    api_key: str,
+    db: AsyncSession,
+) -> PacingRecommendationResponse:
+    """Holt eine KI-Empfehlung fuer die Pacing-Strategie."""
+    user_prompt = _build_prompt(request)
+
+    response_text = await ai_service.chat(
+        message=user_prompt,
+        context={"system_prompt": _SYSTEM_PROMPT},
+        api_key=api_key,
+    )
+
+    parsed = _parse_response(response_text)
+
+    await log_ai_call(
+        db,
+        AICallData(
+            use_case="pacing_recommendation",
+            provider=ai_service.get_active_provider() or "unknown",
+            system_prompt=_SYSTEM_PROMPT,
+            user_prompt=user_prompt,
+            raw_response=response_text,
+            parsed_ok=parsed is not None,
+        ),
+    )
+
+    if not parsed:
+        raise ValueError("KI-Antwort konnte nicht verarbeitet werden")
+
+    return parsed
+
+
+def _build_prompt(request: PacingRecommendationRequest) -> str:
+    """Baut den User-Prompt fuer die KI-Empfehlung."""
+    pace_sec = request.target_time_seconds / request.distance_km
+    pace_min = int(pace_sec // 60)
+    pace_s = int(pace_sec % 60)
+
+    hours = request.target_time_seconds // 3600
+    mins = (request.target_time_seconds % 3600) // 60
+    secs = request.target_time_seconds % 60
+    time_str = f"{hours}:{mins:02d}:{secs:02d}" if hours else f"{mins}:{secs:02d}"
+
+    parts = [
+        f"Distanz: {request.distance_km} km",
+        f"Zielzeit: {time_str} (Pace: {pace_min}:{pace_s:02d}/km)",
+    ]
+    if request.race_name:
+        parts.insert(0, f"Rennen: {request.race_name}")
+    if request.experience_level:
+        labels = {
+            "beginner": "Anfänger",
+            "intermediate": "Fortgeschritten",
+            "advanced": "Erfahren",
+        }
+        parts.append(f"Erfahrung: {labels.get(request.experience_level, request.experience_level)}")
+
+    return "\n".join(parts)
+
+
+def _parse_response(text: str) -> PacingRecommendationResponse | None:
+    """Parst die KI-Antwort als JSON."""
+    cleaned = text.strip()
+    if cleaned.startswith("```"):
+        cleaned = cleaned.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
+
+    try:
+        data = json.loads(cleaned)
+        return PacingRecommendationResponse(**data)
+    except (json.JSONDecodeError, ValueError):
+        logger.warning("KI-Antwort nicht als JSON parsbar: %s", text[:200])
+        return None

--- a/frontend/src/api/pacing.ts
+++ b/frontend/src/api/pacing.ts
@@ -80,6 +80,29 @@ export async function generatePacing(params: PacingRequest): Promise<PacingRespo
   return response.data;
 }
 
+export interface PacingRecommendationRequest {
+  race_name?: string | null;
+  distance_km: number;
+  target_time_seconds: number;
+  experience_level?: 'beginner' | 'intermediate' | 'advanced' | null;
+}
+
+export interface PacingRecommendationResponse {
+  strategy: 'even' | 'negative' | 'effort_based';
+  elevation_preset: 'flat' | 'rolling' | 'hilly';
+  reasoning: string;
+}
+
+export async function getPacingRecommendation(
+  params: PacingRecommendationRequest,
+): Promise<PacingRecommendationResponse> {
+  const response = await apiClient.post<PacingRecommendationResponse>(
+    '/api/v1/pacing/recommend',
+    params,
+  );
+  return response.data;
+}
+
 export async function getWeatherForecast(
   lat: number,
   lng: number,

--- a/frontend/src/components/pacing/PacingForm.tsx
+++ b/frontend/src/components/pacing/PacingForm.tsx
@@ -2,8 +2,9 @@ import { useState, useEffect } from 'react';
 import { Button, Label, Select, Alert, AlertDescription } from '@nordlig/components';
 import { Play } from 'lucide-react';
 import type { RaceGoal } from '@/api/goals';
-import type { PacingRequest } from '@/api/pacing';
+import type { PacingRequest, PacingRecommendationResponse } from '@/api/pacing';
 import { DistanceTimeInputs } from './DistanceTimeInputs';
+import { StrategyInputs } from './StrategyInputs';
 import { WeatherInputs } from './WeatherInputs';
 
 interface PacingFormProps {
@@ -14,18 +15,6 @@ interface PacingFormProps {
 
 type Strategy = 'even' | 'negative' | 'effort_based';
 type ElevationPreset = 'flat' | 'rolling' | 'hilly';
-
-const STRATEGY_OPTIONS = [
-  { value: 'even', label: 'Gleichmäßig (Even Split)' },
-  { value: 'negative', label: 'Negative Splits' },
-  { value: 'effort_based', label: 'Effort-Based (konstante Belastung)' },
-];
-
-const ELEVATION_OPTIONS = [
-  { value: 'flat', label: 'Flach' },
-  { value: 'rolling', label: 'Wellig (~15m/km)' },
-  { value: 'hilly', label: 'Hügelig (~30m/km)' },
-];
 
 function usePacingForm(goals: RaceGoal[]) {
   const [goalId, setGoalId] = useState<number | null>(null);
@@ -38,17 +27,26 @@ function usePacingForm(goals: RaceGoal[]) {
   const [temperature, setTemperature] = useState('');
   const [windSpeed, setWindSpeed] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [raceName, setRaceName] = useState('');
 
   useEffect(() => {
     if (!goalId) return;
     const goal = goals.find((g) => g.id === goalId);
     if (!goal) return;
     setDistance(String(goal.distance_km));
+    setRaceName(goal.title);
     const secs = goal.target_time_seconds;
     setTimeH(String(Math.floor(secs / 3600)));
     setTimeM(String(Math.floor((secs % 3600) / 60)));
     setTimeS(String(secs % 60));
   }, [goalId, goals]);
+
+  const getTimeSeconds = (): number => {
+    const h = parseInt(timeH || '0', 10);
+    const m = parseInt(timeM || '0', 10);
+    const s = parseInt(timeS || '0', 10);
+    return h * 3600 + m * 60 + s;
+  };
 
   const validate = (): PacingRequest | null => {
     setError(null);
@@ -57,10 +55,7 @@ function usePacingForm(goals: RaceGoal[]) {
       setError('Bitte eine gültige Distanz eingeben.');
       return null;
     }
-    const h = parseInt(timeH || '0', 10);
-    const m = parseInt(timeM || '0', 10);
-    const s = parseInt(timeS || '0', 10);
-    const totalSec = h * 3600 + m * 60 + s;
+    const totalSec = getTimeSeconds();
     if (totalSec <= 0) {
       setError('Bitte eine gültige Zielzeit eingeben.');
       return null;
@@ -99,12 +94,15 @@ function usePacingForm(goals: RaceGoal[]) {
     windSpeed,
     setWindSpeed,
     error,
+    raceName,
+    getTimeSeconds,
     validate,
   };
 }
 
 export function PacingForm({ goals, loading, onGenerate }: PacingFormProps) {
   const form = usePacingForm(goals);
+  const [reasoning, setReasoning] = useState<string | null>(null);
   const activeGoals = goals.filter((g) => g.is_active);
   const goalOptions = [
     { value: '', label: 'Manuell eingeben' },
@@ -114,9 +112,10 @@ export function PacingForm({ goals, loading, onGenerate }: PacingFormProps) {
     })),
   ];
 
-  const handleSubmit = () => {
-    const params = form.validate();
-    if (params) onGenerate(params);
+  const handleRecommendation = (rec: PacingRecommendationResponse) => {
+    form.setStrategy(rec.strategy);
+    form.setElevationPreset(rec.elevation_preset);
+    setReasoning(rec.reasoning);
   };
 
   return (
@@ -143,28 +142,19 @@ export function PacingForm({ goals, loading, onGenerate }: PacingFormProps) {
         onTimeSChange={form.setTimeS}
       />
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <div>
-          <Label>Strategie</Label>
-          <Select
-            options={STRATEGY_OPTIONS}
-            value={form.strategy}
-            onChange={(val) => {
-              if (val) form.setStrategy(val as Strategy);
-            }}
-          />
-        </div>
-        <div>
-          <Label>Höhenprofil</Label>
-          <Select
-            options={ELEVATION_OPTIONS}
-            value={form.elevationPreset}
-            onChange={(val) => {
-              if (val) form.setElevationPreset(val as ElevationPreset);
-            }}
-          />
-        </div>
-      </div>
+      <StrategyInputs
+        strategy={form.strategy}
+        elevationPreset={form.elevationPreset}
+        raceName={form.raceName}
+        distanceKm={parseFloat(form.distance) || null}
+        targetTimeSeconds={form.getTimeSeconds() || null}
+        reasoning={reasoning}
+        disabled={loading}
+        onStrategyChange={form.setStrategy}
+        onElevationChange={form.setElevationPreset}
+        onRecommendation={handleRecommendation}
+        onReasoningClose={() => setReasoning(null)}
+      />
 
       <WeatherInputs
         temperature={form.temperature}
@@ -179,7 +169,14 @@ export function PacingForm({ goals, loading, onGenerate }: PacingFormProps) {
         </Alert>
       )}
 
-      <Button variant="primary" onClick={handleSubmit} disabled={loading}>
+      <Button
+        variant="primary"
+        onClick={() => {
+          const p = form.validate();
+          if (p) onGenerate(p);
+        }}
+        disabled={loading}
+      >
         {loading ? (
           'Berechne…'
         ) : (

--- a/frontend/src/components/pacing/RecommendButton.tsx
+++ b/frontend/src/components/pacing/RecommendButton.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { Button, Spinner, Alert, AlertDescription, useToast } from '@nordlig/components';
+import { Sparkles } from 'lucide-react';
+import { getPacingRecommendation } from '@/api/pacing';
+import type { PacingRecommendationResponse } from '@/api/pacing';
+
+interface RecommendButtonProps {
+  raceName: string;
+  distanceKm: number | null;
+  targetTimeSeconds: number | null;
+  disabled?: boolean;
+  onRecommendation: (rec: PacingRecommendationResponse) => void;
+}
+
+export function RecommendButton({
+  raceName,
+  distanceKm,
+  targetTimeSeconds,
+  disabled,
+  onRecommendation,
+}: RecommendButtonProps) {
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(false);
+
+  const handleClick = async () => {
+    if (!distanceKm || distanceKm <= 0 || !targetTimeSeconds || targetTimeSeconds <= 0) {
+      toast({ title: 'Bitte zuerst Distanz und Zielzeit eingeben', variant: 'error' });
+      return;
+    }
+    setLoading(true);
+    try {
+      const rec = await getPacingRecommendation({
+        race_name: raceName || null,
+        distance_km: distanceKm,
+        target_time_seconds: targetTimeSeconds,
+      });
+      onRecommendation(rec);
+    } catch {
+      toast({ title: 'KI-Empfehlung fehlgeschlagen', variant: 'error' });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Button variant="ghost" size="sm" onClick={handleClick} disabled={disabled || loading}>
+      {loading ? <Spinner size="sm" aria-hidden="true" /> : <Sparkles size={14} />}
+      KI-Empfehlung
+    </Button>
+  );
+}
+
+export function RecommendReasoning({
+  reasoning,
+  onClose,
+}: {
+  reasoning: string;
+  onClose: () => void;
+}) {
+  return (
+    <Alert variant="info" closeable onClose={onClose}>
+      <AlertDescription>
+        <strong>KI-Empfehlung:</strong> {reasoning}
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/frontend/src/components/pacing/StrategyInputs.tsx
+++ b/frontend/src/components/pacing/StrategyInputs.tsx
@@ -1,0 +1,86 @@
+import { Label, Select } from '@nordlig/components';
+import type { PacingRecommendationResponse } from '@/api/pacing';
+import { RecommendButton, RecommendReasoning } from './RecommendButton';
+
+type Strategy = 'even' | 'negative' | 'effort_based';
+type ElevationPreset = 'flat' | 'rolling' | 'hilly';
+
+const STRATEGY_OPTIONS = [
+  { value: 'even', label: 'Gleichmäßig (Even Split)' },
+  { value: 'negative', label: 'Negative Splits' },
+  { value: 'effort_based', label: 'Effort-Based (konstante Belastung)' },
+];
+
+const ELEVATION_OPTIONS = [
+  { value: 'flat', label: 'Flach' },
+  { value: 'rolling', label: 'Wellig (~15m/km)' },
+  { value: 'hilly', label: 'Hügelig (~30m/km)' },
+];
+
+interface StrategyInputsProps {
+  strategy: Strategy;
+  elevationPreset: ElevationPreset;
+  raceName: string;
+  distanceKm: number | null;
+  targetTimeSeconds: number | null;
+  reasoning: string | null;
+  disabled?: boolean;
+  onStrategyChange: (val: Strategy) => void;
+  onElevationChange: (val: ElevationPreset) => void;
+  onRecommendation: (rec: PacingRecommendationResponse) => void;
+  onReasoningClose: () => void;
+}
+
+export function StrategyInputs({
+  strategy,
+  elevationPreset,
+  raceName,
+  distanceKm,
+  targetTimeSeconds,
+  reasoning,
+  disabled,
+  onStrategyChange,
+  onElevationChange,
+  onRecommendation,
+  onReasoningClose,
+}: StrategyInputsProps) {
+  return (
+    <>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <div className="flex items-center justify-between">
+            <Label>Strategie</Label>
+            <RecommendButton
+              raceName={raceName}
+              distanceKm={distanceKm}
+              targetTimeSeconds={targetTimeSeconds}
+              disabled={disabled}
+              onRecommendation={onRecommendation}
+            />
+          </div>
+          <Select
+            options={STRATEGY_OPTIONS}
+            value={strategy}
+            onChange={(val) => {
+              if (val) onStrategyChange(val as Strategy);
+              onReasoningClose();
+            }}
+          />
+        </div>
+        <div>
+          <Label>Höhenprofil</Label>
+          <Select
+            options={ELEVATION_OPTIONS}
+            value={elevationPreset}
+            onChange={(val) => {
+              if (val) onElevationChange(val as ElevationPreset);
+              onReasoningClose();
+            }}
+          />
+        </div>
+      </div>
+
+      {reasoning && <RecommendReasoning reasoning={reasoning} onClose={onReasoningClose} />}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Neuer Button „KI-Empfehlung" neben dem Strategie-Dropdown im Pacing-Formular
- Claude analysiert Rennname, Distanz und Zielzeit → empfiehlt Strategie + Höhenprofil mit Begründung
- Backend: `POST /pacing/recommend` Endpoint mit AI-Logging
- Frontend: RecommendButton, StrategyInputs als extrahierte Komponenten

## Test plan
- [x] Backend: 820 Tests grün (Ruff, Mypy, Pytest)
- [x] Frontend: 187 Tests grün (ESLint, Prettier, TSC, Vitest)
- [ ] Manuell: KI-Empfehlung mit verschiedenen Rennen testen (Berlin HM = flach, Zürich = hügelig)
- [ ] Manuell: Empfehlung übernehmen → Strategie generieren → korrekte Werte

Fixes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)