### PR TITLE
fix: GPX-Upload Content-Type auf multipart/form-data (#481)

### DIFF
--- a/frontend/src/api/pacing.ts
+++ b/frontend/src/api/pacing.ts
@@ -106,7 +106,9 @@ export async function getPacingRecommendation(
 export async function parseGpxElevation(file: File): Promise<ElevationSegment[]> {
   const formData = new FormData();
   formData.append('file', file);
-  const response = await apiClient.post<ElevationSegment[]>('/api/v1/pacing/parse-gpx', formData);
+  const response = await apiClient.post<ElevationSegment[]>('/api/v1/pacing/parse-gpx', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
   return response.data;
 }
 


### PR DESCRIPTION
## Summary
- Der `apiClient` hatte `Content-Type: application/json` als Default-Header
- Bei FormData-Uploads (GPX-Datei) wurde dieser Header gesendet statt `multipart/form-data`
- FastAPI konnte die Datei nicht parsen → Fehler-Toast im Frontend
- Fix: Explizit `Content-Type: multipart/form-data` für den GPX-Upload setzen

## Test plan
- [ ] Berlin HM GPX-Datei hochladen → Höhenprofil wird korrekt angezeigt
- [ ] Bestehende API-Calls (JSON) funktionieren weiterhin

🤖 Generated with [Claude Code](https://claude.com/claude-code)