### PR TITLE
feat: Pacing-Strategien am Ziel speichern (#528)

### DIFF
--- a/backend/alembic/versions/c044_add_pacing_strategies.py
+++ b/backend/alembic/versions/c044_add_pacing_strategies.py
@@ -1,0 +1,40 @@
+"""Pacing-Strategien am Ziel speichern (#528).
+
+Revision ID: c044
+Revises: c043
+Create Date: 2026-03-28
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "c044"
+down_revision = "c043"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "pacing_strategies",
+        sa.Column("id", sa.Integer, primary_key=True, index=True),
+        sa.Column(
+            "goal_id", sa.Integer, sa.ForeignKey("race_goals.id"), nullable=False, index=True
+        ),
+        sa.Column("strategy", sa.String(30), nullable=False),
+        sa.Column("strategy_label", sa.String(50), nullable=False),
+        sa.Column("distance_km", sa.Float, nullable=False),
+        sa.Column("target_time_seconds", sa.Integer, nullable=False),
+        sa.Column("target_time_formatted", sa.String(20), nullable=False),
+        sa.Column("avg_pace_sec_per_km", sa.Float, nullable=False),
+        sa.Column("avg_pace_formatted", sa.String(10), nullable=False),
+        sa.Column("splits_json", sa.Text, nullable=False),
+        sa.Column("weather_json", sa.Text, nullable=True),
+        sa.Column("elevation_preset", sa.String(20), nullable=True),
+        sa.Column("notes_json", sa.Text, nullable=True),
+        sa.Column("created_at", sa.DateTime, server_default=sa.func.now(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("pacing_strategies")

--- a/backend/app/api/v1/pacing.py
+++ b/backend/app/api/v1/pacing.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.infrastructure.database.models import (
+    PacingStrategyModel,
     PlannedSessionModel,
     RaceGoalModel,
     WeeklyPlanDayModel,
@@ -22,6 +23,7 @@ from app.infrastructure.external.http_client import ExternalAPIClient
 from app.models.enrichment import wmo_to_label
 from app.models.pacing import (
     ElevationSegment,
+    KmPacingSplit,
     PacingRecommendationRequest,
     PacingRecommendationResponse,
     PacingRequest,
@@ -29,6 +31,9 @@ from app.models.pacing import (
     PacingToWeeklyPlanRequest,
     PacingToWeeklyPlanResponse,
     RaceDayWeatherResponse,
+    SavedPacingStrategyListResponse,
+    SavedPacingStrategyResponse,
+    WeatherAdjustment,
 )
 from app.services.fit_export import export_template_to_fit
 from app.services.gpx_elevation_parser import parse_gpx_elevation
@@ -65,7 +70,13 @@ async def generate_pacing(
             }
         )
 
-    return generate_pacing_strategy(body)
+    pacing = generate_pacing_strategy(body)
+
+    # Auto-Save: Strategie am Ziel speichern wenn goal_id vorhanden
+    if body.goal_id is not None:
+        await _save_pacing_strategy(db, body.goal_id, pacing, body.elevation_preset)
+
+    return pacing
 
 
 @router.get("/weather-forecast", response_model=RaceDayWeatherResponse)
@@ -306,3 +317,123 @@ def _safe_float(value: object) -> float | None:
         return float(value)  # type: ignore[arg-type]
     except (TypeError, ValueError):
         return None
+
+
+# ---------------------------------------------------------------------------
+# Gespeicherte Pacing-Strategien (#528)
+# ---------------------------------------------------------------------------
+
+
+async def _save_pacing_strategy(
+    db: AsyncSession,
+    goal_id: int,
+    pacing: PacingResponse,
+    elevation_preset: str | None,
+) -> PacingStrategyModel:
+    """Speichert eine generierte Pacing-Strategie in der DB."""
+    model = PacingStrategyModel(
+        goal_id=goal_id,
+        strategy=pacing.strategy,
+        strategy_label=pacing.strategy_label,
+        distance_km=pacing.distance_km,
+        target_time_seconds=pacing.target_time_seconds,
+        target_time_formatted=pacing.target_time_formatted,
+        avg_pace_sec_per_km=pacing.avg_pace_sec_per_km,
+        avg_pace_formatted=pacing.avg_pace_formatted,
+        splits_json=json.dumps([s.model_dump() for s in pacing.splits], ensure_ascii=False),
+        weather_json=(
+            json.dumps(pacing.weather_adjustment.model_dump(), ensure_ascii=False)
+            if pacing.weather_adjustment
+            else None
+        ),
+        elevation_preset=elevation_preset,
+        notes_json=json.dumps(pacing.notes, ensure_ascii=False) if pacing.notes else None,
+    )
+    db.add(model)
+    await db.commit()
+    await db.refresh(model)
+    return model
+
+
+def _db_to_response(model: PacingStrategyModel) -> SavedPacingStrategyResponse:
+    """Konvertiert ein DB-Modell in ein Response-Schema."""
+    splits = [KmPacingSplit(**s) for s in json.loads(model.splits_json)]
+    weather = WeatherAdjustment(**json.loads(model.weather_json)) if model.weather_json else None
+    notes: list[str] = json.loads(model.notes_json) if model.notes_json else []
+
+    return SavedPacingStrategyResponse(
+        id=model.id,
+        goal_id=model.goal_id,
+        strategy=model.strategy,
+        strategy_label=model.strategy_label,
+        distance_km=model.distance_km,
+        target_time_seconds=model.target_time_seconds,
+        target_time_formatted=model.target_time_formatted,
+        avg_pace_sec_per_km=model.avg_pace_sec_per_km,
+        avg_pace_formatted=model.avg_pace_formatted,
+        splits=splits,
+        weather_adjustment=weather,
+        elevation_preset=model.elevation_preset,
+        notes=notes,
+        created_at=model.created_at.isoformat() if model.created_at else "",
+    )
+
+
+@router.get(
+    "/goals/{goal_id}/strategies",
+    response_model=SavedPacingStrategyListResponse,
+)
+async def list_pacing_strategies(
+    goal_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> SavedPacingStrategyListResponse:
+    """Listet alle gespeicherten Pacing-Strategien fuer ein Ziel."""
+    result = await db.execute(
+        select(PacingStrategyModel)
+        .where(PacingStrategyModel.goal_id == goal_id)
+        .order_by(PacingStrategyModel.created_at.desc())
+    )
+    models = result.scalars().all()
+    return SavedPacingStrategyListResponse(strategies=[_db_to_response(m) for m in models])
+
+
+@router.get(
+    "/goals/{goal_id}/strategies/{strategy_id}",
+    response_model=SavedPacingStrategyResponse,
+)
+async def get_pacing_strategy(
+    goal_id: int,
+    strategy_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> SavedPacingStrategyResponse:
+    """Gibt eine einzelne gespeicherte Pacing-Strategie zurueck."""
+    result = await db.execute(
+        select(PacingStrategyModel).where(
+            PacingStrategyModel.id == strategy_id,
+            PacingStrategyModel.goal_id == goal_id,
+        )
+    )
+    model = result.scalar_one_or_none()
+    if model is None:
+        raise HTTPException(status_code=404, detail="Strategie nicht gefunden")
+    return _db_to_response(model)
+
+
+@router.delete("/goals/{goal_id}/strategies/{strategy_id}", status_code=204)
+async def delete_pacing_strategy(
+    goal_id: int,
+    strategy_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Loescht eine gespeicherte Pacing-Strategie."""
+    result = await db.execute(
+        select(PacingStrategyModel).where(
+            PacingStrategyModel.id == strategy_id,
+            PacingStrategyModel.goal_id == goal_id,
+        )
+    )
+    model = result.scalar_one_or_none()
+    if model is None:
+        raise HTTPException(status_code=404, detail="Strategie nicht gefunden")
+    await db.delete(model)
+    await db.commit()

--- a/backend/app/infrastructure/database/models.py
+++ b/backend/app/infrastructure/database/models.py
@@ -202,6 +202,30 @@ class RaceGoalModel(Base):
     )
 
 
+class PacingStrategyModel(Base):
+    """Gespeicherte Pacing-Strategie fuer ein Wettkampf-Ziel (#528)."""
+
+    __tablename__ = "pacing_strategies"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    goal_id: Mapped[int] = mapped_column(ForeignKey("race_goals.id"), index=True)
+    strategy: Mapped[str] = mapped_column(String(30))  # even, negative, effort_based
+    strategy_label: Mapped[str] = mapped_column(String(50))
+    distance_km: Mapped[float] = mapped_column(Float)
+    target_time_seconds: Mapped[int] = mapped_column(Integer)
+    target_time_formatted: Mapped[str] = mapped_column(String(20))
+    avg_pace_sec_per_km: Mapped[float] = mapped_column(Float)
+    avg_pace_formatted: Mapped[str] = mapped_column(String(10))
+    splits_json: Mapped[str] = mapped_column(Text)  # JSON: list[KmPacingSplit]
+    weather_json: Mapped[str | None] = mapped_column(Text, default=None)
+    elevation_preset: Mapped[str | None] = mapped_column(String(20), default=None)
+    notes_json: Mapped[str | None] = mapped_column(Text, default=None)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, server_default=func.now()
+    )
+
+
 class TrainingRouteModel(Base):
     """Trainingsroute mit GPS-Waypoints und Segment-Zielen (#508)."""
 

--- a/backend/app/models/pacing.py
+++ b/backend/app/models/pacing.py
@@ -165,3 +165,33 @@ class PacingToWeeklyPlanResponse(BaseModel):
     entry_id: int = Field(description="ID der erstellten/aktualisierten PlannedSession")
     race_date: str = Field(description="Datum des Renntags (ISO)")
     message: str
+
+
+# ---------------------------------------------------------------------------
+# Gespeicherte Pacing-Strategien (#528)
+# ---------------------------------------------------------------------------
+
+
+class SavedPacingStrategyResponse(BaseModel):
+    """Response: Gespeicherte Pacing-Strategie."""
+
+    id: int
+    goal_id: int
+    strategy: str
+    strategy_label: str
+    distance_km: float
+    target_time_seconds: int
+    target_time_formatted: str
+    avg_pace_sec_per_km: float
+    avg_pace_formatted: str
+    splits: list[KmPacingSplit]
+    weather_adjustment: WeatherAdjustment | None = None
+    elevation_preset: str | None = None
+    notes: list[str] = Field(default_factory=list)
+    created_at: str
+
+
+class SavedPacingStrategyListResponse(BaseModel):
+    """Response: Liste gespeicherter Pacing-Strategien fuer ein Ziel."""
+
+    strategies: list[SavedPacingStrategyResponse]

--- a/backend/app/tests/test_pacing_persistence.py
+++ b/backend/app/tests/test_pacing_persistence.py
@@ -1,0 +1,202 @@
+"""Tests fuer Pacing-Strategie Persistenz (#528)."""
+
+from datetime import datetime
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.infrastructure.database.models import RaceGoalModel
+
+PACING_BASE = "/api/v1/pacing"
+
+
+async def _create_goal(db: AsyncSession) -> RaceGoalModel:
+    """Erstellt ein Test-Goal in der DB."""
+    goal = RaceGoalModel(
+        title="Hamburg HM",
+        race_date=datetime(2026, 4, 26),
+        distance_km=21.0975,
+        target_time_seconds=6600,  # 1:50:00
+        is_active=True,
+    )
+    db.add(goal)
+    await db.commit()
+    await db.refresh(goal)
+    return goal
+
+
+@pytest.mark.asyncio
+class TestPacingAutoSave:
+    """Auto-Save: /generate speichert Strategie wenn goal_id vorhanden."""
+
+    async def test_generate_with_goal_saves_strategy(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        goal = await _create_goal(db_session)
+        resp = await client.post(
+            f"{PACING_BASE}/generate",
+            json={
+                "target_time_seconds": 6600,
+                "distance_km": 21.0975,
+                "strategy": "even",
+                "goal_id": goal.id,
+            },
+        )
+        assert resp.status_code == 200
+
+        # Pruefen ob Strategie gespeichert wurde
+        list_resp = await client.get(f"{PACING_BASE}/goals/{goal.id}/strategies")
+        assert list_resp.status_code == 200
+        data = list_resp.json()
+        assert len(data["strategies"]) == 1
+        saved = data["strategies"][0]
+        assert saved["strategy"] == "even"
+        assert saved["goal_id"] == goal.id
+        assert saved["distance_km"] == pytest.approx(21.0975)
+        assert len(saved["splits"]) > 0
+
+    async def test_generate_without_goal_does_not_save(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            f"{PACING_BASE}/generate",
+            json={
+                "target_time_seconds": 6600,
+                "distance_km": 21.0975,
+                "strategy": "even",
+            },
+        )
+        assert resp.status_code == 200
+        # Keine goal_id → nichts gespeichert (kein Crash)
+
+    async def test_multiple_generates_save_multiple(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        goal = await _create_goal(db_session)
+        for strategy in ["even", "negative", "effort_based"]:
+            resp = await client.post(
+                f"{PACING_BASE}/generate",
+                json={
+                    "target_time_seconds": 6600,
+                    "distance_km": 21.0975,
+                    "strategy": strategy,
+                    "goal_id": goal.id,
+                },
+            )
+            assert resp.status_code == 200
+
+        list_resp = await client.get(f"{PACING_BASE}/goals/{goal.id}/strategies")
+        assert list_resp.status_code == 200
+        assert len(list_resp.json()["strategies"]) == 3
+
+
+@pytest.mark.asyncio
+class TestPacingStrategyCRUD:
+    """CRUD-Endpoints fuer gespeicherte Strategien."""
+
+    async def test_list_empty(self, client: AsyncClient, db_session: AsyncSession) -> None:
+        goal = await _create_goal(db_session)
+        resp = await client.get(f"{PACING_BASE}/goals/{goal.id}/strategies")
+        assert resp.status_code == 200
+        assert resp.json()["strategies"] == []
+
+    async def test_get_single(self, client: AsyncClient, db_session: AsyncSession) -> None:
+        goal = await _create_goal(db_session)
+        # Generieren (auto-save)
+        await client.post(
+            f"{PACING_BASE}/generate",
+            json={
+                "target_time_seconds": 6600,
+                "distance_km": 21.0975,
+                "strategy": "negative",
+                "goal_id": goal.id,
+            },
+        )
+        # Liste holen
+        list_resp = await client.get(f"{PACING_BASE}/goals/{goal.id}/strategies")
+        strategy_id = list_resp.json()["strategies"][0]["id"]
+
+        # Einzeln abrufen
+        resp = await client.get(f"{PACING_BASE}/goals/{goal.id}/strategies/{strategy_id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["strategy"] == "negative"
+        assert data["id"] == strategy_id
+
+    async def test_get_nonexistent_returns_404(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        goal = await _create_goal(db_session)
+        resp = await client.get(f"{PACING_BASE}/goals/{goal.id}/strategies/9999")
+        assert resp.status_code == 404
+
+    async def test_delete(self, client: AsyncClient, db_session: AsyncSession) -> None:
+        goal = await _create_goal(db_session)
+        await client.post(
+            f"{PACING_BASE}/generate",
+            json={
+                "target_time_seconds": 6600,
+                "distance_km": 21.0975,
+                "strategy": "even",
+                "goal_id": goal.id,
+            },
+        )
+        list_resp = await client.get(f"{PACING_BASE}/goals/{goal.id}/strategies")
+        strategy_id = list_resp.json()["strategies"][0]["id"]
+
+        # Loeschen
+        del_resp = await client.delete(f"{PACING_BASE}/goals/{goal.id}/strategies/{strategy_id}")
+        assert del_resp.status_code == 204
+
+        # Danach leer
+        list_resp2 = await client.get(f"{PACING_BASE}/goals/{goal.id}/strategies")
+        assert len(list_resp2.json()["strategies"]) == 0
+
+    async def test_delete_nonexistent_returns_404(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        goal = await _create_goal(db_session)
+        resp = await client.delete(f"{PACING_BASE}/goals/{goal.id}/strategies/9999")
+        assert resp.status_code == 404
+
+    async def test_list_ordered_by_newest_first(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        goal = await _create_goal(db_session)
+        for strategy in ["even", "negative"]:
+            await client.post(
+                f"{PACING_BASE}/generate",
+                json={
+                    "target_time_seconds": 6600,
+                    "distance_km": 21.0975,
+                    "strategy": strategy,
+                    "goal_id": goal.id,
+                },
+            )
+
+        list_resp = await client.get(f"{PACING_BASE}/goals/{goal.id}/strategies")
+        strategies = list_resp.json()["strategies"]
+        assert len(strategies) == 2
+        # Neueste zuerst
+        assert strategies[0]["strategy"] == "negative"
+        assert strategies[1]["strategy"] == "even"
+
+    async def test_weather_data_persisted(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        goal = await _create_goal(db_session)
+        resp = await client.post(
+            f"{PACING_BASE}/generate",
+            json={
+                "target_time_seconds": 6600,
+                "distance_km": 21.0975,
+                "strategy": "even",
+                "goal_id": goal.id,
+                "temperature_celsius": 28.0,
+            },
+        )
+        assert resp.status_code == 200
+
+        list_resp = await client.get(f"{PACING_BASE}/goals/{goal.id}/strategies")
+        saved = list_resp.json()["strategies"][0]
+        assert saved["weather_adjustment"] is not None
+        assert saved["weather_adjustment"]["temperature_celsius"] == 28.0


### PR DESCRIPTION
## Summary
- Neues DB-Modell `PacingStrategyModel` mit FK zu `race_goals` — speichert Splits, Wetter, Elevation, Strategie-Typ
- **Auto-Save**: `POST /pacing/generate` speichert Ergebnis automatisch wenn `goal_id` vorhanden
- **CRUD-Endpoints**: `GET /pacing/goals/{id}/strategies`, `GET .../strategies/{id}`, `DELETE .../strategies/{id}`
- Sortierung: Neueste Strategie zuerst
- Alembic Migration `c044`

## Test plan
- [x] 10 neue Tests (Auto-Save, CRUD, Sortierung, Weather-Persistenz, 404-Cases)
- [x] 933 Gesamttests bestanden
- [x] Ruff, Mypy, Format bestanden

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)