### PR TITLE
fix: GPX-Parser unterstützt Waypoints und Routenpunkte (#481)

### DIFF
--- a/backend/app/services/gpx_elevation_parser.py
+++ b/backend/app/services/gpx_elevation_parser.py
@@ -20,17 +20,21 @@ def parse_gpx_elevation(gpx_content: bytes) -> list[ElevationSegment]:
     Returns:
         Liste von ElevationSegment, ein Eintrag pro Kilometer.
     """
-    points = _extract_trackpoints(gpx_content)
+    points = _extract_points(gpx_content)
     if len(points) < 2:
         raise ValueError("GPX-Datei enthält zu wenige Trackpunkte")
 
     return _calculate_km_segments(points)
 
 
-def _extract_trackpoints(
+def _extract_points(
     gpx_content: bytes,
 ) -> list[tuple[float, float, float]]:
-    """Extrahiert (lat, lon, elevation) Tupel aus GPX-Trackpunkten."""
+    """Extrahiert (lat, lon, elevation) Tupel aus GPX-Daten.
+
+    Unterstützt Trackpunkte (<trkpt>), Routenpunkte (<rtept>) und
+    Wegpunkte (<wpt>) — in dieser Priorität.
+    """
     root = ET.fromstring(gpx_content)  # noqa: S314
     points: list[tuple[float, float, float]] = []
 
@@ -39,15 +43,17 @@ def _extract_trackpoints(
         ns = _GPX_NS[ns_prefix]
         prefix = f"{{{ns}}}" if ns else ""
 
-        for trkpt in root.iter(f"{prefix}trkpt"):
-            lat = float(trkpt.get("lat", "0"))
-            lon = float(trkpt.get("lon", "0"))
-            ele_elem = trkpt.find(f"{prefix}ele")
-            ele = float(ele_elem.text) if ele_elem is not None and ele_elem.text else 0.0
-            points.append((lat, lon, ele))
+        # Priorität: trkpt > rtept > wpt
+        for tag in ["trkpt", "rtept", "wpt"]:
+            for pt in root.iter(f"{prefix}{tag}"):
+                lat = float(pt.get("lat", "0"))
+                lon = float(pt.get("lon", "0"))
+                ele_elem = pt.find(f"{prefix}ele")
+                ele = float(ele_elem.text) if ele_elem is not None and ele_elem.text else 0.0
+                points.append((lat, lon, ele))
 
-        if points:
-            break
+            if points:
+                return points
 
     return points
 

--- a/backend/app/tests/test_gpx_elevation_parser.py
+++ b/backend/app/tests/test_gpx_elevation_parser.py
@@ -35,6 +35,28 @@ _FLAT_3KM_GPX = b"""\
 </gpx>
 """
 
+_WAYPOINT_GPX = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+  <wpt lat="52.5200" lon="13.4050"><ele>34.0</ele></wpt>
+  <wpt lat="52.5290" lon="13.4050"><ele>36.0</ele></wpt>
+  <wpt lat="52.5380" lon="13.4050"><ele>33.0</ele></wpt>
+  <wpt lat="52.5470" lon="13.4050"><ele>35.0</ele></wpt>
+</gpx>
+"""
+
+_ROUTE_GPX = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+  <rte>
+    <rtept lat="52.5200" lon="13.4050"><ele>34.0</ele></rtept>
+    <rtept lat="52.5290" lon="13.4050"><ele>36.0</ele></rtept>
+    <rtept lat="52.5380" lon="13.4050"><ele>33.0</ele></rtept>
+    <rtept lat="52.5470" lon="13.4050"><ele>35.0</ele></rtept>
+  </rte>
+</gpx>
+"""
+
 
 class TestGpxElevationParser:
     """Tests fuer parse_gpx_elevation."""
@@ -87,6 +109,16 @@ class TestGpxElevationParser:
 """
         with pytest.raises(ValueError, match="zu wenige"):
             parse_gpx_elevation(gpx)
+
+    def test_waypoint_gpx_returns_segments(self) -> None:
+        """GPX mit <wpt> Elementen wird korrekt geparst."""
+        segments = parse_gpx_elevation(_WAYPOINT_GPX)
+        assert len(segments) > 0
+
+    def test_route_gpx_returns_segments(self) -> None:
+        """GPX mit <rtept> Elementen wird korrekt geparst."""
+        segments = parse_gpx_elevation(_ROUTE_GPX)
+        assert len(segments) > 0
 
     def test_invalid_xml_raises(self) -> None:
         """Ungueltige XML-Datei wirft ET.ParseError."""


### PR DESCRIPTION
## Summary
- GPX-Parser erkennt jetzt neben `<trkpt>` auch `<wpt>` (Waypoints) und `<rtept>` (Routenpunkte)
- Viele Renn-GPX-Dateien (z.B. Berlin HM "Messpunkte") nutzen Waypoints statt Trackpunkte
- 2 neue Tests für Waypoint- und Routenpunkt-GPX-Dateien

## Test plan
- [x] Bestehende 7 Tests weiterhin grün
- [x] Neuer Test: GPX mit `<wpt>` Elementen wird korrekt geparst
- [x] Neuer Test: GPX mit `<rtept>` Elementen wird korrekt geparst
- [ ] Manuell: Berlin HM GPX-Datei hochladen → Höhenprofil wird angezeigt

🤖 Generated with [Claude Code](https://claude.com/claude-code)