### PR TITLE
fix: Peak-Volumen für HM von 45 auf 60 km erhöht (#589)

### DIFF
--- a/backend/app/services/chat_tool_handlers.py
+++ b/backend/app/services/chat_tool_handlers.py
@@ -1100,23 +1100,31 @@ async def _create_plan_model(
     return plan
 
 
-def _estimate_peak_volume(distance_km: float, current_km: float) -> float:
+def _estimate_peak_volume(distance_km: float, current_km: float, weeks: int = 12) -> float:
     """Schätzt das Peak-Wochenvolumen basierend auf Wettkampfdistanz.
 
-    Faustregel: Peak-Volumen = ca. 2.5x Wettkampfdistanz (min. current + 30%).
+    Referenz: Pfitzinger "Advanced Marathoning" / Daniels "Running Formula".
+    Peak-Volumen hängt von der Wettkampfdistanz UND der verfügbaren
+    Aufbauzeit ab — bei langen Plänen (>16 Wochen) kann höher aufgebaut werden.
     """
+    # Basis-Zielvolumen nach Distanz (Pfitzinger-Empfehlungen für ambitionierte Läufer)
     target_by_distance = {
-        42.195: 65.0,  # Marathon: 55-75 km/Woche Peak
-        21.0975: 45.0,  # HM: 35-55 km/Woche Peak
-        10.0: 35.0,  # 10k: 30-40 km/Woche Peak
-        5.0: 30.0,  # 5k: 25-35 km/Woche Peak
+        42.195: 75.0,  # Marathon: 65-90 km/Woche Peak
+        21.0975: 60.0,  # HM: 50-70 km/Woche Peak
+        10.0: 45.0,  # 10k: 40-55 km/Woche Peak
+        5.0: 35.0,  # 5k: 30-40 km/Woche Peak
     }
-    # Nächste bekannte Distanz finden
     closest = min(target_by_distance.keys(), key=lambda d: abs(d - distance_km))
     target_peak = target_by_distance[closest]
 
-    # Nicht unter dem aktuellen Volumen + 30% starten
-    return max(target_peak, current_km * 1.3)
+    # Bei langen Plänen (>16 Wochen) 10% höher, bei kurzen 10% niedriger
+    if weeks >= 20:
+        target_peak *= 1.10
+    elif weeks <= 10:
+        target_peak *= 0.85
+
+    # Nicht unter dem aktuellen Volumen + 50% (genug Steigerungspotenzial)
+    return max(target_peak, current_km * 1.5)
 
 
 # Mapping: phase_type → (Name, Strength-Sessions, Quality-Sessions, Focus-Primary, Focus-Secondary)
@@ -1330,7 +1338,7 @@ async def _create_plan_phases(
     Phasen-Aufteilung wird aus den KI-Templates abgeleitet (weeks pro Phase).
     Wenn keine KI-Templates vorhanden → Default-Verteilung (40/30/15/15).
     """
-    peak_vol = _estimate_peak_volume(distance_km, current_km)
+    peak_vol = _estimate_peak_volume(distance_km, current_km, weeks)
     phase_defs = _build_phase_defs(
         weeks,
         ki_phase_templates,
@@ -1445,7 +1453,8 @@ async def _generate_and_save_weekly_plans(  # noqa: PLR0912, PLR0915
             ]
             # Peak-Volumen aus Wettkampfdistanz schätzen
             goal_dist = _parse_goal_distance(plan.name) if plan.name else 21.0975
-            peak_vol = _estimate_peak_volume(goal_dist, avg_weekly_km)
+            total_plan_weeks = sum(max(1, p.end_week - p.start_week + 1) for p in db_phases)
+            peak_vol = _estimate_peak_volume(goal_dist, avg_weekly_km, total_plan_weeks)
 
             volume_targets = calibrate_weekly_volumes(
                 phase_defs,

--- a/backend/app/tests/test_plan_e2e_validation.py
+++ b/backend/app/tests/test_plan_e2e_validation.py
@@ -56,17 +56,80 @@ def _make_goal(distance_km: float, time_sec: int, race_date: str) -> MagicMock:
     return goal
 
 
+class TestPeakVolumeEstimation:
+    """Die _estimate_peak_volume Funktion erzeugt sinnvolle Werte."""
+
+    def test_hm_peak_at_least_55km(self) -> None:
+        """HM Sub-1:50 mit 28 Wochen → Peak mindestens 55 km."""
+        from app.services.chat_tool_handlers import _estimate_peak_volume
+
+        peak = _estimate_peak_volume(21.0975, 20.0, weeks=28)
+        assert peak >= 55.0, f"HM Peak {peak:.0f} km zu niedrig (soll ≥55)"
+
+    def test_marathon_peak_at_least_65km(self) -> None:
+        """Marathon mit 20 Wochen → Peak mindestens 65 km."""
+        from app.services.chat_tool_handlers import _estimate_peak_volume
+
+        peak = _estimate_peak_volume(42.195, 30.0, weeks=20)
+        assert peak >= 65.0, f"Marathon Peak {peak:.0f} km zu niedrig (soll ≥65)"
+
+    def test_short_plan_lower_peak(self) -> None:
+        """Kurzer Plan (10 Wochen) hat niedrigeres Peak."""
+        from app.services.chat_tool_handlers import _estimate_peak_volume
+
+        short = _estimate_peak_volume(21.0975, 20.0, weeks=10)
+        long = _estimate_peak_volume(21.0975, 20.0, weeks=28)
+        assert short < long
+
+    def test_higher_current_km_higher_peak(self) -> None:
+        """Mehr aktuelles Volumen → höheres Peak."""
+        from app.services.chat_tool_handlers import _estimate_peak_volume
+
+        low = _estimate_peak_volume(21.0975, 15.0, weeks=20)
+        high = _estimate_peak_volume(21.0975, 40.0, weeks=20)
+        assert high >= low
+
+
 class TestGeneratedPlanE2E:
     """End-to-End: Generierter HM Sub-1:50 Plan ist brauchbar."""
 
     def _generate_hm_plan(self) -> list:
+        """Generiert Plan mit realistischen Phasen-Metriken aus _estimate_peak_volume."""
+        from app.services.chat_tool_handlers import _VOLUME_FACTORS, _estimate_peak_volume
+
         plan = _make_plan("2026-04-06", "2026-10-04")  # 26 Wochen
         goal = _make_goal(21.0975, 6600, "2026-10-04")  # 1:50:00
+
+        # Echte Peak-Volumen-Berechnung wie im Produktivcode
+        current_km = 20.0
+        peak_vol = _estimate_peak_volume(21.0975, current_km, weeks=26)
+
         phases: list[Any] = [
-            _make_phase(1, "base", 1, 10, 30, 45),
-            _make_phase(1, "build", 11, 18, 40, 55),
-            _make_phase(1, "peak", 19, 24, 50, 65),
-            _make_phase(1, "taper", 25, 26, 25, 35),
+            _make_phase(
+                1,
+                "base",
+                1,
+                10,
+                peak_vol * _VOLUME_FACTORS["base"] * 0.9,
+                peak_vol * _VOLUME_FACTORS["base"] * 1.1,
+            ),
+            _make_phase(
+                1,
+                "build",
+                11,
+                18,
+                peak_vol * _VOLUME_FACTORS["build"] * 0.9,
+                peak_vol * _VOLUME_FACTORS["build"] * 1.1,
+            ),
+            _make_phase(1, "peak", 19, 24, peak_vol * 0.9, peak_vol * 1.1),
+            _make_phase(
+                1,
+                "taper",
+                25,
+                26,
+                peak_vol * _VOLUME_FACTORS["taper"] * 0.9,
+                peak_vol * _VOLUME_FACTORS["taper"] * 1.1,
+            ),
         ]
         from app.services.vdot_calculator import estimate_vdot
 


### PR DESCRIPTION
## Summary

**Root Cause:** `_estimate_peak_volume()` gab für HM nur 45 km Peak zurück. Bei 20 km Start und `_VOLUME_FACTORS` ergab das:
- Base: 45×0.6 = 27 km → Long Run 8 km (35 Min)
- Peak: 45×1.0 = 45 km → Long Run 13.5 km (65 Min)

Pfitzinger empfiehlt für HM Sub-1:50 eher **55-70 km Peak**.

**Fix:**
- HM Peak: 45 → 60 km
- Marathon Peak: 65 → 75 km  
- Planlänge berücksichtigt (≥20W: +10%, ≤10W: -15%)
- E2E-Tests nutzen jetzt echte `_estimate_peak_volume()` Werte statt handverlesene Metriken

54/54 Tests bestehen.

**Story:** #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)