### PR TITLE
fix: Recovery-Phase Duration-Cap greift auch bei Template-Sessions (#597)

### DIFF
--- a/backend/app/services/plan_generator.py
+++ b/backend/app/services/plan_generator.py
@@ -1277,6 +1277,32 @@ def generate_weekly_plans(  # noqa: C901, PLR0912, PLR0913, PLR0915  # TODO: E16
                         max_hr=max_hr,
                     )
 
+        # Phase-spezifischen Duration-Cap nachträglich auf ALLE easy/recovery Sessions
+        # anwenden — auch auf Template-Sessions die von _has_explicit_run_details
+        # übersprungen wurden. Damit wirkt z.B. easy_max_duration_min=35 in der
+        # Recovery-Phase auch wenn Templates Paces (und damit explicit details) haben.
+        easy_cap_dur = defaults.get("easy_max_duration_min")
+        if easy_cap_dur is not None:
+            _easy_run_types = {"easy", "recovery"}
+            for entry in entries:
+                for sess in entry.sessions:
+                    if sess.run_details is None:
+                        continue
+                    if sess.run_details.run_type not in _easy_run_types:
+                        continue
+                    for seg in sess.run_details.segments or []:
+                        if (
+                            seg.target_duration_minutes is not None
+                            and seg.target_duration_minutes > easy_cap_dur
+                        ):
+                            seg.target_duration_minutes = float(easy_cap_dur)
+                    # Aggregat auf RunDetails aktualisieren
+                    if (
+                        sess.run_details.target_duration_minutes is not None
+                        and sess.run_details.target_duration_minutes > easy_cap_dur
+                    ):
+                        sess.run_details.target_duration_minutes = int(easy_cap_dur)
+
         # Enrich sessions with structured segments (intervals, tempo, strides etc.)
         _enrich_sessions_for_week(
             entries,


### PR DESCRIPTION
## Summary

- Post-Processing-Schritt nach Volume-Distribution: `easy_max_duration_min` wird auf **alle** easy/recovery Sessions angewendet
- Auch Template-Sessions mit gesetzten Paces (`_has_explicit_run_details == True`) werden gecappt
- Damit gilt der 35-Min-Cap aus #594 auch nach Re-Generate des Plans

Closes #597

## Test plan

- [x] 1228 Pytest-Tests grün
- [x] Ruff + Mypy bestanden
- [x] Recovery phase easy/recovery Läufe: max 35 Min (auch nach Regenerierung)
- [x] Andere Phasen unverändert

🤖 Generated with [Claude Code](https://claude.com/claude-code)