### PR TITLE
feat: Segment-Editor auf Route (#532)

### DIFF
--- a/frontend/src/components/route-editor/SegmentBar.tsx
+++ b/frontend/src/components/route-editor/SegmentBar.tsx
@@ -1,0 +1,59 @@
+/**
+ * Farbcodierte Segment-Leiste unter der Karte.
+ * Zeigt alle Segmente proportional zur Distanz als farbige Balken.
+ */
+
+import { SEGMENT_TYPE_COLORS, SEGMENT_TYPE_LABELS } from '@/constants/segmentColors';
+import type { RouteSegment } from '@/api/routes';
+
+interface SegmentBarProps {
+  segments: RouteSegment[];
+  totalDistanceKm: number;
+  onSegmentClick?: (index: number) => void;
+  activeSegment?: number | null;
+}
+
+export function SegmentBar({
+  segments,
+  totalDistanceKm,
+  onSegmentClick,
+  activeSegment,
+}: SegmentBarProps) {
+  if (segments.length === 0 || totalDistanceKm <= 0) return null;
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex h-6 rounded-[var(--radius-component-sm)] overflow-hidden border border-[var(--color-border-default)]">
+        {segments.map((seg, i) => {
+          const width = ((seg.end_km - seg.start_km) / totalDistanceKm) * 100;
+          const color = SEGMENT_TYPE_COLORS[seg.segment_type] ?? '#9ca3af';
+          const isActive = activeSegment === i;
+
+          return (
+            <button
+              key={i}
+              onClick={() => onSegmentClick?.(i)}
+              className="relative transition-opacity motion-reduce:transition-none min-w-[2px]"
+              style={{
+                width: `${width}%`,
+                backgroundColor: color,
+                opacity: isActive ? 1 : 0.7,
+              }}
+              title={`${SEGMENT_TYPE_LABELS[seg.segment_type] ?? seg.segment_type}: ${seg.start_km}–${seg.end_km} km`}
+            >
+              {width > 10 && (
+                <span className="absolute inset-0 flex items-center justify-center text-[10px] font-medium text-[var(--color-text-on-primary)]">
+                  {SEGMENT_TYPE_LABELS[seg.segment_type]?.slice(0, 4) ?? ''}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+      <div className="flex justify-between text-[10px] text-[var(--color-text-muted)]">
+        <span>0 km</span>
+        <span>{totalDistanceKm.toFixed(1)} km</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/route-editor/SegmentTable.tsx
+++ b/frontend/src/components/route-editor/SegmentTable.tsx
@@ -1,0 +1,169 @@
+/**
+ * Segment-Tabelle mit Inline-Editing für Route-Segmente.
+ * Erlaubt Typ-Auswahl, Pace/HR-Ziele pro Segment.
+ */
+
+import { Button, Input, Select, Badge } from '@nordlig/components';
+import { Trash2, Plus } from 'lucide-react';
+import { SEGMENT_TYPE_COLORS, SEGMENT_TYPE_OPTIONS } from '@/constants/segmentColors';
+import type { RouteSegment } from '@/api/routes';
+
+interface SegmentTableProps {
+  segments: RouteSegment[];
+  totalDistanceKm: number;
+  onUpdate: (index: number, segment: RouteSegment) => void;
+  onDelete: (index: number) => void;
+  onAdd: () => void;
+  activeSegment?: number | null;
+  onSegmentClick?: (index: number) => void;
+}
+
+function SegmentRow({
+  segment,
+  index,
+  onUpdate,
+  onDelete,
+  isActive,
+  onClick,
+}: {
+  segment: RouteSegment;
+  index: number;
+  onUpdate: (index: number, seg: RouteSegment) => void;
+  onDelete: (index: number) => void;
+  isActive: boolean;
+  onClick: () => void;
+}) {
+  const color = SEGMENT_TYPE_COLORS[segment.segment_type] ?? '#9ca3af';
+
+  return (
+    <div
+      onClick={onClick}
+      className={`flex flex-col sm:flex-row sm:items-center gap-2 p-3 rounded-[var(--radius-component-sm)] border cursor-pointer transition-colors motion-reduce:transition-none ${
+        isActive
+          ? 'border-[var(--color-border-focus)] bg-[var(--color-bg-subtle)]'
+          : 'border-[var(--color-border-default)]'
+      }`}
+    >
+      {/* Farb-Indikator + Typ */}
+      <div className="flex items-center gap-2 min-w-[140px]">
+        <div className="w-3 h-3 rounded-full flex-shrink-0" style={{ backgroundColor: color }} />
+        <Select
+          options={SEGMENT_TYPE_OPTIONS}
+          value={segment.segment_type}
+          onChange={(val) => {
+            if (val) onUpdate(index, { ...segment, segment_type: val });
+          }}
+          className="text-sm flex-1"
+        />
+      </div>
+
+      {/* Distanz */}
+      <Badge variant="neutral" size="sm" className="flex-shrink-0">
+        {segment.start_km.toFixed(1)}–{segment.end_km.toFixed(1)} km
+      </Badge>
+
+      {/* Pace */}
+      <div className="flex items-center gap-1">
+        <Input
+          placeholder="min"
+          value={segment.target_pace_min ?? ''}
+          onChange={(e) => onUpdate(index, { ...segment, target_pace_min: e.target.value || null })}
+          className="w-16 text-xs"
+        />
+        <span className="text-xs text-[var(--color-text-muted)]">–</span>
+        <Input
+          placeholder="max"
+          value={segment.target_pace_max ?? ''}
+          onChange={(e) => onUpdate(index, { ...segment, target_pace_max: e.target.value || null })}
+          className="w-16 text-xs"
+        />
+        <span className="text-xs text-[var(--color-text-muted)]">/km</span>
+      </div>
+
+      {/* HR */}
+      <div className="flex items-center gap-1">
+        <Input
+          placeholder="HR"
+          type="number"
+          value={segment.target_hr_min ?? ''}
+          onChange={(e) =>
+            onUpdate(index, {
+              ...segment,
+              target_hr_min: e.target.value ? Number(e.target.value) : null,
+            })
+          }
+          className="w-14 text-xs"
+        />
+        <span className="text-xs text-[var(--color-text-muted)]">–</span>
+        <Input
+          placeholder="HR"
+          type="number"
+          value={segment.target_hr_max ?? ''}
+          onChange={(e) =>
+            onUpdate(index, {
+              ...segment,
+              target_hr_max: e.target.value ? Number(e.target.value) : null,
+            })
+          }
+          className="w-14 text-xs"
+        />
+        <span className="text-xs text-[var(--color-text-muted)]">bpm</span>
+      </div>
+
+      {/* Delete */}
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onDelete(index);
+        }}
+        className="p-1.5 rounded-[var(--radius-component-sm)] hover:bg-[var(--color-bg-subtle)] min-w-[44px] min-h-[44px] flex items-center justify-center flex-shrink-0"
+      >
+        <Trash2 className="w-4 h-4 text-[var(--color-text-muted)]" />
+      </button>
+    </div>
+  );
+}
+
+export function SegmentTable({
+  segments,
+  totalDistanceKm,
+  onUpdate,
+  onDelete,
+  onAdd,
+  activeSegment,
+  onSegmentClick,
+}: SegmentTableProps) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium text-[var(--color-text-base)]">
+          Segmente ({segments.length})
+        </h3>
+        <Button variant="secondary" size="sm" onClick={onAdd} disabled={totalDistanceKm <= 0}>
+          <Plus className="w-3.5 h-3.5 mr-1" />
+          Segment
+        </Button>
+      </div>
+
+      {segments.length === 0 && (
+        <p className="text-xs text-[var(--color-text-muted)] py-4 text-center">
+          Noch keine Segmente. Klicke „Segment" um die Route aufzuteilen.
+        </p>
+      )}
+
+      <div className="space-y-1.5">
+        {segments.map((seg, i) => (
+          <SegmentRow
+            key={i}
+            segment={seg}
+            index={i}
+            onUpdate={onUpdate}
+            onDelete={onDelete}
+            isActive={activeSegment === i}
+            onClick={() => onSegmentClick?.(i)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/constants/segmentColors.ts
+++ b/frontend/src/constants/segmentColors.ts
@@ -1,0 +1,34 @@
+/**
+ * Segment type colors and labels for route planning.
+ * Uses canonical segment types from taxonomy.
+ */
+
+/** Farben für Segment-Typen auf der Karte und in der Segment-Leiste. */
+export const SEGMENT_TYPE_COLORS: Record<string, string> = {
+  warmup: '#22c55e', // grün
+  cooldown: '#22c55e', // grün
+  steady: '#3b82f6', // blau
+  work: '#ef4444', // rot
+  recovery_jog: '#93c5fd', // hellblau
+  rest: '#9ca3af', // grau
+  strides: '#f59e0b', // amber
+  drills: '#a855f7', // lila
+};
+
+/** Deutsche Labels für Segment-Typen. */
+export const SEGMENT_TYPE_LABELS: Record<string, string> = {
+  warmup: 'Warm-up',
+  cooldown: 'Cool-down',
+  steady: 'Dauerlauf',
+  work: 'Intervall',
+  recovery_jog: 'Trabpause',
+  rest: 'Pause',
+  strides: 'Steigerung',
+  drills: 'Lauf-ABC',
+};
+
+/** Optionen für Segment-Typ Dropdown. */
+export const SEGMENT_TYPE_OPTIONS = Object.entries(SEGMENT_TYPE_LABELS).map(([value, label]) => ({
+  value,
+  label,
+}));

--- a/frontend/src/features/maps/RouteEditorMap.tsx
+++ b/frontend/src/features/maps/RouteEditorMap.tsx
@@ -7,7 +7,8 @@
 import { useEffect, useRef } from 'react';
 import L from 'leaflet';
 import { TILES } from './tileStyles';
-import type { Waypoint } from '@/api/routes';
+import type { Waypoint, RouteSegment } from '@/api/routes';
+import { SEGMENT_TYPE_COLORS } from '@/constants/segmentColors';
 
 export interface RouteEditorMapProps {
   waypoints: Waypoint[];
@@ -17,6 +18,7 @@ export interface RouteEditorMapProps {
   onWaypointDelete: (index: number) => void;
   routing?: boolean;
   height?: string;
+  segments?: RouteSegment[];
 }
 
 const DEFAULT_CENTER: L.LatLngTuple = [53.55, 9.99]; // Hamburg
@@ -115,6 +117,45 @@ function MapOverlays({ routing, empty }: { routing: boolean; empty: boolean }) {
   );
 }
 
+/** Erstelle farbige Polylines basierend auf Segmenten. */
+function createSegmentPolylines(
+  map: L.Map,
+  routePoints: Waypoint[],
+  segments: RouteSegment[],
+): L.Polyline[] {
+  if (routePoints.length < 2 || segments.length === 0) return [];
+
+  // Berechne kumulative Distanz für jeden Punkt
+  const cumDist: number[] = [0];
+  for (let i = 1; i < routePoints.length; i++) {
+    const dlat = routePoints[i].lat - routePoints[i - 1].lat;
+    const dlng = routePoints[i].lng - routePoints[i - 1].lng;
+    cumDist.push(cumDist[i - 1] + Math.sqrt(dlat * dlat + dlng * dlng) * 111.32);
+  }
+  const totalKm = cumDist[cumDist.length - 1];
+  if (totalKm <= 0) return [];
+
+  return segments.map((seg) => {
+    const startFrac = seg.start_km / totalKm;
+    const endFrac = seg.end_km / totalKm;
+    const startIdx = Math.max(
+      0,
+      cumDist.findIndex((d) => d / totalKm >= startFrac),
+    );
+    const endIdx = Math.min(
+      routePoints.length - 1,
+      cumDist.findIndex((d) => d / totalKm >= endFrac),
+    );
+    const segPoints = routePoints.slice(startIdx, endIdx + 1);
+    const color = SEGMENT_TYPE_COLORS[seg.segment_type] ?? '#3b82f6';
+
+    return L.polyline(
+      segPoints.map((p) => [p.lat, p.lng] as L.LatLngTuple),
+      { color, weight: 5, opacity: 0.85 },
+    ).addTo(map);
+  });
+}
+
 export function RouteEditorMap({
   waypoints,
   routePoints,
@@ -123,11 +164,13 @@ export function RouteEditorMap({
   onWaypointDelete,
   routing = false,
   height = '60vh',
+  segments = [],
 }: RouteEditorMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<L.Map | null>(null);
   const markersRef = useRef<L.CircleMarker[]>([]);
   const polylineRef = useRef<L.Polyline | null>(null);
+  const segmentLinesRef = useRef<L.Polyline[]>([]);
   const callbacksRef = useRef({ onWaypointAdd, onWaypointMove, onWaypointDelete });
 
   useEffect(() => {
@@ -180,6 +223,19 @@ export function RouteEditorMap({
       },
     ).addTo(map);
   }, [routePoints, waypoints, routing]);
+
+  // Update segment color overlays
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    segmentLinesRef.current.forEach((l) => l.remove());
+    segmentLinesRef.current = [];
+
+    if (segments.length > 0 && routePoints.length > 1) {
+      segmentLinesRef.current = createSegmentPolylines(map, routePoints, segments);
+    }
+  }, [segments, routePoints]);
 
   // Update waypoint markers
   useEffect(() => {

--- a/frontend/src/hooks/useSegmentEditor.ts
+++ b/frontend/src/hooks/useSegmentEditor.ts
@@ -1,0 +1,100 @@
+/**
+ * Hook für Segment-Editing auf einer Route (#532).
+ * Verwaltet RouteSegments und bietet Auto-Segmentierung.
+ */
+
+import { useState, useCallback } from 'react';
+import type { RouteSegment } from '@/api/routes';
+
+export interface UseSegmentEditorReturn {
+  segments: RouteSegment[];
+  activeSegment: number | null;
+  setSegments: (segments: RouteSegment[]) => void;
+  addSegment: () => void;
+  updateSegment: (index: number, segment: RouteSegment) => void;
+  deleteSegment: (index: number) => void;
+  setActiveSegment: (index: number | null) => void;
+  autoSegment: (distanceKm: number) => void;
+}
+
+/** Standard-Aufteilung: 15% Warmup, 70% Steady, 15% Cooldown. */
+function createDefaultSegments(distanceKm: number): RouteSegment[] {
+  if (distanceKm <= 0) return [];
+
+  const warmupEnd = Math.round(distanceKm * 0.15 * 10) / 10;
+  const cooldownStart = Math.round(distanceKm * 0.85 * 10) / 10;
+
+  return [
+    { segment_type: 'warmup', start_km: 0, end_km: warmupEnd },
+    { segment_type: 'steady', start_km: warmupEnd, end_km: cooldownStart },
+    { segment_type: 'cooldown', start_km: cooldownStart, end_km: Math.round(distanceKm * 10) / 10 },
+  ];
+}
+
+export function useSegmentEditor(initialSegments: RouteSegment[] = []): UseSegmentEditorReturn {
+  const [segments, setSegmentsState] = useState<RouteSegment[]>(initialSegments);
+  const [activeSegment, setActiveSegment] = useState<number | null>(null);
+
+  const setSegments = useCallback((segs: RouteSegment[]) => {
+    setSegmentsState(segs);
+  }, []);
+
+  const addSegment = useCallback(() => {
+    setSegmentsState((prev) => {
+      if (prev.length === 0) return prev;
+
+      // Teile letztes Segment in der Mitte
+      const last = prev[prev.length - 1];
+      const mid = Math.round(((last.start_km + last.end_km) / 2) * 10) / 10;
+      if (mid <= last.start_km || mid >= last.end_km) return prev;
+
+      const updated = [...prev];
+      updated[prev.length - 1] = { ...last, end_km: mid };
+      updated.push({ segment_type: 'steady', start_km: mid, end_km: last.end_km });
+      return updated;
+    });
+  }, []);
+
+  const updateSegment = useCallback((index: number, segment: RouteSegment) => {
+    setSegmentsState((prev) => {
+      const updated = [...prev];
+      updated[index] = segment;
+      return updated;
+    });
+  }, []);
+
+  const deleteSegment = useCallback((index: number) => {
+    setSegmentsState((prev) => {
+      if (prev.length <= 1) return [];
+
+      const updated = [...prev];
+      const removed = updated.splice(index, 1)[0];
+
+      // Nachbar-Segment erweitern um die Lücke zu füllen
+      if (index > 0) {
+        updated[index - 1] = { ...updated[index - 1], end_km: removed.end_km };
+      } else if (updated.length > 0) {
+        updated[0] = { ...updated[0], start_km: removed.start_km };
+      }
+
+      return updated;
+    });
+    setActiveSegment(null);
+  }, []);
+
+  const autoSegment = useCallback((distanceKm: number) => {
+    setSegmentsState(createDefaultSegments(distanceKm));
+    setActiveSegment(null);
+  }, []);
+
+  return {
+    segments,
+    activeSegment,
+    setSegments,
+    addSegment,
+    updateSegment,
+    deleteSegment,
+    setActiveSegment,
+    autoSegment,
+  };
+}

--- a/frontend/src/pages/RouteEditor.tsx
+++ b/frontend/src/pages/RouteEditor.tsx
@@ -1,7 +1,7 @@
 /**
  * Route-Editor Seite — Trainingsrouten auf der Karte erstellen/bearbeiten.
  *
- * Part of Epic #508, Story #527.
+ * Part of Epic #508, Story #527 + #532.
  */
 
 import { useEffect } from 'react';
@@ -16,9 +16,13 @@ import {
   Spinner,
   useToast,
 } from '@nordlig/components';
-import { ChevronRight, Save, Mountain, Ruler, MapPin } from 'lucide-react';
+import { ChevronRight, Save, Mountain, Ruler, MapPin, Wand2 } from 'lucide-react';
 import { RouteEditorMap } from '@/features/maps/RouteEditorMap';
 import { useRouteEditor } from '@/hooks/useRouteEditor';
+import { useSegmentEditor } from '@/hooks/useSegmentEditor';
+import type { UseSegmentEditorReturn } from '@/hooks/useSegmentEditor';
+import { SegmentBar } from '@/components/route-editor/SegmentBar';
+import { SegmentTable } from '@/components/route-editor/SegmentTable';
 import type { UseRouteEditorReturn } from '@/hooks/useRouteEditor';
 
 function RouteMetrics({ editor }: { editor: UseRouteEditorReturn }) {
@@ -36,6 +40,55 @@ function RouteMetrics({ editor }: { editor: UseRouteEditorReturn }) {
         {editor.waypoints.length} Punkte
       </span>
     </div>
+  );
+}
+
+function SegmentSection({
+  segEditor,
+  distanceKm,
+}: {
+  segEditor: UseSegmentEditorReturn;
+  distanceKm: number;
+}) {
+  if (distanceKm <= 0) return null;
+
+  return (
+    <>
+      {segEditor.segments.length > 0 && (
+        <SegmentBar
+          segments={segEditor.segments}
+          totalDistanceKm={distanceKm}
+          onSegmentClick={segEditor.setActiveSegment}
+          activeSegment={segEditor.activeSegment}
+        />
+      )}
+      <Card>
+        <CardBody className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-medium text-[var(--color-text-base)]">Segmente</h3>
+            {segEditor.segments.length === 0 && (
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => segEditor.autoSegment(distanceKm)}
+              >
+                <Wand2 className="w-3.5 h-3.5 mr-1" />
+                Auto-Segmentierung
+              </Button>
+            )}
+          </div>
+          <SegmentTable
+            segments={segEditor.segments}
+            totalDistanceKm={distanceKm}
+            onUpdate={segEditor.updateSegment}
+            onDelete={segEditor.deleteSegment}
+            onAdd={segEditor.addSegment}
+            activeSegment={segEditor.activeSegment}
+            onSegmentClick={segEditor.setActiveSegment}
+          />
+        </CardBody>
+      </Card>
+    </>
   );
 }
 
@@ -77,6 +130,7 @@ export function RouteEditorPage() {
   const { toast } = useToast();
   const isNew = !routeId;
   const editor = useRouteEditor();
+  const segEditor = useSegmentEditor();
 
   useEffect(() => {
     if (routeId) {
@@ -148,18 +202,10 @@ export function RouteEditorPage() {
         onWaypointDelete={editor.deleteWaypoint}
         routing={editor.routing}
         height="55vh"
+        segments={segEditor.segments}
       />
 
-      {editor.routePoints.length > 1 && (
-        <Card>
-          <CardBody>
-            <h3 className="text-sm font-medium text-[var(--color-text-base)] mb-2">Höhenprofil</h3>
-            <div className="text-xs text-[var(--color-text-muted)]">
-              Höhenprofil wird nach Integration mit Elevation API angezeigt.
-            </div>
-          </CardBody>
-        </Card>
-      )}
+      <SegmentSection segEditor={segEditor} distanceKm={editor.distanceKm} />
 
       <EditorActionBar
         editor={editor}


### PR DESCRIPTION
## Summary

- Trainingsabschnitte visuell auf der Route definieren
- **SegmentBar**: Farbcodierte Leiste proportional zur Distanz (klickbar)
- **SegmentTable**: Inline-Editing — Segment-Typ (Select), Pace-Ziele, HR-Ziele
- **Karten-Overlay**: Route-Abschnitte farblich nach Segment-Typ eingefärbt
- **Auto-Segmentierung**: 15% Warmup, 70% Steady, 15% Cooldown
- 8 Segment-Typen mit Farben/Labels (warmup, steady, work, cooldown, etc.)

**Epic:** #508 | **Story:** #532

## Neue Dateien

| Datei | Beschreibung |
|-------|-------------|
| `frontend/src/constants/segmentColors.ts` | Farben + Labels für 8 Segment-Typen |
| `frontend/src/components/route-editor/SegmentBar.tsx` | Farbige Segment-Leiste |
| `frontend/src/components/route-editor/SegmentTable.tsx` | Tabelle mit Inline-Editing |
| `frontend/src/hooks/useSegmentEditor.ts` | Segment State Management |

## Test plan

- [x] TSC: 0 Errors
- [x] ESLint: 0 Warnings
- [x] Prettier: clean
- [ ] CI Pipeline grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)