### PR TITLE
fix: Pace-Toleranzband ±10s + RunDetails-Fix (#525)

### DIFF
--- a/backend/app/api/v1/pacing.py
+++ b/backend/app/api/v1/pacing.py
@@ -243,11 +243,11 @@ async def transfer_pacing_to_weekly_plan(
         db.add(day_model)
         await db.flush()  # ID generieren
 
-    # 5) RunDetails JSON bauen
-    run_details = {
-        "run_type": "race",
-        "segments": [seg.model_dump(exclude_none=True) for seg in segments],
-    }
+    # 5) RunDetails via Pydantic Model bauen (Validatoren berechnen top-level Felder)
+    from app.models.weekly_plan import RunDetails
+
+    run_details_model = RunDetails(run_type="race", segments=segments)
+    run_details = run_details_model.model_dump(exclude_none=True)
 
     # 6) Existierende Race-Session suchen (Duplikat-Erkennung)
     sessions_result = await db.execute(

--- a/backend/app/services/pacing_strategy.py
+++ b/backend/app/services/pacing_strategy.py
@@ -394,13 +394,16 @@ def _build_notes(
 # ---------------------------------------------------------------------------
 
 _GROUPING_TOLERANCE_SEC = 3.0  # km mit <=3s Pace-Differenz werden zusammengefasst
+_PACE_BAND_SEC = 10.0  # ±10s Toleranzband um die Zielpace fuer FIT-Export
 
 
 def pacing_splits_to_segments(splits: list[KmPacingSplit]) -> list[Segment]:
     """Konvertiert Pacing-Splits zu Segment-Objekten fuer FIT-Export.
 
     Aufeinanderfolgende km mit aehnlicher Pace (<=3 sec/km) werden
-    zu einem einzelnen Segment zusammengefasst.
+    zu einem einzelnen Segment zusammengefasst. Auf die Zielpace wird
+    ein Toleranzband von ±10 sec/km angewendet, damit die Uhr nicht
+    bei minimalen Abweichungen alarmiert.
     """
     from app.models.segment import Segment
 
@@ -423,16 +426,20 @@ def pacing_splits_to_segments(splits: list[KmPacingSplit]) -> list[Segment]:
     for i, group in enumerate(groups):
         total_dist = round(sum(s.distance_km for s in group), 2)
         paces = [s.target_pace_sec_per_km for s in group]
-        min_pace = min(paces)  # schnellste
-        max_pace = max(paces)  # langsamste
+        fastest = min(paces)
+        slowest = max(paces)
+
+        # Toleranzband: schnellere Grenze = fastest - Band, langsamere = slowest + Band
+        pace_min_sec = max(fastest - _PACE_BAND_SEC, 60.0)  # nicht unter 1:00/km
+        pace_max_sec = slowest + _PACE_BAND_SEC
 
         segments.append(
             Segment(
                 position=i,
                 segment_type="steady",
                 target_distance_km=total_dist,
-                target_pace_min=_format_pace_sec(min_pace),
-                target_pace_max=_format_pace_sec(max_pace),
+                target_pace_min=_format_pace_sec(pace_min_sec),
+                target_pace_max=_format_pace_sec(pace_max_sec),
             )
         )
 

--- a/backend/app/tests/test_pacing_strategy.py
+++ b/backend/app/tests/test_pacing_strategy.py
@@ -396,3 +396,24 @@ class TestPacingSplitsToSegments:
         seg_total = sum(s.target_distance_km or 0 for s in segments)
         split_total = sum(s.distance_km for s in result.splits)
         assert seg_total == pytest.approx(split_total, abs=0.01)
+
+    def test_pace_tolerance_band(self) -> None:
+        """Toleranzband: pace_min ~10s schneller, pace_max ~10s langsamer als Ziel."""
+        result = generate_pacing_strategy(_hm_request(strategy="even", elevation_preset="flat"))
+        segments = pacing_splits_to_segments(result.splits)
+        assert len(segments) == 1
+        seg = segments[0]
+        avg_pace = result.avg_pace_sec_per_km
+
+        def _pace_to_sec(pace_str: str) -> float:
+            parts = pace_str.split(":")
+            return int(parts[0]) * 60 + int(parts[1])
+
+        assert seg.target_pace_min is not None
+        assert seg.target_pace_max is not None
+        min_sec = _pace_to_sec(seg.target_pace_min)
+        max_sec = _pace_to_sec(seg.target_pace_max)
+        # min (schneller) sollte ~10s unter avg liegen
+        assert min_sec == pytest.approx(avg_pace - 10, abs=1.5)
+        # max (langsamer) sollte ~10s ueber avg liegen
+        assert max_sec == pytest.approx(avg_pace + 10, abs=1.5)


### PR DESCRIPTION
## Summary
- Pace-Toleranzband von ±10 sec/km statt exakter Zielpace im FIT-Export und Wochenplan
- Bei Zielpace 5:41/km → Korridor 5:31–5:51/km auf der Uhr
- RunDetails via Pydantic Model statt rohes dict, damit Wochenplan den Pace-Bereich korrekt anzeigt

## Test plan
- [ ] FIT-Export: Segment hat pace_min ~10s schneller und pace_max ~10s langsamer als Zielpace
- [ ] Wochenplan: Pace-Bereich (z.B. "5:31–5:51") statt fixem Wert angezeigt
- [ ] `pytest app/tests/test_pacing_strategy.py` — 37 Tests bestanden

Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)