### PR TITLE
feat: GPX-Import für eigenes Streckenprofil (#481)

### DIFF
--- a/backend/app/api/v1/pacing.py
+++ b/backend/app/api/v1/pacing.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from datetime import date
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -16,12 +16,14 @@ from app.infrastructure.database.session import get_db
 from app.infrastructure.external.http_client import ExternalAPIClient
 from app.models.enrichment import wmo_to_label
 from app.models.pacing import (
+    ElevationSegment,
     PacingRecommendationRequest,
     PacingRecommendationResponse,
     PacingRequest,
     PacingResponse,
     RaceDayWeatherResponse,
 )
+from app.services.gpx_elevation_parser import parse_gpx_elevation
 from app.services.pacing_recommendation import get_pacing_recommendation
 from app.services.pacing_strategy import generate_pacing_strategy
 
@@ -140,6 +142,25 @@ async def recommend_pacing(
         raise HTTPException(
             status_code=502, detail="KI-Empfehlung konnte nicht generiert werden"
         ) from e
+
+
+@router.post("/parse-gpx", response_model=list[ElevationSegment])
+async def parse_gpx(file: UploadFile) -> list[ElevationSegment]:
+    """Parst eine GPX-Datei und gibt pro-km Höhenprofil zurück."""
+    if not file.filename or not file.filename.lower().endswith(".gpx"):
+        raise HTTPException(status_code=400, detail="Nur GPX-Dateien werden unterstützt")
+
+    content = await file.read()
+    if len(content) > 10 * 1024 * 1024:  # 10 MB Limit
+        raise HTTPException(status_code=400, detail="Datei zu groß (max. 10 MB)")
+
+    try:
+        return parse_gpx_elevation(content)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        logger.error("GPX-Parsing fehlgeschlagen: %s", e)
+        raise HTTPException(status_code=400, detail="GPX-Datei konnte nicht gelesen werden") from e
 
 
 def _safe_float(value: object) -> float | None:

--- a/backend/app/services/gpx_elevation_parser.py
+++ b/backend/app/services/gpx_elevation_parser.py
@@ -1,0 +1,114 @@
+"""GPX-Datei parsen und pro-km Höhenprofil berechnen."""
+
+from __future__ import annotations
+
+import math
+import xml.etree.ElementTree as ET
+
+from app.models.pacing import ElevationSegment
+
+# GPX XML Namespaces
+_GPX_NS = {
+    "": "http://www.topografix.com/GPX/1/1",
+    "gpx10": "http://www.topografix.com/GPX/1/0",
+}
+
+
+def parse_gpx_elevation(gpx_content: bytes) -> list[ElevationSegment]:
+    """Parst eine GPX-Datei und berechnet pro-km Höhengewinn/-verlust.
+
+    Returns:
+        Liste von ElevationSegment, ein Eintrag pro Kilometer.
+    """
+    points = _extract_trackpoints(gpx_content)
+    if len(points) < 2:
+        raise ValueError("GPX-Datei enthält zu wenige Trackpunkte")
+
+    return _calculate_km_segments(points)
+
+
+def _extract_trackpoints(
+    gpx_content: bytes,
+) -> list[tuple[float, float, float]]:
+    """Extrahiert (lat, lon, elevation) Tupel aus GPX-Trackpunkten."""
+    root = ET.fromstring(gpx_content)  # noqa: S314
+    points: list[tuple[float, float, float]] = []
+
+    # GPX 1.1 und 1.0 Namespaces probieren
+    for ns_prefix in ["", "gpx10"]:
+        ns = _GPX_NS[ns_prefix]
+        prefix = f"{{{ns}}}" if ns else ""
+
+        for trkpt in root.iter(f"{prefix}trkpt"):
+            lat = float(trkpt.get("lat", "0"))
+            lon = float(trkpt.get("lon", "0"))
+            ele_elem = trkpt.find(f"{prefix}ele")
+            ele = float(ele_elem.text) if ele_elem is not None and ele_elem.text else 0.0
+            points.append((lat, lon, ele))
+
+        if points:
+            break
+
+    return points
+
+
+def _haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Berechnet die Distanz zwischen zwei GPS-Punkten in Metern."""
+    r = 6_371_000  # Erdradius in Metern
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlam = math.radians(lon2 - lon1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlam / 2) ** 2
+    return 2 * r * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
+def _calculate_km_segments(
+    points: list[tuple[float, float, float]],
+) -> list[ElevationSegment]:
+    """Berechnet pro-km Höhengewinn und -verlust aus Trackpunkten."""
+    segments: list[ElevationSegment] = []
+    cum_dist = 0.0
+    km_gain = 0.0
+    km_loss = 0.0
+    km_num = 1
+
+    for i in range(1, len(points)):
+        lat1, lon1, ele1 = points[i - 1]
+        lat2, lon2, ele2 = points[i]
+
+        dist = _haversine_m(lat1, lon1, lat2, lon2)
+        ele_diff = ele2 - ele1
+
+        # Rauschen filtern: nur Änderungen > 1m zählen
+        if ele_diff > 1.0:
+            km_gain += ele_diff
+        elif ele_diff < -1.0:
+            km_loss += abs(ele_diff)
+
+        cum_dist += dist
+
+        # Kilometer-Grenze erreicht
+        while cum_dist >= 1000.0:
+            segments.append(
+                ElevationSegment(
+                    km=km_num,
+                    gain_m=round(km_gain, 1),
+                    loss_m=round(km_loss, 1),
+                )
+            )
+            km_num += 1
+            cum_dist -= 1000.0
+            km_gain = 0.0
+            km_loss = 0.0
+
+    # Letzten Abschnitt hinzufügen (wenn > 50m übrig)
+    if cum_dist > 50.0:
+        segments.append(
+            ElevationSegment(
+                km=km_num,
+                gain_m=round(km_gain, 1),
+                loss_m=round(km_loss, 1),
+            )
+        )
+
+    return segments

--- a/backend/app/tests/test_gpx_elevation_parser.py
+++ b/backend/app/tests/test_gpx_elevation_parser.py
@@ -1,0 +1,94 @@
+"""Tests fuer den GPX-Elevation-Parser."""
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from app.services.gpx_elevation_parser import parse_gpx_elevation
+
+# ---------------------------------------------------------------------------
+# Test-GPX Daten
+# ---------------------------------------------------------------------------
+
+_SIMPLE_GPX = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+  <trk><trkseg>
+    <trkpt lat="52.5200" lon="13.4050"><ele>34.0</ele></trkpt>
+    <trkpt lat="52.5290" lon="13.4050"><ele>36.0</ele></trkpt>
+    <trkpt lat="52.5380" lon="13.4050"><ele>33.0</ele></trkpt>
+    <trkpt lat="52.5470" lon="13.4050"><ele>35.0</ele></trkpt>
+  </trkseg></trk>
+</gpx>
+"""
+
+_FLAT_3KM_GPX = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+  <trk><trkseg>
+    <trkpt lat="52.5200" lon="13.4050"><ele>34.0</ele></trkpt>
+    <trkpt lat="52.5290" lon="13.4050"><ele>34.0</ele></trkpt>
+    <trkpt lat="52.5380" lon="13.4050"><ele>34.0</ele></trkpt>
+    <trkpt lat="52.5470" lon="13.4050"><ele>34.0</ele></trkpt>
+    <trkpt lat="52.5560" lon="13.4050"><ele>34.0</ele></trkpt>
+  </trkseg></trk>
+</gpx>
+"""
+
+
+class TestGpxElevationParser:
+    """Tests fuer parse_gpx_elevation."""
+
+    def test_returns_segments(self) -> None:
+        """Gibt eine nicht-leere Liste von ElevationSegments zurueck."""
+        segments = parse_gpx_elevation(_SIMPLE_GPX)
+        assert len(segments) > 0
+
+    def test_segments_have_km_numbers(self) -> None:
+        """Jeder Segment hat eine aufsteigende km-Nummer."""
+        segments = parse_gpx_elevation(_SIMPLE_GPX)
+        for i, seg in enumerate(segments):
+            assert seg.km == i + 1
+
+    def test_flat_course_no_elevation(self) -> None:
+        """Flache Strecke: kein Hoehengewinn/-verlust."""
+        segments = parse_gpx_elevation(_FLAT_3KM_GPX)
+        for seg in segments:
+            assert seg.gain_m == 0.0
+            assert seg.loss_m == 0.0
+
+    def test_gain_and_loss_are_non_negative(self) -> None:
+        """Gain und Loss sind immer >= 0."""
+        segments = parse_gpx_elevation(_SIMPLE_GPX)
+        for seg in segments:
+            assert seg.gain_m >= 0.0
+            assert seg.loss_m >= 0.0
+
+    def test_too_few_points_raises(self) -> None:
+        """Weniger als 2 Trackpunkte wirft ValueError."""
+        gpx = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+  <trk><trkseg>
+    <trkpt lat="52.5200" lon="13.4050"><ele>34.0</ele></trkpt>
+  </trkseg></trk>
+</gpx>
+"""
+        with pytest.raises(ValueError, match="zu wenige"):
+            parse_gpx_elevation(gpx)
+
+    def test_empty_gpx_raises(self) -> None:
+        """Leere GPX-Datei ohne Trackpunkte wirft ValueError."""
+        gpx = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+  <trk><trkseg></trkseg></trk>
+</gpx>
+"""
+        with pytest.raises(ValueError, match="zu wenige"):
+            parse_gpx_elevation(gpx)
+
+    def test_invalid_xml_raises(self) -> None:
+        """Ungueltige XML-Datei wirft ET.ParseError."""
+        with pytest.raises(ET.ParseError):
+            parse_gpx_elevation(b"this is not xml")

--- a/frontend/src/api/pacing.ts
+++ b/frontend/src/api/pacing.ts
@@ -103,6 +103,13 @@ export async function getPacingRecommendation(
   return response.data;
 }
 
+export async function parseGpxElevation(file: File): Promise<ElevationSegment[]> {
+  const formData = new FormData();
+  formData.append('file', file);
+  const response = await apiClient.post<ElevationSegment[]>('/api/v1/pacing/parse-gpx', formData);
+  return response.data;
+}
+
 export async function getWeatherForecast(
   lat: number,
   lng: number,

--- a/frontend/src/components/pacing/ElevationChart.tsx
+++ b/frontend/src/components/pacing/ElevationChart.tsx
@@ -1,0 +1,61 @@
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, ReferenceLine } from 'recharts';
+import type { ElevationSegment } from '@/api/pacing';
+
+interface ElevationChartProps {
+  segments: ElevationSegment[];
+}
+
+export function ElevationChart({ segments }: ElevationChartProps) {
+  const totalGain = segments.reduce((sum, s) => sum + s.gain_m, 0);
+  const totalLoss = segments.reduce((sum, s) => sum + s.loss_m, 0);
+  const chartData = segments.map((s) => ({
+    km: `${s.km}`,
+    gain: s.gain_m,
+    loss: -s.loss_m,
+  }));
+
+  return (
+    <div className="space-y-2">
+      <div className="flex gap-4 text-xs text-[var(--color-text-muted)]">
+        <span>
+          Anstieg: <strong>{Math.round(totalGain)}m</strong>
+        </span>
+        <span>
+          Abstieg: <strong>{Math.round(totalLoss)}m</strong>
+        </span>
+        <span>{segments.length} km</span>
+      </div>
+      <div className="h-32">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={chartData} barGap={0}>
+            <XAxis
+              dataKey="km"
+              tick={{ fontSize: 10, fill: 'var(--color-text-muted)' }}
+              interval={Math.max(0, Math.floor(chartData.length / 10) - 1)}
+            />
+            <YAxis
+              tick={{ fontSize: 10, fill: 'var(--color-text-muted)' }}
+              width={30}
+              tickFormatter={(v: number) => `${Math.abs(v)}`}
+            />
+            <Tooltip
+              formatter={(value, name) => [
+                `${Math.abs(Number(value)).toFixed(1)}m`,
+                name === 'gain' ? 'Anstieg' : 'Abstieg',
+              ]}
+              labelFormatter={(label) => `km ${label}`}
+              contentStyle={{
+                fontSize: 12,
+                borderRadius: 'var(--radius-component-sm)',
+                border: '1px solid var(--color-border-muted)',
+              }}
+            />
+            <ReferenceLine y={0} stroke="var(--color-border-muted)" />
+            <Bar dataKey="gain" fill="var(--color-text-success)" radius={[2, 2, 0, 0]} />
+            <Bar dataKey="loss" fill="var(--color-text-error)" radius={[0, 0, 2, 2]} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/pacing/ElevationProfile.tsx
+++ b/frontend/src/components/pacing/ElevationProfile.tsx
@@ -1,0 +1,78 @@
+import { useRef } from 'react';
+import { Button, useToast } from '@nordlig/components';
+import { Upload, X } from 'lucide-react';
+import type { ElevationSegment } from '@/api/pacing';
+import { parseGpxElevation } from '@/api/pacing';
+import { ElevationChart } from './ElevationChart';
+
+interface ElevationProfileProps {
+  segments: ElevationSegment[] | null;
+  onSegmentsChange: (segments: ElevationSegment[] | null) => void;
+  disabled?: boolean;
+}
+
+export function ElevationProfile({ segments, onSegmentsChange, disabled }: ElevationProfileProps) {
+  const { toast } = useToast();
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    try {
+      const parsed = await parseGpxElevation(file);
+      if (parsed.length === 0) {
+        toast({ title: 'Keine Höhendaten in der GPX-Datei gefunden', variant: 'error' });
+        return;
+      }
+      onSegmentsChange(parsed);
+    } catch {
+      toast({ title: 'GPX-Datei konnte nicht gelesen werden', variant: 'error' });
+    } finally {
+      if (fileRef.current) fileRef.current.value = '';
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-[var(--color-text-base)]">
+          Streckenprofil (GPX)
+        </span>
+        <div className="flex items-center gap-2">
+          {segments && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => onSegmentsChange(null)}
+              disabled={disabled}
+            >
+              <X size={14} />
+              Entfernen
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => fileRef.current?.click()}
+            disabled={disabled}
+          >
+            <Upload size={14} />
+            GPX hochladen
+          </Button>
+        </div>
+      </div>
+
+      <input
+        ref={fileRef}
+        type="file"
+        accept=".gpx"
+        onChange={handleFileChange}
+        className="hidden"
+        aria-label="GPX-Datei hochladen"
+      />
+
+      {segments && <ElevationChart segments={segments} />}
+    </div>
+  );
+}

--- a/frontend/src/components/pacing/PacingForm.tsx
+++ b/frontend/src/components/pacing/PacingForm.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { Button, Label, Select, Alert, AlertDescription } from '@nordlig/components';
 import { Play } from 'lucide-react';
 import type { RaceGoal } from '@/api/goals';
-import type { PacingRequest, PacingRecommendationResponse } from '@/api/pacing';
+import type { ElevationSegment, PacingRequest, PacingRecommendationResponse } from '@/api/pacing';
 import { DistanceTimeInputs } from './DistanceTimeInputs';
 import { StrategyInputs } from './StrategyInputs';
 import { WeatherInputs } from './WeatherInputs';
@@ -28,6 +28,7 @@ function usePacingForm(goals: RaceGoal[]) {
   const [windSpeed, setWindSpeed] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [raceName, setRaceName] = useState('');
+  const [elevationSegments, setElevationSegments] = useState<ElevationSegment[] | null>(null);
 
   useEffect(() => {
     if (!goalId) return;
@@ -64,7 +65,8 @@ function usePacingForm(goals: RaceGoal[]) {
       target_time_seconds: totalSec,
       distance_km: dist,
       strategy,
-      elevation_preset: elevationPreset,
+      elevation_preset: elevationSegments ? null : elevationPreset,
+      elevation_segments: elevationSegments,
       goal_id: goalId,
     };
     const temp = parseFloat(temperature);
@@ -95,6 +97,8 @@ function usePacingForm(goals: RaceGoal[]) {
     setWindSpeed,
     error,
     raceName,
+    elevationSegments,
+    setElevationSegments,
     getTimeSeconds,
     validate,
   };
@@ -145,6 +149,7 @@ export function PacingForm({ goals, loading, onGenerate }: PacingFormProps) {
       <StrategyInputs
         strategy={form.strategy}
         elevationPreset={form.elevationPreset}
+        elevationSegments={form.elevationSegments}
         raceName={form.raceName}
         distanceKm={parseFloat(form.distance) || null}
         targetTimeSeconds={form.getTimeSeconds() || null}
@@ -152,6 +157,7 @@ export function PacingForm({ goals, loading, onGenerate }: PacingFormProps) {
         disabled={loading}
         onStrategyChange={form.setStrategy}
         onElevationChange={form.setElevationPreset}
+        onElevationSegmentsChange={form.setElevationSegments}
         onRecommendation={handleRecommendation}
         onReasoningClose={() => setReasoning(null)}
       />

--- a/frontend/src/components/pacing/StrategyInputs.tsx
+++ b/frontend/src/components/pacing/StrategyInputs.tsx
@@ -1,5 +1,6 @@
 import { Label, Select } from '@nordlig/components';
-import type { PacingRecommendationResponse } from '@/api/pacing';
+import type { ElevationSegment, PacingRecommendationResponse } from '@/api/pacing';
+import { ElevationProfile } from './ElevationProfile';
 import { RecommendButton, RecommendReasoning } from './RecommendButton';
 
 type Strategy = 'even' | 'negative' | 'effort_based';
@@ -20,6 +21,7 @@ const ELEVATION_OPTIONS = [
 interface StrategyInputsProps {
   strategy: Strategy;
   elevationPreset: ElevationPreset;
+  elevationSegments: ElevationSegment[] | null;
   raceName: string;
   distanceKm: number | null;
   targetTimeSeconds: number | null;
@@ -27,6 +29,7 @@ interface StrategyInputsProps {
   disabled?: boolean;
   onStrategyChange: (val: Strategy) => void;
   onElevationChange: (val: ElevationPreset) => void;
+  onElevationSegmentsChange: (segments: ElevationSegment[] | null) => void;
   onRecommendation: (rec: PacingRecommendationResponse) => void;
   onReasoningClose: () => void;
 }
@@ -34,6 +37,7 @@ interface StrategyInputsProps {
 export function StrategyInputs({
   strategy,
   elevationPreset,
+  elevationSegments,
   raceName,
   distanceKm,
   targetTimeSeconds,
@@ -41,6 +45,7 @@ export function StrategyInputs({
   disabled,
   onStrategyChange,
   onElevationChange,
+  onElevationSegmentsChange,
   onRecommendation,
   onReasoningClose,
 }: StrategyInputsProps) {
@@ -74,11 +79,19 @@ export function StrategyInputs({
             value={elevationPreset}
             onChange={(val) => {
               if (val) onElevationChange(val as ElevationPreset);
+              onElevationSegmentsChange(null);
               onReasoningClose();
             }}
+            disabled={!!elevationSegments}
           />
         </div>
       </div>
+
+      <ElevationProfile
+        segments={elevationSegments}
+        onSegmentsChange={onElevationSegmentsChange}
+        disabled={disabled}
+      />
 
       {reasoning && <RecommendReasoning reasoning={reasoning} onClose={onReasoningClose} />}
     </>


### PR DESCRIPTION
## Summary
- GPX-Datei hochladen → reales Streckenprofil für Pacing-Strategie
- Pro-km Höhengewinn/-verlust wird berechnet (Haversine-Distanz, 1m-Rauschfilter)
- Balkendiagramm zeigt Anstieg (grün) und Abstieg (rot) pro km
- Höhenprofil-Preset wird deaktiviert wenn GPX-Daten vorhanden
- Backend: GPX-Parser ohne externe Dependencies (xml.etree)

## Test plan
- [x] 7 neue GPX-Parser Backend-Tests (flat, gain/loss, edge cases)
- [x] 827 Backend-Tests grün (Ruff, Mypy, Pytest)
- [x] 187 Frontend-Tests grün (ESLint, Prettier, TSC, Vitest)
- [ ] Manuell: GPX-Datei hochladen → Chart prüfen
- [ ] Manuell: Effort-Based mit GPX → km-genaue Pace-Anpassung prüfen

Fixes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)