### PR TITLE
fix: package-lock.json Integrity-Hashes für NDS tgz

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -750,7 +750,7 @@
     "node_modules/@nordlig/components": {
       "version": "1.0.2",
       "resolved": "file:packages/nordlig-components-1.0.2.tgz",
-      "integrity": "sha512-P3dFQsteeO6V6Hqv/KnKnSKLqfsSFMGAgON5VJBkjRvt1fhIZ/5ATFr2z4zXUrC3EI4o+NYHX8/Ygrje6vnJsg==",
+      "integrity": "sha512-2SVC0JhupuLaC9rmMoqxJFFhHxlo/g7pHNxKZbzn6qHnH5GmASvexa9GRsoo3UNk4Yk3/xIvFfo685AGMONWGw==",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@nordlig/styles": "1.0.0",
@@ -818,7 +818,7 @@
     "node_modules/@nordlig/styles": {
       "version": "1.0.0",
       "resolved": "file:packages/nordlig-styles-1.0.0.tgz",
-      "integrity": "sha512-igt75ZeNU+Z/zJA9w4Wibrrx5f7gCO7kXDuv+gLpj3OjnHZmzt6kotupEB4aHHB6P6guJFFuSiJ/qBEb1Er08A==",
+      "integrity": "sha512-9NRHf6x8Jg8lYY4SFwgZQvjldQLN3H/aE4jyjJ/NoIXJHY4PzSYdtfkoPpRAzSf0wQeTZHvDue5rhV5rRKKj5Q==",
       "dependencies": {
         "@nordlig/tokens": "1.0.0"
       }


### PR DESCRIPTION
## Summary
- `package-lock.json` Integrity-Hashes für `@nordlig/styles` und `@nordlig/components` aktualisiert
- Docker-Build schlug mit `EINTEGRITY` bei `npm ci` fehl weil die tgz-Dateien aus #504 neue Hashes hatten

## Test plan
- [ ] `npm ci` lokal erfolgreich
- [ ] Docker-Build (`vite build`) erfolgreich  
- [ ] Coolify Deployment erfolgreich

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)