### PR TITLE
fix: FIT-Export Pace-Toleranzband ±10s (#523)

### DIFF
--- a/backend/app/services/pacing_strategy.py
+++ b/backend/app/services/pacing_strategy.py
@@ -394,13 +394,16 @@ def _build_notes(
 # ---------------------------------------------------------------------------
 
 _GROUPING_TOLERANCE_SEC = 3.0  # km mit <=3s Pace-Differenz werden zusammengefasst
+_PACE_BAND_SEC = 10.0  # ±10s Toleranzband um die Zielpace fuer FIT-Export
 
 
 def pacing_splits_to_segments(splits: list[KmPacingSplit]) -> list[Segment]:
     """Konvertiert Pacing-Splits zu Segment-Objekten fuer FIT-Export.
 
     Aufeinanderfolgende km mit aehnlicher Pace (<=3 sec/km) werden
-    zu einem einzelnen Segment zusammengefasst.
+    zu einem einzelnen Segment zusammengefasst. Auf die Zielpace wird
+    ein Toleranzband von ±10 sec/km angewendet, damit die Uhr nicht
+    bei minimalen Abweichungen alarmiert.
     """
     from app.models.segment import Segment
 
@@ -423,16 +426,20 @@ def pacing_splits_to_segments(splits: list[KmPacingSplit]) -> list[Segment]:
     for i, group in enumerate(groups):
         total_dist = round(sum(s.distance_km for s in group), 2)
         paces = [s.target_pace_sec_per_km for s in group]
-        min_pace = min(paces)  # schnellste
-        max_pace = max(paces)  # langsamste
+        fastest = min(paces)  # schnellste Pace in der Gruppe
+        slowest = max(paces)  # langsamste Pace in der Gruppe
+
+        # Toleranzband: schnellere Grenze = fastest - Band, langsamere = slowest + Band
+        pace_min_sec = max(fastest - _PACE_BAND_SEC, 60.0)  # nicht unter 1:00/km
+        pace_max_sec = slowest + _PACE_BAND_SEC
 
         segments.append(
             Segment(
                 position=i,
                 segment_type="steady",
                 target_distance_km=total_dist,
-                target_pace_min=_format_pace_sec(min_pace),
-                target_pace_max=_format_pace_sec(max_pace),
+                target_pace_min=_format_pace_sec(pace_min_sec),
+                target_pace_max=_format_pace_sec(pace_max_sec),
             )
         )
 

--- a/backend/app/tests/test_pacing_strategy.py
+++ b/backend/app/tests/test_pacing_strategy.py
@@ -396,3 +396,25 @@ class TestPacingSplitsToSegments:
         seg_total = sum(s.target_distance_km or 0 for s in segments)
         split_total = sum(s.distance_km for s in result.splits)
         assert seg_total == pytest.approx(split_total, abs=0.01)
+
+    def test_pace_tolerance_band(self) -> None:
+        """Toleranzband: pace_min ~10s schneller, pace_max ~10s langsamer als Ziel."""
+        result = generate_pacing_strategy(_hm_request(strategy="even", elevation_preset="flat"))
+        segments = pacing_splits_to_segments(result.splits)
+        assert len(segments) == 1
+        seg = segments[0]
+        # Zielpace ist ~341s (5:41) -> Band: 331s (5:31) bis 351s (5:51)
+        avg_pace = result.avg_pace_sec_per_km
+
+        def _pace_to_sec(pace_str: str) -> float:
+            parts = pace_str.split(":")
+            return int(parts[0]) * 60 + int(parts[1])
+
+        assert seg.target_pace_min is not None
+        assert seg.target_pace_max is not None
+        min_sec = _pace_to_sec(seg.target_pace_min)
+        max_sec = _pace_to_sec(seg.target_pace_max)
+        # min (schneller) sollte ~10s unter avg liegen
+        assert min_sec == pytest.approx(avg_pace - 10, abs=1.5)
+        # max (langsamer) sollte ~10s ueber avg liegen
+        assert max_sec == pytest.approx(avg_pace + 10, abs=1.5)


### PR DESCRIPTION
## Summary
- Pace-Toleranzband von ±10 sec/km statt exakter Zielpace im FIT-Export
- Bei Zielpace 5:41/km → Korridor 5:31–5:51/km auf der Uhr
- Verhindert ständige Pace-Alarme bei minimalen Abweichungen

## Test plan
- [ ] FIT-Datei exportieren → Segment hat pace_min ~10s schneller und pace_max ~10s langsamer als Zielpace
- [ ] `pytest app/tests/test_pacing_strategy.py` — 37 Tests bestanden inkl. neuem Toleranzband-Test

Closes #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)