### PR TITLE
fix: Volumen-Kalibrierung zu restriktiv für HM-Pläne (#585)

### DIFF
--- a/backend/app/services/chat_tool_handlers.py
+++ b/backend/app/services/chat_tool_handlers.py
@@ -1443,9 +1443,14 @@ async def _generate_and_save_weekly_plans(  # noqa: PLR0912, PLR0915
                 }
                 for p in db_phases
             ]
+            # Peak-Volumen aus Wettkampfdistanz schätzen
+            goal_dist = _parse_goal_distance(plan.name) if plan.name else 21.0975
+            peak_vol = _estimate_peak_volume(goal_dist, avg_weekly_km)
+
             volume_targets = calibrate_weekly_volumes(
                 phase_defs,
                 current_weekly_km=avg_weekly_km,
+                peak_volume_km=peak_vol,
                 deload_ratio=deload_ratio,
             )
             logger.info(

--- a/backend/app/services/volume_calibration.py
+++ b/backend/app/services/volume_calibration.py
@@ -25,8 +25,9 @@ from app.services.deload_pattern import (
 # Maximale Steigerung pro Woche (10%-Regel, Daniels)
 MAX_WEEKLY_INCREASE_PCT = 0.10
 
-# Maximaler Peak als Vielfaches des Start-Volumens
-MAX_PEAK_MULTIPLIER = 2.0
+# Maximaler Peak als Vielfaches des Start-Volumens.
+# Bei langen Plänen (>16 Wochen) kann der Athlet deutlich über 2× wachsen.
+MAX_PEAK_MULTIPLIER = 3.0
 
 # Minimum-Volumen (km/Woche) — darunter macht Periodisierung keinen Sinn
 MIN_WEEKLY_VOLUME_KM = 10.0
@@ -61,7 +62,9 @@ def calibrate_weekly_volumes(
     if peak_volume_km is None:
         peak_km = _estimate_peak_from_progression(start_km, total_weeks)
     else:
-        peak_km = min(peak_volume_km, start_km * MAX_PEAK_MULTIPLIER)
+        # Cap an die 10%-Regel: ist das Peak mit 10%/Woche erreichbar?
+        max_reachable = start_km * (1 + MAX_WEEKLY_INCREASE_PCT) ** (total_weeks * 0.75)
+        peak_km = min(peak_volume_km, max_reachable, start_km * MAX_PEAK_MULTIPLIER)
 
     peak_km = max(peak_km, start_km)  # Peak nie unter Start
 
@@ -92,7 +95,7 @@ def calibrate_weekly_volumes(
         )
 
     # 10%-Regel validieren
-    _enforce_10_percent_rule(result)
+    _enforce_10_percent_rule(result, start_km=start_km)
 
     return result
 
@@ -172,27 +175,37 @@ def _estimate_peak_from_progression(start_km: float, total_weeks: int) -> float:
     return min(raw_peak, start_km * MAX_PEAK_MULTIPLIER)
 
 
-def _enforce_10_percent_rule(targets: list[WeeklyVolumeTarget]) -> None:
+def _enforce_10_percent_rule(
+    targets: list[WeeklyVolumeTarget],
+    start_km: float = 0,
+) -> None:
     """Stelle sicher dass keine Woche >10% mehr als die Vorwoche hat.
 
     Deload- und Taper-Wochen werden übersprungen (reduziertes Volumen ist ok).
     Nach einem Deload darf das Volumen auf das Niveau vor dem Deload zurückkehren.
+    Nach Recovery/Transition darf das Volumen auf start_km springen (kein Aufbau nötig).
     """
     if len(targets) < 2:
         return
 
-    pre_deload_volume = targets[0].adjusted_volume_km
+    pre_deload_volume = max(targets[0].adjusted_volume_km, start_km)
 
     for i in range(1, len(targets)):
         current = targets[i]
         prev = targets[i - 1]
 
-        # Deload/Taper: Reduzierung ist immer ok, merke Pre-Deload-Volumen
+        # Deload/Taper: Reduzierung ist immer ok
         if current.is_deload or current.is_taper:
             continue
 
-        # Nach Deload: darf auf Pre-Deload-Niveau zurückkehren
-        if prev.is_deload:
+        # Phase-Wechsel aus Recovery/Transition: darf auf start_km springen
+        if prev.phase in ("recovery", "transition") and current.phase not in (
+            "recovery",
+            "transition",
+        ):
+            max_allowed = max(start_km, prev.adjusted_volume_km * (1 + MAX_WEEKLY_INCREASE_PCT))
+        elif prev.is_deload:
+            # Nach Deload: darf auf Pre-Deload-Niveau zurückkehren
             max_allowed = max(
                 pre_deload_volume,
                 prev.adjusted_volume_km * (1 + MAX_WEEKLY_INCREASE_PCT),

--- a/backend/app/tests/test_volume_calibration.py
+++ b/backend/app/tests/test_volume_calibration.py
@@ -68,13 +68,13 @@ class TestCalibrateWeeklyVolumes:
         for t in targets:
             assert t.adjusted_volume_km >= 10.0
 
-    def test_peak_capped_at_2x_start(self) -> None:
-        """Peak-Volumen wird auf 2x Start gecappt."""
+    def test_peak_capped_at_3x_start(self) -> None:
+        """Peak-Volumen wird auf 3x Start gecappt."""
         phases = [{"phase_type": "base", "weeks": 20}]
-        targets = calibrate_weekly_volumes(phases, current_weekly_km=20.0, peak_volume_km=100.0)
-        # 100 km wird auf 2x20=40 km gecappt
+        targets = calibrate_weekly_volumes(phases, current_weekly_km=20.0, peak_volume_km=200.0)
+        # 200 km wird auf 3x20=60 km gecappt (oder 10%-Regel, was kleiner ist)
         max_vol = max(t.adjusted_volume_km for t in targets)
-        assert max_vol <= 40.0 * 1.01  # Kleine Rundungstoleranz
+        assert max_vol <= 60.0 * 1.01  # Kleine Rundungstoleranz
 
     def test_custom_peak_volume(self) -> None:
         """Benutzerdefiniertes Peak-Volumen wird respektiert."""


### PR DESCRIPTION
## Summary
- MAX_PEAK_MULTIPLIER von 2.0 auf 3.0 erhöht
- Peak-Cap berücksichtigt 10%-Regel über Planwochen
- peak_volume_km aus Wettkampfdistanz berechnet und an calibrate_weekly_volumes übergeben
- Nach Recovery-Phase darf Volumen auf start_km springen
- 11 Tests bestehen

**Ergebnis:** HM-Plan mit 20 km Start → 52 km Peak (statt 40), Long Runs ~15.5 km (~80 Min statt 50).

**Story:** #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)