### PR TITLE
fix: Brotli-Image revert — Production 503 beheben

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,11 +12,14 @@ COPY . .
 RUN npm run build
 
 # ---- Production Stage ----
-# nginx-brotli adds Brotli compression module (~20-30% smaller than gzip)
-FROM fholzer/nginx-brotli:latest
+FROM nginx:alpine
 
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Pre-compress static assets at max gzip level (served via gzip_static)
+RUN find /usr/share/nginx/html/assets -type f \( -name '*.js' -o -name '*.css' -o -name '*.svg' -o -name '*.json' \) \
+    -exec sh -c 'gzip -9 -k "$1"' _ {} \;
 
 EXPOSE 80
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -38,30 +38,16 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
-    # Gzip compression (level 6 balances CPU vs size, default is 1)
+    # Serve pre-compressed .gz files when available (built at gzip -9)
+    gzip_static on;
+
+    # Gzip compression for dynamic responses (level 6 balances CPU vs size)
     gzip on;
     gzip_vary on;
     gzip_comp_level 6;
     gzip_min_length 256;
     gzip_proxied any;
     gzip_types
-        text/plain
-        text/css
-        text/xml
-        text/javascript
-        application/json
-        application/javascript
-        application/xml
-        application/rss+xml
-        application/atom+xml
-        image/svg+xml
-        font/woff2;
-
-    # Brotli compression (~20-30% smaller than gzip for text assets)
-    brotli on;
-    brotli_comp_level 6;
-    brotli_min_length 256;
-    brotli_types
         text/plain
         text/css
         text/xml


### PR DESCRIPTION
## Summary
- **HOTFIX**: `fholzer/nginx-brotli` Image aus #494 verursacht 503 auf Production
- Zurück auf `nginx:alpine` (bewährt)
- Stattdessen: Assets beim Docker-Build mit `gzip -9` vorcomprimieren + `gzip_static on` für direkte Auslieferung ohne Runtime-CPU-Kosten

Ref #492

## Test plan
- [ ] CI grün
- [ ] Nach Deploy: App erreichbar (kein 503 mehr)
- [ ] Lighthouse Audit triggern

🤖 Generated with [Claude Code](https://claude.com/claude-code)