### PR TITLE
fix: Chart-Farb-Tokens + Hook-Fix (#510)

### DIFF
--- a/.claude/hooks/pre-commit-gate.sh
+++ b/.claude/hooks/pre-commit-gate.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 # PreToolUse hook: blocks `git commit` unless all required QA gates have passed.
 # Exit 0 = allow commit, Exit 2 = block with error message.
+#
+# NOTE: This hook runs on EVERY Bash tool call. It must exit 0 quickly
+# for non-commit commands to avoid blocking normal work.
+
+# Only act on git commit commands — read tool input from stdin
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | grep -o '"command":"[^"]*"' | head -1 | sed 's/"command":"//;s/"$//' 2>/dev/null || true)
+if ! echo "$COMMAND" | grep -q 'git commit'; then
+  exit 0
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "${SCRIPT_DIR}/lib/common.sh"

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 # PreToolUse hook: blocks `git push` to main without a feature branch.
 # Exit 0 = allow push, Exit 2 = block with error message.
+#
+# NOTE: This hook runs on EVERY Bash tool call. It must exit 0 quickly
+# for non-push commands to avoid blocking normal work.
+
+# Only act on git push commands — read tool input from stdin
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | grep -o '"command":"[^"]*"' | head -1 | sed 's/"command":"//;s/"$//' 2>/dev/null || true)
+if ! echo "$COMMAND" | grep -q 'git push'; then
+  exit 0
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "${SCRIPT_DIR}/lib/common.sh"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,6 @@
 @import '@nordlig/styles/core';
 @import '@nordlig/styles/tokens/actionbar';
+@import '@nordlig/styles/tokens/chart';
 
 @import 'tailwindcss';
 


### PR DESCRIPTION
## Summary
- `@import '@nordlig/styles/tokens/chart'` hinzugefügt — `core` enthält keine Chart-Tokens, daher waren `--color-chart-*` undefiniert (schwarz)
- PreToolUse Hooks (`pre-commit-gate.sh`, `pre-push-check.sh`) filtern jetzt nach dem tatsächlichen Befehl — vorher blockierten sie jeden Bash-Aufruf

## Test plan
- [ ] Analyse → Kraft-Tab: Balken sind farbig (nicht schwarz)
- [ ] Wochen-Tonnage Balken farbig
- [ ] Gewichtsverlauf Linien farbig

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)