### PR TITLE
perf: Brotli-Kompression für LCP-Optimierung

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,7 +12,8 @@ COPY . .
 RUN npm run build
 
 # ---- Production Stage ----
-FROM nginx:alpine
+# nginx-brotli adds Brotli compression module (~20-30% smaller than gzip)
+FROM fholzer/nginx-brotli:latest
 
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -56,4 +56,21 @@ server {
         application/atom+xml
         image/svg+xml
         font/woff2;
+
+    # Brotli compression (~20-30% smaller than gzip for text assets)
+    brotli on;
+    brotli_comp_level 6;
+    brotli_min_length 256;
+    brotli_types
+        text/plain
+        text/css
+        text/xml
+        text/javascript
+        application/json
+        application/javascript
+        application/xml
+        application/rss+xml
+        application/atom+xml
+        image/svg+xml
+        font/woff2;
 }


### PR DESCRIPTION
## Summary
- Nginx-Image auf `fholzer/nginx-brotli` gewechselt (Drop-in für `nginx:alpine` mit Brotli-Modul)
- Brotli-Kompression mit Level 6 konfiguriert (~20-30% kleiner als gzip)
- Vorheriger Audit: FCP ✅ bestanden, LCP 5405ms (Budget 5000ms) — noch ~400ms zu viel

Follows up on #493. Closes #492

## Test plan
- [ ] CI grün
- [ ] Docker-Build funktioniert mit `fholzer/nginx-brotli` Image
- [ ] Nach Deploy: Lighthouse Audit erneut laufen lassen
- [ ] LCP ≤ 5000ms verifizieren
- [ ] Browser DevTools: `Content-Encoding: br` Header für CSS/JS prüfen

🤖 Generated with [Claude Code](https://claude.com/claude-code)