### PR TITLE
feat: Als Route speichern in Session-Detail (#513)

### DIFF
--- a/frontend/src/api/routes.ts
+++ b/frontend/src/api/routes.ts
@@ -251,6 +251,18 @@ export async function routeFromTemplate(
   return response.data;
 }
 
+export async function createRouteFromSession(
+  sessionId: number,
+  name?: string,
+): Promise<TrainingRouteResponse> {
+  const params = name ? { name } : {};
+  const response = await apiClient.post<TrainingRouteResponse>(
+    `/api/v1/routes/from-session/${sessionId}`,
+    params,
+  );
+  return response.data;
+}
+
 export async function exportRouteGpx(routeId: number, routeName: string): Promise<void> {
   const response = await apiClient.get(`/api/v1/routes/${routeId}/export/gpx`, {
     responseType: 'blob',

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -1,5 +1,5 @@
 import { useRef } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link, useNavigate } from 'react-router-dom';
 import {
   Button,
   Card,
@@ -40,6 +40,7 @@ import {
   BookmarkPlus,
   RefreshCw,
   Download,
+  Route,
 } from 'lucide-react';
 import { format, parseISO } from 'date-fns';
 import { de } from 'date-fns/locale';
@@ -50,6 +51,7 @@ import {
 } from '@/constants/training';
 import { createTemplateFromSession } from '@/api/session-templates';
 import { reparseSession, exportSessionFit } from '@/api/training';
+import { createRouteFromSession } from '@/api/routes';
 import type { StrengthExercisesEditorRef } from '@/components/StrengthExercisesEditor';
 import { generateInsights } from '@/utils/insights';
 import type { InsightType } from '@/utils/insights';
@@ -92,6 +94,7 @@ const insightVariantMap: Record<InsightType, 'success' | 'warning' | 'info'> = {
 export function SessionDetailPage() {
   const { id } = useParams<{ id: string }>();
   const { toast } = useToast();
+  const navigate = useNavigate();
   const sessionId = Number(id);
 
   const exercisesEditorRef = useRef<StrengthExercisesEditorRef>(null);
@@ -310,6 +313,30 @@ export function SessionDetailPage() {
               >
                 Neu analysieren
               </DropdownMenuItem>
+              {gpsTrack && gpsTrack.points.length > 0 && (
+                <DropdownMenuItem
+                  icon={<Route />}
+                  onSelect={async () => {
+                    try {
+                      const route = await createRouteFromSession(sessionId);
+                      toast({
+                        title: 'Route gespeichert',
+                        description: `„${route.name}" wurde als Route angelegt.`,
+                        variant: 'success',
+                      });
+                      navigate(`/plan/routes/${route.id}`);
+                    } catch {
+                      toast({
+                        title: 'Fehler',
+                        description: 'Route konnte nicht erstellt werden.',
+                        variant: 'error',
+                      });
+                    }
+                  }}
+                >
+                  Als Route speichern
+                </DropdownMenuItem>
+              )}
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 icon={<Trash2 />}


### PR DESCRIPTION
## Summary
- Neuer Menüeintrag „Als Route speichern" im Kebab-Menü der Session-Detailseite
- Nur sichtbar wenn die Session einen GPS-Track hat
- Ruft den bestehenden Backend-Endpunkt \`POST /routes/from-session/{id}\` auf
- Nach Erfolg: Toast + Navigation zur neu erstellten Route

## Test plan
- [ ] Session mit GPS-Track öffnen → Kebab-Menü → „Als Route speichern"
- [ ] Route wird erstellt, Toast erscheint, Navigation zu `/plan/routes/{id}`
- [ ] Session ohne GPS → Eintrag nicht sichtbar
- [ ] Vitest 182 passed

Closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)