### PR TITLE
feat: Pacing-Empfehlung durch evidenzbasierte Regeln ersetzen

### DIFF
--- a/backend/app/api/v1/pacing.py
+++ b/backend/app/api/v1/pacing.py
@@ -9,7 +9,6 @@ from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.api_key_resolver import resolve_claude_api_key
 from app.core.config import settings
 from app.infrastructure.database.models import RaceGoalModel
 from app.infrastructure.database.session import get_db
@@ -24,7 +23,7 @@ from app.models.pacing import (
     RaceDayWeatherResponse,
 )
 from app.services.gpx_elevation_parser import parse_gpx_elevation
-from app.services.pacing_recommendation import get_pacing_recommendation
+from app.services.pacing_recommendation import recommend_pacing
 from app.services.pacing_strategy import generate_pacing_strategy
 
 logger = logging.getLogger(__name__)
@@ -124,24 +123,11 @@ async def get_weather_forecast(
 
 
 @router.post("/recommend", response_model=PacingRecommendationResponse)
-async def recommend_pacing(
+async def recommend_pacing_endpoint(
     body: PacingRecommendationRequest,
-    db: AsyncSession = Depends(get_db),
 ) -> PacingRecommendationResponse:
-    """KI-Empfehlung fuer die optimale Pacing-Strategie."""
-    api_key = await resolve_claude_api_key(db)
-    if not api_key:
-        raise HTTPException(status_code=503, detail="Kein KI-Provider verfügbar")
-
-    try:
-        return await get_pacing_recommendation(body, api_key, db)
-    except ValueError as e:
-        raise HTTPException(status_code=502, detail=str(e)) from e
-    except Exception as e:
-        logger.error("Pacing-Empfehlung fehlgeschlagen: %s", e)
-        raise HTTPException(
-            status_code=502, detail="KI-Empfehlung konnte nicht generiert werden"
-        ) from e
+    """Evidenzbasierte Empfehlung fuer die optimale Pacing-Strategie."""
+    return recommend_pacing(body)
 
 
 @router.post("/parse-gpx", response_model=list[ElevationSegment])

--- a/backend/app/models/pacing.py
+++ b/backend/app/models/pacing.py
@@ -120,19 +120,28 @@ class RaceDayWeatherResponse(BaseModel):
 
 
 class PacingRecommendationRequest(BaseModel):
-    """Request-Schema: KI-Empfehlung fuer Pacing-Strategie."""
+    """Request-Schema: Evidenzbasierte Pacing-Strategie-Empfehlung."""
 
     race_name: str | None = Field(None, description="Name des Rennens (z.B. Berlin Halbmarathon)")
     distance_km: float = Field(..., gt=0, description="Distanz in Kilometern")
     target_time_seconds: int = Field(..., gt=0, description="Zielzeit in Sekunden")
-    experience_level: Literal["beginner", "intermediate", "advanced"] | None = Field(
-        None, description="Erfahrungslevel"
+    experience_level: Literal["beginner", "intermediate", "advanced"] = Field(
+        ..., description="Erfahrungslevel"
+    )
+    temperature_celsius: float | None = Field(
+        None, description="Erwartete Temperatur am Renntag in Grad Celsius"
+    )
+    elevation_preset: Literal["flat", "rolling", "hilly"] | None = Field(
+        None, description="Manuell gewaehltes Hoehenprofil-Preset"
+    )
+    elevation_segments: list[ElevationSegment] | None = Field(
+        None, description="Hoehenprofil aus GPX-Upload (pro km)"
     )
 
 
 class PacingRecommendationResponse(BaseModel):
-    """Response-Schema: KI-Empfehlung mit Begruendung."""
+    """Response-Schema: Evidenzbasierte Empfehlung mit Begruendung."""
 
     strategy: Literal["even", "negative", "effort_based"]
-    elevation_preset: Literal["flat", "rolling", "hilly"]
-    reasoning: str = Field(description="Begruendung der Empfehlung")
+    elevation_preset: Literal["flat", "rolling", "hilly"] | None
+    reasoning: str = Field(description="Evidenzbasierte Begruendung der Empfehlung")

--- a/backend/app/services/pacing_recommendation.py
+++ b/backend/app/services/pacing_recommendation.py
@@ -1,117 +1,236 @@
-"""KI-basierte Pacing-Strategie-Empfehlung via Claude API."""
+"""Evidenzbasierte Pacing-Strategie-Empfehlung.
+
+Ersetzt die vorherige KI-basierte Empfehlung durch deterministische Regeln.
+Gleiche Inputs liefern immer die gleiche Empfehlung.
+
+Quellen:
+- Systematic Review Pacing Strategies in Marathons (2024, 39 Studien)
+  https://pmc.ncbi.nlm.nih.gov/articles/PMC11400961/
+- Frontiers: Physiology & Psychology of Negative Splits (2025)
+  https://doi.org/10.3389/fphys.2025.1639816
+- Frontiers: Pacing Differences by Performance Level (2023)
+  https://doi.org/10.3389/fpsyg.2023.1273451
+- Abbiss & Laursen 2008: Pacing Strategies in Athletic Competition
+  https://pubmed.ncbi.nlm.nih.gov/18278984/
+"""
 
 from __future__ import annotations
 
-import json
-import logging
+from typing import Literal
 
-from sqlalchemy.ext.asyncio import AsyncSession
+from app.models.pacing import (
+    ElevationSegment,
+    PacingRecommendationRequest,
+    PacingRecommendationResponse,
+)
 
-from app.infrastructure.ai.ai_service import ai_service
-from app.models.pacing import PacingRecommendationRequest, PacingRecommendationResponse
-from app.services.ai_log_service import AICallData, log_ai_call
+# ---------------------------------------------------------------------------
+# Schwellwerte (aus der Literatur)
+# ---------------------------------------------------------------------------
 
-logger = logging.getLogger(__name__)
+# Hoehenprofil: ab 10m Gain pro km → huegelig (GAP-Forschung, LetsRun-Konsens)
+HILLY_THRESHOLD_M_PER_KM = 10.0
+# Hoehenprofil: ab 5m Gain pro km → wellig
+ROLLING_THRESHOLD_M_PER_KM = 5.0
 
-_SYSTEM_PROMPT = """\
-Du bist ein erfahrener Lauftrainer und Sportwissenschaftler.
-Der Athlet fragt dich, welche Pacing-Strategie er für ein Rennen wählen soll.
+# Temperatur: ab 25°C → ~5% Performance-Loss, Thermoregulation kritisch
+HEAT_THRESHOLD_CELSIUS = 25.0
 
-Antworte NUR mit einem JSON-Objekt (kein Markdown, kein Text drumherum):
-{
-  "strategy": "even" | "negative" | "effort_based",
-  "elevation_preset": "flat" | "rolling" | "hilly",
-  "reasoning": "<2-3 Sätze Begründung auf Deutsch>"
+# Distanz: unter 10km ist Negative-Split-Effekt minimal (Systematic Review 2024)
+SHORT_DISTANCE_KM = 10.0
+# Distanz: ab 21km wird Energiemanagement kritisch (Marathon-Review)
+LONG_DISTANCE_KM = 21.0
+
+
+# ---------------------------------------------------------------------------
+# Rennstrecken-Lookup (bekannte Streckenprofile)
+# ---------------------------------------------------------------------------
+
+_KNOWN_RACES: dict[str, Literal["flat", "rolling", "hilly"]] = {
+    # Flach
+    "berlin": "flat",
+    "hamburg": "flat",
+    "amsterdam": "flat",
+    "rotterdam": "flat",
+    "valencia": "flat",
+    "chicago": "flat",
+    "london": "flat",
+    "hannover": "flat",
+    "dubai": "flat",
+    "wien": "flat",
+    "vienna": "flat",
+    # Wellig
+    "frankfurt": "rolling",
+    "köln": "rolling",
+    "koeln": "rolling",
+    "münchen": "rolling",
+    "muenchen": "rolling",
+    "munich": "rolling",
+    "paris": "rolling",
+    "new york": "rolling",
+    "stockholm": "rolling",
+    "kopenhagen": "rolling",
+    "copenhagen": "rolling",
+    # Hügelig
+    "zürich": "hilly",
+    "zurich": "hilly",
+    "jena": "hilly",
+    "tübingen": "hilly",
+    "tuebingen": "hilly",
+    "boston": "hilly",
+    "luzern": "hilly",
+    "lucerne": "hilly",
+    "san francisco": "hilly",
 }
 
-Regeln für die Empfehlung:
-- even (Gleichmäßig): Gut für Anfänger und flache Strecken. Einfachste Strategie.
-- negative (Negative Splits): Für erfahrene Läufer. Konservativer Start, starkes Finish.
-- effort_based (Konstanter Effort): Für hügelige Strecken. Pace variiert, Belastung gleich.
 
-Höhenprofil:
-- flat: Flache Strecken (z.B. Berlin, Hamburg, Amsterdam)
-- rolling: Leicht wellige Strecken (z.B. Frankfurt, Köln)
-- hilly: Hügelige Strecken (z.B. Zürich, Jena)
+# ---------------------------------------------------------------------------
+# Begründungstexte (evidenzbasiert, deutsch)
+# ---------------------------------------------------------------------------
 
-Berücksichtige:
-- Bekannte Rennstrecken und deren Profile
-- Erfahrungslevel des Athleten
-- Ambitionsniveau (Pace zur Distanz)
-"""
+_REASON_HILLY = (
+    "Effort-Based Pacing ist bei hügeligen Strecken die evidenzbasierte Wahl: "
+    "Konstante Pace bei Steigungen treibt dich über die Laktatschwelle und "
+    "entleert die Glykogenspeicher schneller. Stattdessen hältst du die "
+    "Belastung konstant — bergauf langsamer, bergab schneller."
+)
 
+_REASON_BEGINNER = (
+    "Gleichmäßiges Pacing ist für Einsteiger die sicherste Strategie: "
+    "Die Forschung zeigt, dass erfahrenere Läufer gleichmäßiger pacen. "
+    "Eine konstante Pace ist einfach umzusetzen und vermeidet das häufigste "
+    "Problem — in der ersten Hälfte zu schnell zu starten."
+)
 
-async def get_pacing_recommendation(
-    request: PacingRecommendationRequest,
-    api_key: str,
-    db: AsyncSession,
-) -> PacingRecommendationResponse:
-    """Holt eine KI-Empfehlung fuer die Pacing-Strategie."""
-    user_prompt = _build_prompt(request)
+_REASON_SHORT_DISTANCE = (
+    "Bei Distanzen unter 10 km ist gleichmäßiges Pacing am effizientesten: "
+    "Systematic Reviews zeigen, dass der Unterschied zwischen Even und "
+    "Negative Splits bei kürzeren Distanzen minimal ist."
+)
 
-    response_text = await ai_service.chat(
-        message=user_prompt,
-        context={"system_prompt": _SYSTEM_PROMPT},
-        api_key=api_key,
-    )
+_REASON_HEAT = (
+    "Bei hohen Temperaturen ist ein konservativer Start entscheidend: "
+    "Die Thermoregulation ist in der ersten Rennhälfte am wichtigsten. "
+    "Starte bewusst zurückhaltend und steigere dich, wenn sich der Körper "
+    "stabilisiert hat."
+)
 
-    parsed = _parse_response(response_text)
+_REASON_ADVANCED = (
+    "Negative Splits nutzen deine Erfahrung optimal: Ein kontrollierter Start "
+    "schont die Glykogenspeicher und ermöglicht ein starkes Finish. Die Forschung "
+    "zeigt, dass Weltrekorde mit Even bis leicht negativem Pacing gelaufen werden."
+)
 
-    await log_ai_call(
-        db,
-        AICallData(
-            use_case="pacing_recommendation",
-            provider=ai_service.get_active_provider() or "unknown",
-            system_prompt=_SYSTEM_PROMPT,
-            user_prompt=user_prompt,
-            raw_response=response_text,
-            parsed_ok=parsed is not None,
-        ),
-    )
+_REASON_INTERMEDIATE_LONG = (
+    "Ab Halbmarathon-Distanz wird das Energiemanagement kritisch: "
+    "Ein konservativer Start mit Negative Splits verhindert das typische "
+    "Einbrechen in der zweiten Hälfte."
+)
 
-    if not parsed:
-        raise ValueError("KI-Antwort konnte nicht verarbeitet werden")
-
-    return parsed
-
-
-def _build_prompt(request: PacingRecommendationRequest) -> str:
-    """Baut den User-Prompt fuer die KI-Empfehlung."""
-    pace_sec = request.target_time_seconds / request.distance_km
-    pace_min = int(pace_sec // 60)
-    pace_s = int(pace_sec % 60)
-
-    hours = request.target_time_seconds // 3600
-    mins = (request.target_time_seconds % 3600) // 60
-    secs = request.target_time_seconds % 60
-    time_str = f"{hours}:{mins:02d}:{secs:02d}" if hours else f"{mins}:{secs:02d}"
-
-    parts = [
-        f"Distanz: {request.distance_km} km",
-        f"Zielzeit: {time_str} (Pace: {pace_min}:{pace_s:02d}/km)",
-    ]
-    if request.race_name:
-        parts.insert(0, f"Rennen: {request.race_name}")
-    if request.experience_level:
-        labels = {
-            "beginner": "Anfänger",
-            "intermediate": "Fortgeschritten",
-            "advanced": "Erfahren",
-        }
-        parts.append(f"Erfahrung: {labels.get(request.experience_level, request.experience_level)}")
-
-    return "\n".join(parts)
+_REASON_EVEN_DEFAULT = (
+    "Gleichmäßiges Pacing ist die physiologisch optimale Strategie: "
+    "Systematic Reviews zeigen, dass konstante Pace den Glykogenverbrauch "
+    "und die Laktatakkumulation minimiert."
+)
 
 
-def _parse_response(text: str) -> PacingRecommendationResponse | None:
-    """Parst die KI-Antwort als JSON."""
-    cleaned = text.strip()
-    if cleaned.startswith("```"):
-        cleaned = cleaned.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
+# ---------------------------------------------------------------------------
+# Elevation-Klassifizierung
+# ---------------------------------------------------------------------------
 
-    try:
-        data = json.loads(cleaned)
-        return PacingRecommendationResponse(**data)
-    except (json.JSONDecodeError, ValueError):
-        logger.warning("KI-Antwort nicht als JSON parsbar: %s", text[:200])
+
+def _classify_elevation_from_segments(
+    segments: list[ElevationSegment],
+    distance_km: float,
+) -> Literal["flat", "rolling", "hilly"]:
+    """Klassifiziert das Höhenprofil aus GPX-Segmenten."""
+    if not segments:
+        return "flat"
+    total_gain = sum(s.gain_m for s in segments)
+    avg_gain = total_gain / distance_km if distance_km > 0 else 0.0
+    if avg_gain >= HILLY_THRESHOLD_M_PER_KM:
+        return "hilly"
+    if avg_gain >= ROLLING_THRESHOLD_M_PER_KM:
+        return "rolling"
+    return "flat"
+
+
+def _classify_elevation_from_race_name(
+    race_name: str | None,
+) -> Literal["flat", "rolling", "hilly"] | None:
+    """Versucht das Höhenprofil aus dem Rennnamen abzuleiten."""
+    if not race_name:
         return None
+    name_lower = race_name.lower()
+    for keyword, preset in _KNOWN_RACES.items():
+        if keyword in name_lower:
+            return preset
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Hauptfunktion
+# ---------------------------------------------------------------------------
+
+
+StrategyType = Literal["even", "negative", "effort_based"]
+
+
+def _determine_strategy(
+    request: PacingRecommendationRequest,
+    is_hilly: bool,
+) -> tuple[StrategyType, str]:
+    """Bestimmt Strategie und Begründung anhand des Entscheidungsbaums.
+
+    Prioritätsreihenfolge:
+    1. Höhenprofil hügelig → effort_based
+    2. Anfänger → even
+    3. Distanz < 10km → even
+    4. Hitze ≥ 25°C (intermediate/advanced) → negative
+    5. Advanced ≥ 10km oder Intermediate ≥ 21km → negative
+    6. Default → even
+    """
+    if is_hilly:
+        return "effort_based", _REASON_HILLY
+    if request.experience_level == "beginner":
+        return "even", _REASON_BEGINNER
+    if request.distance_km < SHORT_DISTANCE_KM:
+        return "even", _REASON_SHORT_DISTANCE
+    if (
+        request.temperature_celsius is not None
+        and request.temperature_celsius >= HEAT_THRESHOLD_CELSIUS
+    ):
+        return "negative", _REASON_HEAT
+    is_negative = request.experience_level == "advanced" or request.distance_km >= LONG_DISTANCE_KM
+    if is_negative:
+        reason = (
+            _REASON_ADVANCED
+            if request.experience_level == "advanced"
+            else _REASON_INTERMEDIATE_LONG
+        )
+        return "negative", reason
+    return "even", _REASON_EVEN_DEFAULT
+
+
+def recommend_pacing(
+    request: PacingRecommendationRequest,
+) -> PacingRecommendationResponse:
+    """Gibt eine deterministische, evidenzbasierte Pacing-Empfehlung zurück."""
+    # Elevation bestimmen (Priorität: GPX > manuelles Preset > Rennname)
+    elevation: Literal["flat", "rolling", "hilly"] | None
+    if request.elevation_segments:
+        elevation = _classify_elevation_from_segments(
+            request.elevation_segments, request.distance_km
+        )
+    elif request.elevation_preset:
+        elevation = request.elevation_preset
+    else:
+        elevation = _classify_elevation_from_race_name(request.race_name)
+
+    strategy, reasoning = _determine_strategy(request, is_hilly=elevation == "hilly")
+
+    return PacingRecommendationResponse(
+        strategy=strategy,
+        elevation_preset=elevation,
+        reasoning=reasoning,
+    )

--- a/backend/app/tests/test_pacing_recommendation.py
+++ b/backend/app/tests/test_pacing_recommendation.py
@@ -1,0 +1,377 @@
+"""Tests fuer die evidenzbasierte Pacing-Strategie-Empfehlung.
+
+Jeder Pfad im Entscheidungsbaum wird deterministisch getestet.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.models.pacing import (
+    ElevationSegment,
+    PacingRecommendationRequest,
+)
+from app.services.pacing_recommendation import (
+    HEAT_THRESHOLD_CELSIUS,
+    HILLY_THRESHOLD_M_PER_KM,
+    LONG_DISTANCE_KM,
+    ROLLING_THRESHOLD_M_PER_KM,
+    SHORT_DISTANCE_KM,
+    recommend_pacing,
+)
+
+
+def _req(
+    *,
+    distance_km: float = 21.1,
+    target_time_seconds: int = 6600,
+    experience_level: str = "intermediate",
+    race_name: str | None = None,
+    temperature_celsius: float | None = None,
+    elevation_preset: str | None = None,
+    elevation_segments: list[ElevationSegment] | None = None,
+) -> PacingRecommendationRequest:
+    """Erzeugt einen PacingRecommendationRequest mit sinnvollen Defaults."""
+    return PacingRecommendationRequest(
+        distance_km=distance_km,
+        target_time_seconds=target_time_seconds,
+        experience_level=experience_level,  # type: ignore[arg-type]
+        race_name=race_name,
+        temperature_celsius=temperature_celsius,
+        elevation_preset=elevation_preset,  # type: ignore[arg-type]
+        elevation_segments=elevation_segments,
+    )
+
+
+# -----------------------------------------------------------------------
+# Determinismus: Gleicher Input → gleicher Output
+# -----------------------------------------------------------------------
+
+
+class TestDeterminism:
+    """Gleiche Inputs muessen immer die gleiche Empfehlung liefern."""
+
+    def test_same_input_same_output(self) -> None:
+        req = _req(distance_km=21.1, experience_level="advanced")
+        results = [recommend_pacing(req) for _ in range(50)]
+        strategies = {r.strategy for r in results}
+        assert len(strategies) == 1
+
+
+# -----------------------------------------------------------------------
+# Faktor 1: Höhenprofil
+# -----------------------------------------------------------------------
+
+
+class TestElevation:
+    """Hügeliges Höhenprofil → effort_based, unabhaengig von Erfahrung."""
+
+    def test_hilly_race_name_returns_effort_based(self) -> None:
+        result = recommend_pacing(_req(race_name="Zürich Marathon", experience_level="beginner"))
+        assert result.strategy == "effort_based"
+        assert result.elevation_preset == "hilly"
+
+    def test_hilly_gpx_returns_effort_based(self) -> None:
+        segments = [ElevationSegment(km=i, gain_m=15.0, loss_m=5.0) for i in range(1, 22)]
+        result = recommend_pacing(_req(elevation_segments=segments))
+        assert result.strategy == "effort_based"
+        assert result.elevation_preset == "hilly"
+
+    def test_gpx_overrides_race_name(self) -> None:
+        """GPX-Daten haben Vorrang vor Rennname-Lookup."""
+        flat_segments = [ElevationSegment(km=i, gain_m=1.0, loss_m=1.0) for i in range(1, 22)]
+        result = recommend_pacing(
+            _req(race_name="Zürich Marathon", elevation_segments=flat_segments)
+        )
+        # GPX sagt flach → nicht effort_based, obwohl Zürich hügelig ist
+        assert result.strategy != "effort_based"
+
+    def test_rolling_race_name_sets_preset(self) -> None:
+        result = recommend_pacing(_req(race_name="Frankfurt Marathon", experience_level="advanced"))
+        assert result.elevation_preset == "rolling"
+        assert result.strategy == "negative"  # Advanced + ≥10km → negative
+
+    def test_flat_race_name_sets_preset(self) -> None:
+        result = recommend_pacing(
+            _req(race_name="Berlin Halbmarathon", experience_level="advanced")
+        )
+        assert result.elevation_preset == "flat"
+
+    def test_unknown_race_returns_no_preset(self) -> None:
+        result = recommend_pacing(_req(race_name="Dorflauf Hintertupfingen"))
+        assert result.elevation_preset is None
+
+    def test_no_race_name_returns_no_preset(self) -> None:
+        result = recommend_pacing(_req(race_name=None))
+        assert result.elevation_preset is None
+
+    def test_hilly_overrides_advanced_negative(self) -> None:
+        """Höhenprofil hat höchste Priorität — auch für erfahrene Läufer."""
+        result = recommend_pacing(_req(race_name="Boston Marathon", experience_level="advanced"))
+        assert result.strategy == "effort_based"
+
+    def test_gpx_rolling_threshold(self) -> None:
+        """Ø 5-10m/km → rolling, nicht hügelig."""
+        segments = [ElevationSegment(km=i, gain_m=7.0, loss_m=3.0) for i in range(1, 22)]
+        result = recommend_pacing(_req(elevation_segments=segments, experience_level="advanced"))
+        assert result.elevation_preset == "rolling"
+        assert result.strategy == "negative"  # rolling + advanced → negative
+
+    def test_gpx_flat_threshold(self) -> None:
+        """Ø <5m/km → flat."""
+        segments = [ElevationSegment(km=i, gain_m=2.0, loss_m=2.0) for i in range(1, 22)]
+        result = recommend_pacing(
+            _req(elevation_segments=segments, experience_level="intermediate")
+        )
+        assert result.elevation_preset == "flat"
+
+    def test_manual_preset_hilly_returns_effort_based(self) -> None:
+        """Manuell gewähltes Preset 'hilly' → effort_based."""
+        result = recommend_pacing(_req(elevation_preset="hilly", experience_level="advanced"))
+        assert result.strategy == "effort_based"
+        assert result.elevation_preset == "hilly"
+
+    def test_manual_preset_flat_no_effort_based(self) -> None:
+        """Manuell gewähltes Preset 'flat' → nicht effort_based."""
+        result = recommend_pacing(_req(elevation_preset="flat", experience_level="advanced"))
+        assert result.strategy == "negative"
+
+    def test_gpx_overrides_manual_preset(self) -> None:
+        """GPX hat Vorrang vor manuellem Preset."""
+        flat_segments = [ElevationSegment(km=i, gain_m=1.0, loss_m=1.0) for i in range(1, 22)]
+        result = recommend_pacing(_req(elevation_preset="hilly", elevation_segments=flat_segments))
+        # GPX sagt flach → nicht effort_based, obwohl Preset hilly
+        assert result.strategy != "effort_based"
+        assert result.elevation_preset == "flat"
+
+    def test_preset_overrides_race_name(self) -> None:
+        """Manuelles Preset hat Vorrang vor Rennname."""
+        result = recommend_pacing(
+            _req(race_name="Berlin", elevation_preset="hilly", experience_level="beginner")
+        )
+        # Preset sagt hilly → effort_based, obwohl Berlin=flat
+        assert result.strategy == "effort_based"
+        assert result.elevation_preset == "hilly"
+
+
+# -----------------------------------------------------------------------
+# Faktor 2: Anfänger
+# -----------------------------------------------------------------------
+
+
+class TestBeginner:
+    """Anfänger → even, immer (außer hügelig)."""
+
+    def test_beginner_flat_returns_even(self) -> None:
+        result = recommend_pacing(_req(experience_level="beginner", race_name="Berlin"))
+        assert result.strategy == "even"
+
+    def test_beginner_heat_still_returns_even(self) -> None:
+        """Auch bei Hitze: Anfänger sollen nicht mit Negative Splits experimentieren."""
+        result = recommend_pacing(
+            _req(experience_level="beginner", temperature_celsius=30.0, race_name="Berlin")
+        )
+        assert result.strategy == "even"
+
+    def test_beginner_marathon_returns_even(self) -> None:
+        result = recommend_pacing(
+            _req(experience_level="beginner", distance_km=42.2, target_time_seconds=18000)
+        )
+        assert result.strategy == "even"
+
+
+# -----------------------------------------------------------------------
+# Faktor 3: Kurze Distanz
+# -----------------------------------------------------------------------
+
+
+class TestShortDistance:
+    """Distanz < 10km → even (zu kurz fuer Negative-Split-Effekt)."""
+
+    def test_5k_advanced_returns_even(self) -> None:
+        result = recommend_pacing(
+            _req(distance_km=5.0, target_time_seconds=1200, experience_level="advanced")
+        )
+        assert result.strategy == "even"
+
+    def test_9k_intermediate_returns_even(self) -> None:
+        result = recommend_pacing(
+            _req(distance_km=9.0, target_time_seconds=2700, experience_level="intermediate")
+        )
+        assert result.strategy == "even"
+
+    def test_10k_advanced_returns_negative(self) -> None:
+        """Exakt 10km ist NICHT kurz → Erfahrungsregeln greifen."""
+        result = recommend_pacing(
+            _req(distance_km=10.0, target_time_seconds=3000, experience_level="advanced")
+        )
+        assert result.strategy == "negative"
+
+
+# -----------------------------------------------------------------------
+# Faktor 4: Hitze
+# -----------------------------------------------------------------------
+
+
+class TestHeat:
+    """Temperatur ≥ 25°C → negative (für intermediate/advanced)."""
+
+    def test_heat_intermediate_returns_negative(self) -> None:
+        result = recommend_pacing(
+            _req(temperature_celsius=28.0, experience_level="intermediate", distance_km=15.0)
+        )
+        assert result.strategy == "negative"
+
+    def test_heat_advanced_returns_negative(self) -> None:
+        result = recommend_pacing(_req(temperature_celsius=30.0, experience_level="advanced"))
+        assert result.strategy == "negative"
+
+    def test_no_heat_intermediate_15k_returns_even(self) -> None:
+        """Ohne Hitze: intermediate + 15km → even."""
+        result = recommend_pacing(
+            _req(temperature_celsius=18.0, experience_level="intermediate", distance_km=15.0)
+        )
+        assert result.strategy == "even"
+
+    def test_exactly_25c_triggers_heat(self) -> None:
+        """Exakt 25°C ist >= Schwellwert → negative."""
+        result = recommend_pacing(
+            _req(temperature_celsius=25.0, experience_level="intermediate", distance_km=15.0)
+        )
+        assert result.strategy == "negative"
+
+    def test_24c_no_heat(self) -> None:
+        """24°C ist unter Schwellwert → kein Heat-Override."""
+        result = recommend_pacing(
+            _req(temperature_celsius=24.0, experience_level="intermediate", distance_km=15.0)
+        )
+        assert result.strategy == "even"
+
+
+# -----------------------------------------------------------------------
+# Faktor 5: Erfahrung × Distanz
+# -----------------------------------------------------------------------
+
+
+class TestExperienceDistance:
+    """Kombination aus Erfahrung und Distanz."""
+
+    def test_advanced_half_marathon_returns_negative(self) -> None:
+        result = recommend_pacing(_req(experience_level="advanced", distance_km=21.1))
+        assert result.strategy == "negative"
+
+    def test_advanced_marathon_returns_negative(self) -> None:
+        result = recommend_pacing(
+            _req(experience_level="advanced", distance_km=42.2, target_time_seconds=14400)
+        )
+        assert result.strategy == "negative"
+
+    def test_intermediate_half_marathon_returns_negative(self) -> None:
+        """Intermediate + ≥21km → negative."""
+        result = recommend_pacing(_req(experience_level="intermediate", distance_km=21.1))
+        assert result.strategy == "negative"
+
+    def test_intermediate_15k_returns_even(self) -> None:
+        """Intermediate + 15km (< 21km) → even."""
+        result = recommend_pacing(_req(experience_level="intermediate", distance_km=15.0))
+        assert result.strategy == "even"
+
+    def test_intermediate_10k_returns_even(self) -> None:
+        result = recommend_pacing(
+            _req(experience_level="intermediate", distance_km=10.0, target_time_seconds=3000)
+        )
+        assert result.strategy == "even"
+
+
+# -----------------------------------------------------------------------
+# Schwellwert-Konsistenz
+# -----------------------------------------------------------------------
+
+
+class TestThresholds:
+    """Schwellwerte muessen mit den exportierten Konstanten uebereinstimmen."""
+
+    def test_hilly_threshold(self) -> None:
+        assert HILLY_THRESHOLD_M_PER_KM == 10.0
+
+    def test_rolling_threshold(self) -> None:
+        assert ROLLING_THRESHOLD_M_PER_KM == 5.0
+
+    def test_heat_threshold(self) -> None:
+        assert HEAT_THRESHOLD_CELSIUS == 25.0
+
+    def test_short_distance_threshold(self) -> None:
+        assert SHORT_DISTANCE_KM == 10.0
+
+    def test_long_distance_threshold(self) -> None:
+        assert LONG_DISTANCE_KM == 21.0
+
+
+# -----------------------------------------------------------------------
+# Begründungstexte
+# -----------------------------------------------------------------------
+
+
+class TestReasoning:
+    """Jede Empfehlung muss eine nicht-leere Begründung enthalten."""
+
+    @pytest.mark.parametrize(
+        ("kwargs", "expected_strategy"),
+        [
+            ({"race_name": "Zürich", "experience_level": "beginner"}, "effort_based"),
+            ({"experience_level": "beginner"}, "even"),
+            (
+                {"distance_km": 5.0, "target_time_seconds": 1500, "experience_level": "advanced"},
+                "even",
+            ),
+            ({"temperature_celsius": 30.0, "experience_level": "intermediate"}, "negative"),
+            ({"experience_level": "advanced"}, "negative"),
+            (
+                {
+                    "experience_level": "intermediate",
+                    "distance_km": 42.2,
+                    "target_time_seconds": 14400,
+                },
+                "negative",
+            ),
+            (
+                {
+                    "experience_level": "intermediate",
+                    "distance_km": 15.0,
+                    "target_time_seconds": 4500,
+                },
+                "even",
+            ),
+        ],
+    )
+    def test_reasoning_not_empty(self, kwargs: dict, expected_strategy: str) -> None:  # type: ignore[type-arg]
+        result = recommend_pacing(_req(**kwargs))
+        assert result.strategy == expected_strategy
+        assert len(result.reasoning) > 20
+
+
+# -----------------------------------------------------------------------
+# Race-Name Matching
+# -----------------------------------------------------------------------
+
+
+class TestRaceNameLookup:
+    """Case-insensitive Substring-Match auf Rennnamen."""
+
+    def test_case_insensitive(self) -> None:
+        result = recommend_pacing(_req(race_name="BERLIN marathon", experience_level="advanced"))
+        assert result.elevation_preset == "flat"
+
+    def test_substring_match(self) -> None:
+        result = recommend_pacing(
+            _req(race_name="35. Hamburg Marathon 2026", experience_level="advanced")
+        )
+        assert result.elevation_preset == "flat"
+
+    def test_umlaut_match(self) -> None:
+        result = recommend_pacing(_req(race_name="Zürich", experience_level="advanced"))
+        assert result.elevation_preset == "hilly"
+
+    def test_alternate_spelling(self) -> None:
+        result = recommend_pacing(_req(race_name="Muenchen Marathon", experience_level="advanced"))
+        assert result.elevation_preset == "rolling"

--- a/frontend/src/api/pacing.ts
+++ b/frontend/src/api/pacing.ts
@@ -80,16 +80,21 @@ export async function generatePacing(params: PacingRequest): Promise<PacingRespo
   return response.data;
 }
 
+export type ExperienceLevel = 'beginner' | 'intermediate' | 'advanced';
+
 export interface PacingRecommendationRequest {
   race_name?: string | null;
   distance_km: number;
   target_time_seconds: number;
-  experience_level?: 'beginner' | 'intermediate' | 'advanced' | null;
+  experience_level: ExperienceLevel;
+  temperature_celsius?: number | null;
+  elevation_preset?: 'flat' | 'rolling' | 'hilly' | null;
+  elevation_segments?: ElevationSegment[] | null;
 }
 
 export interface PacingRecommendationResponse {
   strategy: 'even' | 'negative' | 'effort_based';
-  elevation_preset: 'flat' | 'rolling' | 'hilly';
+  elevation_preset: 'flat' | 'rolling' | 'hilly' | null;
   reasoning: string;
 }
 

--- a/frontend/src/components/pacing/PacingForm.test.tsx
+++ b/frontend/src/components/pacing/PacingForm.test.tsx
@@ -35,11 +35,12 @@ describe('PacingForm', () => {
     expect(screen.getByText('Wettkampfziel')).toBeDefined();
   });
 
-  it('zeigt keine Goal-Auswahl ohne aktive Ziele', () => {
+  it('zeigt Hinweis statt Select ohne aktive Ziele', () => {
     const inactiveGoal = { ...mockGoal, is_active: false };
     render(<PacingForm goals={[inactiveGoal]} loading={false} onGenerate={vi.fn()} />);
 
-    expect(screen.queryByText('Wettkampfziel')).toBeNull();
+    expect(screen.getByText('Wettkampfziel')).toBeDefined();
+    expect(screen.getByText(/Noch keine Ziele angelegt/)).toBeDefined();
   });
 
   it('zeigt Fehlermeldung bei fehlender Distanz', () => {

--- a/frontend/src/components/pacing/PacingForm.tsx
+++ b/frontend/src/components/pacing/PacingForm.tsx
@@ -2,7 +2,12 @@ import { useState, useEffect } from 'react';
 import { Button, Label, Select, Alert, AlertDescription } from '@nordlig/components';
 import { Play } from 'lucide-react';
 import type { RaceGoal } from '@/api/goals';
-import type { ElevationSegment, PacingRequest, PacingRecommendationResponse } from '@/api/pacing';
+import type {
+  ElevationSegment,
+  ExperienceLevel,
+  PacingRequest,
+  PacingRecommendationResponse,
+} from '@/api/pacing';
 import { DistanceTimeInputs } from './DistanceTimeInputs';
 import { StrategyInputs } from './StrategyInputs';
 import { WeatherInputs } from './WeatherInputs';
@@ -29,6 +34,7 @@ function usePacingForm(goals: RaceGoal[]) {
   const [error, setError] = useState<string | null>(null);
   const [raceName, setRaceName] = useState('');
   const [elevationSegments, setElevationSegments] = useState<ElevationSegment[] | null>(null);
+  const [experienceLevel, setExperienceLevel] = useState<ExperienceLevel>('intermediate');
 
   useEffect(() => {
     if (!goalId) return;
@@ -99,6 +105,8 @@ function usePacingForm(goals: RaceGoal[]) {
     raceName,
     elevationSegments,
     setElevationSegments,
+    experienceLevel,
+    setExperienceLevel,
     getTimeSeconds,
     validate,
   };
@@ -118,22 +126,30 @@ export function PacingForm({ goals, loading, onGenerate }: PacingFormProps) {
 
   const handleRecommendation = (rec: PacingRecommendationResponse) => {
     form.setStrategy(rec.strategy);
-    form.setElevationPreset(rec.elevation_preset);
+    if (rec.elevation_preset) form.setElevationPreset(rec.elevation_preset);
     setReasoning(rec.reasoning);
   };
 
   return (
     <div className="space-y-5">
-      {activeGoals.length > 0 && (
-        <div>
-          <Label>Wettkampfziel</Label>
+      <div>
+        <Label>Wettkampfziel</Label>
+        {activeGoals.length > 0 ? (
           <Select
             options={goalOptions}
             value={form.goalId ? String(form.goalId) : ''}
             onChange={(val) => form.setGoalId(val ? Number(val) : null)}
           />
-        </div>
-      )}
+        ) : (
+          <p className="text-sm text-[var(--color-text-muted)]">
+            Noch keine Ziele angelegt. Du kannst unter{' '}
+            <a href="/plan/goals" className="underline text-[var(--color-text-primary)]">
+              Ziele
+            </a>{' '}
+            ein Wettkampfziel erstellen.
+          </p>
+        )}
+      </div>
 
       <DistanceTimeInputs
         distance={form.distance}
@@ -146,27 +162,30 @@ export function PacingForm({ goals, loading, onGenerate }: PacingFormProps) {
         onTimeSChange={form.setTimeS}
       />
 
-      <StrategyInputs
-        strategy={form.strategy}
-        elevationPreset={form.elevationPreset}
-        elevationSegments={form.elevationSegments}
-        raceName={form.raceName}
-        distanceKm={parseFloat(form.distance) || null}
-        targetTimeSeconds={form.getTimeSeconds() || null}
-        reasoning={reasoning}
-        disabled={loading}
-        onStrategyChange={form.setStrategy}
-        onElevationChange={form.setElevationPreset}
-        onElevationSegmentsChange={form.setElevationSegments}
-        onRecommendation={handleRecommendation}
-        onReasoningClose={() => setReasoning(null)}
-      />
-
       <WeatherInputs
         temperature={form.temperature}
         windSpeed={form.windSpeed}
         onTemperatureChange={form.setTemperature}
         onWindSpeedChange={form.setWindSpeed}
+      />
+
+      <StrategyInputs
+        strategy={form.strategy}
+        elevationPreset={form.elevationPreset}
+        elevationSegments={form.elevationSegments}
+        experienceLevel={form.experienceLevel}
+        raceName={form.raceName}
+        distanceKm={parseFloat(form.distance) || null}
+        targetTimeSeconds={form.getTimeSeconds() || null}
+        temperatureCelsius={parseFloat(form.temperature) || null}
+        reasoning={reasoning}
+        disabled={loading}
+        onStrategyChange={form.setStrategy}
+        onElevationChange={form.setElevationPreset}
+        onElevationSegmentsChange={form.setElevationSegments}
+        onExperienceLevelChange={form.setExperienceLevel}
+        onRecommendation={handleRecommendation}
+        onReasoningClose={() => setReasoning(null)}
       />
 
       {form.error && (
@@ -182,6 +201,7 @@ export function PacingForm({ goals, loading, onGenerate }: PacingFormProps) {
           if (p) onGenerate(p);
         }}
         disabled={loading}
+        className="w-full"
       >
         {loading ? (
           'Berechne…'

--- a/frontend/src/components/pacing/RecommendButton.tsx
+++ b/frontend/src/components/pacing/RecommendButton.tsx
@@ -2,12 +2,16 @@ import { useState } from 'react';
 import { Button, Spinner, Alert, AlertDescription, useToast } from '@nordlig/components';
 import { Sparkles } from 'lucide-react';
 import { getPacingRecommendation } from '@/api/pacing';
-import type { PacingRecommendationResponse } from '@/api/pacing';
+import type { ExperienceLevel, ElevationSegment, PacingRecommendationResponse } from '@/api/pacing';
 
 interface RecommendButtonProps {
   raceName: string;
   distanceKm: number | null;
   targetTimeSeconds: number | null;
+  experienceLevel: ExperienceLevel;
+  temperatureCelsius: number | null;
+  elevationPreset: 'flat' | 'rolling' | 'hilly';
+  elevationSegments: ElevationSegment[] | null;
   disabled?: boolean;
   onRecommendation: (rec: PacingRecommendationResponse) => void;
 }
@@ -16,6 +20,10 @@ export function RecommendButton({
   raceName,
   distanceKm,
   targetTimeSeconds,
+  experienceLevel,
+  temperatureCelsius,
+  elevationPreset,
+  elevationSegments,
   disabled,
   onRecommendation,
 }: RecommendButtonProps) {
@@ -33,19 +41,28 @@ export function RecommendButton({
         race_name: raceName || null,
         distance_km: distanceKm,
         target_time_seconds: targetTimeSeconds,
+        experience_level: experienceLevel,
+        temperature_celsius: temperatureCelsius,
+        elevation_preset: elevationSegments ? null : elevationPreset,
+        elevation_segments: elevationSegments,
       });
       onRecommendation(rec);
     } catch {
-      toast({ title: 'KI-Empfehlung fehlgeschlagen', variant: 'error' });
+      toast({ title: 'Empfehlung fehlgeschlagen', variant: 'error' });
     } finally {
       setLoading(false);
     }
   };
 
   return (
-    <Button variant="ghost" size="sm" onClick={handleClick} disabled={disabled || loading}>
-      {loading ? <Spinner size="sm" aria-hidden="true" /> : <Sparkles size={14} />}
-      KI-Empfehlung
+    <Button
+      variant="secondary"
+      onClick={handleClick}
+      disabled={disabled || loading}
+      className="w-full"
+    >
+      {loading ? <Spinner size="sm" aria-hidden="true" /> : <Sparkles size={16} />}
+      Strategie empfehlen
     </Button>
   );
 }
@@ -60,7 +77,7 @@ export function RecommendReasoning({
   return (
     <Alert variant="info" closeable onClose={onClose}>
       <AlertDescription>
-        <strong>KI-Empfehlung:</strong> {reasoning}
+        <strong>Empfehlung:</strong> {reasoning}
       </AlertDescription>
     </Alert>
   );

--- a/frontend/src/components/pacing/StrategyInputs.tsx
+++ b/frontend/src/components/pacing/StrategyInputs.tsx
@@ -1,5 +1,5 @@
 import { Label, Select } from '@nordlig/components';
-import type { ElevationSegment, PacingRecommendationResponse } from '@/api/pacing';
+import type { ElevationSegment, ExperienceLevel, PacingRecommendationResponse } from '@/api/pacing';
 import { ElevationProfile } from './ElevationProfile';
 import { RecommendButton, RecommendReasoning } from './RecommendButton';
 
@@ -18,18 +18,27 @@ const ELEVATION_OPTIONS = [
   { value: 'hilly', label: 'Hügelig (~30m/km)' },
 ];
 
+const EXPERIENCE_OPTIONS = [
+  { value: 'beginner', label: 'Anfänger' },
+  { value: 'intermediate', label: 'Fortgeschritten' },
+  { value: 'advanced', label: 'Erfahren' },
+];
+
 interface StrategyInputsProps {
   strategy: Strategy;
   elevationPreset: ElevationPreset;
   elevationSegments: ElevationSegment[] | null;
+  experienceLevel: ExperienceLevel;
   raceName: string;
   distanceKm: number | null;
   targetTimeSeconds: number | null;
+  temperatureCelsius: number | null;
   reasoning: string | null;
   disabled?: boolean;
   onStrategyChange: (val: Strategy) => void;
   onElevationChange: (val: ElevationPreset) => void;
   onElevationSegmentsChange: (segments: ElevationSegment[] | null) => void;
+  onExperienceLevelChange: (val: ExperienceLevel) => void;
   onRecommendation: (rec: PacingRecommendationResponse) => void;
   onReasoningClose: () => void;
 }
@@ -38,40 +47,24 @@ export function StrategyInputs({
   strategy,
   elevationPreset,
   elevationSegments,
+  experienceLevel,
   raceName,
   distanceKm,
   targetTimeSeconds,
+  temperatureCelsius,
   reasoning,
   disabled,
   onStrategyChange,
   onElevationChange,
   onElevationSegmentsChange,
+  onExperienceLevelChange,
   onRecommendation,
   onReasoningClose,
 }: StrategyInputsProps) {
   return (
     <>
+      {/* Inputs: Höhenprofil + Erfahrung (beeinflussen die Empfehlung) */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <div>
-          <div className="flex items-center justify-between">
-            <Label>Strategie</Label>
-            <RecommendButton
-              raceName={raceName}
-              distanceKm={distanceKm}
-              targetTimeSeconds={targetTimeSeconds}
-              disabled={disabled}
-              onRecommendation={onRecommendation}
-            />
-          </div>
-          <Select
-            options={STRATEGY_OPTIONS}
-            value={strategy}
-            onChange={(val) => {
-              if (val) onStrategyChange(val as Strategy);
-              onReasoningClose();
-            }}
-          />
-        </div>
         <div>
           <Label>Höhenprofil</Label>
           <Select
@@ -85,6 +78,17 @@ export function StrategyInputs({
             disabled={!!elevationSegments}
           />
         </div>
+        <div>
+          <Label>Erfahrung</Label>
+          <Select
+            options={EXPERIENCE_OPTIONS}
+            value={experienceLevel}
+            onChange={(val) => {
+              if (val) onExperienceLevelChange(val as ExperienceLevel);
+              onReasoningClose();
+            }}
+          />
+        </div>
       </div>
 
       <ElevationProfile
@@ -93,7 +97,32 @@ export function StrategyInputs({
         disabled={disabled}
       />
 
+      {/* Empfehlung: Button + Begründung */}
+      <RecommendButton
+        raceName={raceName}
+        distanceKm={distanceKm}
+        targetTimeSeconds={targetTimeSeconds}
+        experienceLevel={experienceLevel}
+        temperatureCelsius={temperatureCelsius}
+        elevationPreset={elevationPreset}
+        elevationSegments={elevationSegments}
+        disabled={disabled}
+        onRecommendation={onRecommendation}
+      />
       {reasoning && <RecommendReasoning reasoning={reasoning} onClose={onReasoningClose} />}
+
+      {/* Output: Strategie (wird von Empfehlung gesetzt, manuell überschreibbar) */}
+      <div>
+        <Label>Strategie</Label>
+        <Select
+          options={STRATEGY_OPTIONS}
+          value={strategy}
+          onChange={(val) => {
+            if (val) onStrategyChange(val as Strategy);
+            onReasoningClose();
+          }}
+        />
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## Summary

- KI-basierte Pacing-Empfehlung (Claude API) durch **deterministische, sportwissenschaftlich fundierte Regeln** ersetzt
- Gleiche Inputs liefern jetzt immer die gleiche Empfehlung — kein inkonsistentes KI-Verhalten mehr
- Frontend-Flow umgebaut: logische Reihenfolge von oben nach unten (Inputs → Empfehlung → Strategie)

### Entscheidungsbaum

1. **Höhenprofil** hügelig (≥10m/km avg gain) → effort_based
2. **Anfänger** → even (immer)
3. **Distanz** <10km → even
4. **Hitze** ≥25°C → negative (konservativer Start)
5. **Erfahrung × Distanz** → advanced ≥10km / intermediate ≥21km → negative

### Wissenschaftliche Quellen

- [Systematic Review Pacing Strategies in Marathons (2024, 39 Studien)](https://pmc.ncbi.nlm.nih.gov/articles/PMC11400961/)
- [Frontiers: Physiology & Psychology of Negative Splits (2025)](https://doi.org/10.3389/fphys.2025.1639816)
- [Frontiers: Pacing Differences by Performance Level (2023)](https://doi.org/10.3389/fpsyg.2023.1273451)
- [Abbiss & Laursen 2008: Pacing Strategies in Athletic Competition](https://pubmed.ncbi.nlm.nih.gov/18278984/)

Closes #490

## Test plan

- [x] 47 deterministische Backend-Tests für alle Entscheidungspfade
- [x] Frontend-Tests angepasst (187 grün)
- [x] Backend Quality Gates: ruff, mypy, pytest 876 grün
- [x] Visuell verifiziert: Flow, Layout, Empfehlung-Button, GPX-Upload
- [ ] E2E: Verschiedene Kombinationen testen (hügelig→effort_based, Anfänger→even, Hitze→negative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)