### PR TITLE
fix: RouteEditor — Karte auf Card, Edit-Modus interaktiv, Segment-Redesign (#613)

### DIFF
--- a/frontend/src/components/route-editor/SegmentBar.tsx
+++ b/frontend/src/components/route-editor/SegmentBar.tsx
@@ -1,6 +1,6 @@
 /**
- * Farbcodierte Segment-Leiste unter der Karte.
- * Zeigt alle Segmente proportional zur Distanz als farbige Balken.
+ * Farbcodierte Segment-Leiste — zeigt Segmente proportional zur Distanz.
+ * Klickbar für Segment-Auswahl.
  */
 
 import { SEGMENT_TYPE_COLORS, SEGMENT_TYPE_LABELS } from '@/constants/segmentColors';
@@ -23,30 +23,40 @@ export function SegmentBar({
 
   return (
     <div className="space-y-1.5">
-      <div className="flex h-6 rounded-[var(--radius-component-sm)] overflow-hidden border border-[var(--color-border-default)]">
+      <div
+        className="flex h-5 rounded-[var(--radius-component-sm)] overflow-hidden"
+        role="group"
+        aria-label="Segment-Übersicht"
+      >
         {segments.map((seg, i) => {
           const width = ((seg.end_km - seg.start_km) / totalDistanceKm) * 100;
           const color = SEGMENT_TYPE_COLORS[seg.segment_type] ?? '#9ca3af';
           const isActive = activeSegment === i;
+          const label = SEGMENT_TYPE_LABELS[seg.segment_type] ?? seg.segment_type;
 
           return (
-            <button
+            <div
               key={i}
+              role="button"
+              tabIndex={0}
               onClick={() => onSegmentClick?.(i)}
-              className="relative transition-opacity motion-reduce:transition-none min-w-[2px]"
+              onKeyDown={(e) => e.key === 'Enter' && onSegmentClick?.(i)}
+              className="relative transition-opacity motion-reduce:transition-none min-w-[2px] cursor-pointer"
               style={{
                 width: `${width}%`,
                 backgroundColor: color,
-                opacity: isActive ? 1 : 0.7,
+                opacity: isActive ? 1 : 0.75,
               }}
-              title={`${SEGMENT_TYPE_LABELS[seg.segment_type] ?? seg.segment_type}: ${seg.start_km}–${seg.end_km} km`}
+              title={`${label}: ${seg.start_km.toFixed(1)}–${seg.end_km.toFixed(1)} km`}
+              aria-label={`${label}: ${seg.start_km.toFixed(1)} bis ${seg.end_km.toFixed(1)} km`}
+              aria-pressed={isActive}
             >
-              {width > 10 && (
-                <span className="absolute inset-0 flex items-center justify-center text-[10px] font-medium text-[var(--color-text-on-primary)]">
-                  {SEGMENT_TYPE_LABELS[seg.segment_type]?.slice(0, 4) ?? ''}
+              {width > 12 && (
+                <span className="absolute inset-0 flex items-center justify-center text-[10px] font-medium text-[var(--color-text-on-primary)] select-none">
+                  {label.slice(0, 4)}
                 </span>
               )}
-            </button>
+            </div>
           );
         })}
       </div>

--- a/frontend/src/components/route-editor/SegmentTable.tsx
+++ b/frontend/src/components/route-editor/SegmentTable.tsx
@@ -1,11 +1,15 @@
 /**
- * Segment-Tabelle mit Inline-Editing für Route-Segmente.
- * Erlaubt Typ-Auswahl, Pace/HR-Ziele pro Segment.
+ * Segment-Liste mit Inline-Editing für Route-Segmente.
+ * Im readOnly-Modus: statische Darstellung ohne Edit-Controls.
  */
 
 import { Button, Input, Select, Badge } from '@nordlig/components';
-import { Trash2, Plus } from 'lucide-react';
-import { SEGMENT_TYPE_COLORS, SEGMENT_TYPE_OPTIONS } from '@/constants/segmentColors';
+import { Trash2 } from 'lucide-react';
+import {
+  SEGMENT_TYPE_COLORS,
+  SEGMENT_TYPE_LABELS,
+  SEGMENT_TYPE_OPTIONS,
+} from '@/constants/segmentColors';
 import type { RouteSegment } from '@/api/routes';
 
 interface SegmentTableProps {
@@ -16,9 +20,70 @@ interface SegmentTableProps {
   onAdd: () => void;
   activeSegment?: number | null;
   onSegmentClick?: (index: number) => void;
+  readOnly?: boolean;
 }
 
-function SegmentRow({
+// ---------------------------------------------------------------------------
+// Read-only Zeile
+// ---------------------------------------------------------------------------
+
+function SegmentRowReadOnly({
+  segment,
+  isActive,
+  onClick,
+}: {
+  segment: RouteSegment;
+  isActive: boolean;
+  onClick: () => void;
+}) {
+  const color = SEGMENT_TYPE_COLORS[segment.segment_type] ?? '#9ca3af';
+  const label = SEGMENT_TYPE_LABELS[segment.segment_type] ?? segment.segment_type;
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={(e) => e.key === 'Enter' && onClick()}
+      className={`flex items-center gap-3 px-3 py-2.5 rounded-[var(--radius-component-sm)] border cursor-pointer transition-colors motion-reduce:transition-none ${
+        isActive
+          ? 'border-[var(--color-border-focus)] bg-[var(--color-bg-subtle)]'
+          : 'border-[var(--color-border-default)]'
+      }`}
+    >
+      <div
+        className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+        style={{ backgroundColor: color }}
+        aria-hidden="true"
+      />
+      <span className="text-sm font-medium text-[var(--color-text-base)] min-w-[100px]">
+        {label}
+      </span>
+      <Badge variant="neutral" size="sm" className="flex-shrink-0">
+        {segment.start_km.toFixed(1)}–{segment.end_km.toFixed(1)} km
+      </Badge>
+      {segment.target_pace_min && (
+        <span className="text-xs text-[var(--color-text-muted)] ml-auto">
+          {segment.target_pace_min}
+          {segment.target_pace_max ? `–${segment.target_pace_max}` : ''} /km
+        </span>
+      )}
+      {segment.target_hr_min && (
+        <span className="text-xs text-[var(--color-text-muted)]">
+          {segment.target_hr_min}
+          {segment.target_hr_max ? `–${segment.target_hr_max}` : ''} bpm
+        </span>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Edit-Zeile
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line max-lines-per-function -- Segment-Zeile enthält Pace + HR + Typ-Felder
+function SegmentRowEdit({
   segment,
   index,
   onUpdate,
@@ -46,7 +111,10 @@ function SegmentRow({
     >
       {/* Farb-Indikator + Typ */}
       <div className="flex items-center gap-2 min-w-[140px]">
-        <div className="w-3 h-3 rounded-full flex-shrink-0" style={{ backgroundColor: color }} />
+        <div
+          className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+          style={{ backgroundColor: color }}
+        />
         <Select
           options={SEGMENT_TYPE_OPTIONS}
           value={segment.segment_type}
@@ -110,19 +178,26 @@ function SegmentRow({
         <span className="text-xs text-[var(--color-text-muted)]">bpm</span>
       </div>
 
-      {/* Delete */}
-      <button
-        onClick={(e) => {
+      {/* Löschen */}
+      <Button
+        variant="ghost"
+        size="sm"
+        aria-label="Segment löschen"
+        onClick={(e: React.MouseEvent) => {
           e.stopPropagation();
           onDelete(index);
         }}
-        className="p-1.5 rounded-[var(--radius-component-sm)] hover:bg-[var(--color-bg-subtle)] min-w-[44px] min-h-[44px] flex items-center justify-center flex-shrink-0"
+        className="flex-shrink-0"
       >
         <Trash2 className="w-4 h-4 text-[var(--color-text-muted)]" />
-      </button>
+      </Button>
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Tabelle
+// ---------------------------------------------------------------------------
 
 export function SegmentTable({
   segments,
@@ -132,28 +207,23 @@ export function SegmentTable({
   onAdd,
   activeSegment,
   onSegmentClick,
+  readOnly = false,
 }: SegmentTableProps) {
+  void totalDistanceKm; // wird vom Parent für Distanz-Berechnung genutzt
+  void onAdd; // wird vom Parent (CardHeader) ausgelöst
+
   return (
-    <div className="space-y-2">
-      <div className="flex items-center justify-between">
-        <h3 className="text-sm font-medium text-[var(--color-text-base)]">
-          Segmente ({segments.length})
-        </h3>
-        <Button variant="secondary" size="sm" onClick={onAdd} disabled={totalDistanceKm <= 0}>
-          <Plus className="w-3.5 h-3.5 mr-1" />
-          Segment
-        </Button>
-      </div>
-
-      {segments.length === 0 && (
-        <p className="text-xs text-[var(--color-text-muted)] py-4 text-center">
-          Noch keine Segmente. Klicke „Segment" um die Route aufzuteilen.
-        </p>
-      )}
-
-      <div className="space-y-1.5">
-        {segments.map((seg, i) => (
-          <SegmentRow
+    <div className="space-y-1.5">
+      {segments.map((seg, i) =>
+        readOnly ? (
+          <SegmentRowReadOnly
+            key={i}
+            segment={seg}
+            isActive={activeSegment === i}
+            onClick={() => onSegmentClick?.(i)}
+          />
+        ) : (
+          <SegmentRowEdit
             key={i}
             segment={seg}
             index={i}
@@ -162,8 +232,8 @@ export function SegmentTable({
             isActive={activeSegment === i}
             onClick={() => onSegmentClick?.(i)}
           />
-        ))}
-      </div>
+        ),
+      )}
     </div>
   );
 }

--- a/frontend/src/features/maps/RouteEditorMap.tsx
+++ b/frontend/src/features/maps/RouteEditorMap.tsx
@@ -157,6 +157,7 @@ function createSegmentPolylines(
   });
 }
 
+// eslint-disable-next-line max-lines-per-function -- Karten-Orchestrator mit mehreren unabhängigen useEffect-Blöcken
 export function RouteEditorMap({
   waypoints,
   routePoints,
@@ -175,16 +176,28 @@ export function RouteEditorMap({
   const polylineCasingRef = useRef<L.Polyline | null>(null);
   const segmentLinesRef = useRef<L.Polyline[]>([]);
   const callbacksRef = useRef({ onWaypointAdd, onWaypointMove, onWaypointDelete });
+  // readOnly als Ref damit der Klick-Handler reaktiv ist ohne Map-Neustart
+  const readOnlyRef = useRef(readOnly);
 
   useEffect(() => {
     callbacksRef.current = { onWaypointAdd, onWaypointMove, onWaypointDelete };
   }, [onWaypointAdd, onWaypointMove, onWaypointDelete]);
 
+  useEffect(() => {
+    readOnlyRef.current = readOnly;
+    // Cursor-Stil für Edit-Modus anzeigen
+    if (mapRef.current) {
+      const container = mapRef.current.getContainer();
+      container.style.cursor = readOnly ? '' : 'crosshair';
+    }
+  }, [readOnly]);
+
   // Initialize map once
   useEffect(() => {
     if (!containerRef.current || mapRef.current) return;
 
-    const tile = TILES.outdoor;
+    // Standard OSM: gute Lesbarkeit, Sky-500 Route kontrastiert gut
+    const tile = TILES.streets;
     const map = L.map(containerRef.current, {
       scrollWheelZoom: true,
       maxZoom: tile.maxZoom ?? 19,
@@ -195,18 +208,18 @@ export function RouteEditorMap({
       map,
     );
 
-    if (!readOnly) {
-      map.on('click', (e: L.LeafletMouseEvent) => {
+    // Klick-Handler prüft readOnlyRef — reagiert auf Modus-Wechsel ohne Map-Neustart
+    map.on('click', (e: L.LeafletMouseEvent) => {
+      if (!readOnlyRef.current) {
         callbacksRef.current.onWaypointAdd(e.latlng.lat, e.latlng.lng);
-      });
-    }
+      }
+    });
 
     mapRef.current = map;
     return () => {
       map.remove();
       mapRef.current = null;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- readOnly captured at mount; map is initialized once
   }, []);
 
   // Update route polyline
@@ -222,14 +235,14 @@ export function RouteEditorMap({
     if (points.length < 2) return;
 
     const cs = getComputedStyle(document.documentElement);
-    // Leaflet requires raw CSS values — resolve semantic tokens at runtime
+    // Leaflet benötigt rohe CSS-Werte — semantische Tokens zur Laufzeit auflösen
     const routeColor = cs.getPropertyValue('--color-bg-primary').trim() || '#0ea5e9';
     const casingColor = cs.getPropertyValue('--color-bg-surface').trim() || '#ffffff';
 
     const latlngs = points.map((p) => [p.lat, p.lng] as L.LatLngTuple);
     const opacity = routing ? 0.45 : 1;
 
-    // White casing beneath the route line for visibility on any tile style
+    // Weißes Casing unter der Route für Sichtbarkeit auf jedem Kartenstil
     polylineCasingRef.current = L.polyline(latlngs, {
       color: casingColor,
       weight: 9,
@@ -274,12 +287,8 @@ export function RouteEditorMap({
 
   return (
     <div className="relative">
-      <div
-        ref={containerRef}
-        style={{ height, minHeight: '250px' }}
-        className="w-full rounded-[var(--radius-component-md)] border border-[var(--color-border-default)] shadow-[var(--shadow-card-raised)] z-0"
-      />
-      <MapOverlays routing={routing} empty={waypoints.length === 0} />
+      <div ref={containerRef} style={{ height, minHeight: '250px' }} className="w-full z-0" />
+      <MapOverlays routing={routing} empty={!readOnly && waypoints.length === 0} />
     </div>
   );
 }

--- a/frontend/src/pages/RouteEditor.tsx
+++ b/frontend/src/pages/RouteEditor.tsx
@@ -33,6 +33,7 @@ import {
   Ruler,
   MapPin,
   Wand2,
+  Plus,
   Download,
   Pencil,
   Trash2,
@@ -101,14 +102,16 @@ function SegmentSection({
   segEditor,
   distanceKm,
   routeId,
-  readOnly,
+  isEditing,
 }: {
   segEditor: UseSegmentEditorReturn;
   distanceKm: number;
   routeId: number | null;
-  readOnly: boolean;
+  isEditing: boolean;
 }) {
   if (distanceKm <= 0) return null;
+  // Im Read-only ohne Segmente: nichts zeigen
+  if (!isEditing && segEditor.segments.length === 0) return null;
 
   return (
     <>
@@ -120,11 +123,14 @@ function SegmentSection({
           activeSegment={segEditor.activeSegment}
         />
       )}
+
       <Card elevation="raised">
         <CardHeader>
           <div className="flex items-center justify-between">
-            <h2 className="text-sm font-semibold text-[var(--color-text-base)]">Segmente</h2>
-            {!readOnly && segEditor.segments.length === 0 && (
+            <h2 className="text-sm font-semibold text-[var(--color-text-base)]">
+              Segmente{segEditor.segments.length > 0 ? ` (${segEditor.segments.length})` : ''}
+            </h2>
+            {isEditing && segEditor.segments.length === 0 && (
               <Button
                 variant="secondary"
                 size="sm"
@@ -134,22 +140,34 @@ function SegmentSection({
                 Auto-Segmentierung
               </Button>
             )}
+            {isEditing && segEditor.segments.length > 0 && (
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={segEditor.addSegment}
+                disabled={distanceKm <= 0}
+              >
+                <Plus className="w-3.5 h-3.5 mr-1" />
+                Segment
+              </Button>
+            )}
           </div>
         </CardHeader>
         <CardBody>
           {segEditor.segments.length === 0 ? (
             <p className="text-sm text-[var(--color-text-muted)] text-center py-4">
-              Noch keine Segmente. Klicke „Segment" um die Route aufzuteilen.
+              Noch keine Segmente. Klicke „Auto-Segmentierung" um die Route aufzuteilen.
             </p>
           ) : (
             <SegmentTable
               segments={segEditor.segments}
               totalDistanceKm={distanceKm}
-              onUpdate={readOnly ? () => {} : segEditor.updateSegment}
-              onDelete={readOnly ? () => {} : segEditor.deleteSegment}
-              onAdd={readOnly ? () => {} : segEditor.addSegment}
+              onUpdate={segEditor.updateSegment}
+              onDelete={segEditor.deleteSegment}
+              onAdd={segEditor.addSegment}
               activeSegment={segEditor.activeSegment}
               onSegmentClick={segEditor.setActiveSegment}
+              readOnly={!isEditing}
             />
           )}
         </CardBody>
@@ -160,7 +178,7 @@ function SegmentSection({
           routeId={routeId}
           distanceKm={distanceKm}
           segments={segEditor.segments}
-          onSegmentsUpdate={readOnly ? () => {} : segEditor.setSegments}
+          onSegmentsUpdate={isEditing ? segEditor.setSegments : () => {}}
         />
       )}
     </>
@@ -369,22 +387,12 @@ export function RouteEditorPage() {
           <BreadcrumbItem isCurrent>{isNew ? 'Neue Route' : routeName}</BreadcrumbItem>
         </Breadcrumbs>
 
+        {/* h1 ist immer statisch — kein Inline-Edit des Titels */}
         <header className="flex items-center justify-between gap-2 pb-2">
-          <div className="min-w-0 flex-1">
-            {isEditing ? (
-              <Input
-                placeholder="Routenname"
-                value={editor.name}
-                onChange={(e) => editor.setName(e.target.value)}
-                className="text-xl font-semibold"
-              />
-            ) : (
-              <h1 className="text-xl sm:text-2xl font-semibold text-[var(--color-text-base)] truncate">
-                {routeName}
-              </h1>
-            )}
-          </div>
-          {!isNew && routeId && (
+          <h1 className="text-xl sm:text-2xl font-semibold text-[var(--color-text-base)] truncate">
+            {isNew ? 'Neue Route' : routeName}
+          </h1>
+          {!isNew && routeId && !isEditing && (
             <RouteKebabMenu
               routeId={Number(routeId)}
               routeName={routeName}
@@ -392,14 +400,37 @@ export function RouteEditorPage() {
               onDelete={handleDelete}
             />
           )}
+          {isEditing && !isNew && (
+            <Button variant="ghost" size="sm" onClick={handleCancelEdit}>
+              Abbrechen
+            </Button>
+          )}
         </header>
       </div>
 
       {/* Kennzahlen — immer sichtbar */}
       <RouteMetricsGrid editor={editor} />
 
-      {/* Karte — Card-Wrapper ohne inner padding, overflow-hidden für border-radius */}
-      <div className="rounded-[var(--radius-card)] border border-[var(--color-card-border)] bg-[var(--color-card-bg-raised)] [box-shadow:var(--shadow-card-raised)] overflow-hidden">
+      {/* Edit-Modus: Routenname als eigenes Feld */}
+      {isEditing && (
+        <Card elevation="raised">
+          <CardBody>
+            <label className="block">
+              <span className="text-xs font-semibold text-[var(--color-text-muted)] uppercase tracking-wider mb-1.5 block">
+                Routenname
+              </span>
+              <Input
+                placeholder="z.B. Alsterrunde 21 km"
+                value={editor.name}
+                onChange={(e) => editor.setName(e.target.value)}
+              />
+            </label>
+          </CardBody>
+        </Card>
+      )}
+
+      {/* Karte auf Card — overflow-hidden clippt die Map an den border-radius */}
+      <Card elevation="raised" className="!p-0 overflow-hidden">
         <RouteEditorMap
           waypoints={editor.waypoints}
           routePoints={editor.routePoints}
@@ -411,14 +442,14 @@ export function RouteEditorPage() {
           segments={segEditor.segments}
           readOnly={!isEditing}
         />
-      </div>
+      </Card>
 
       {/* Segmente */}
       <SegmentSection
         segEditor={segEditor}
         distanceKm={editor.distanceKm}
         routeId={routeId ? Number(routeId) : null}
-        readOnly={!isEditing}
+        isEditing={isEditing}
       />
 
       {isEditing && (


### PR DESCRIPTION
## Summary

- Karte liegt jetzt in `<Card elevation="raised" className="!p-0 overflow-hidden">` (DS-konform)
- `readOnlyRef`-Pattern → Edit-Modus aktiviert Karten-Klicks auch bei bestehenden Routen
- Tile-Wechsel CyclOSM → Standard-OSM (Route in Sky-500 klar sichtbar)
- `h1` immer statisch; Routenname als separates Input-Feld im Edit-Modus
- `SegmentTable`: doppelter Header entfernt, ReadOnly-Modus zeigt statische Werte
- Nativer `<button>` in SegmentTable/SegmentBar durch DS-konforme Elemente ersetzt

Closes #613

## Test plan

- [ ] Karte liegt auf Card (Schatten, border-radius sichtbar)
- [ ] Bei bestehender Route → Bearbeiten → Wegpunkte setzen möglich
- [ ] Route auf Standard-OSM-Karte deutlich erkennbar
- [ ] h1 bleibt immer stehen; Name-Feld erscheint nur im Edit-Modus
- [ ] Segmente-Header nur einmal sichtbar
- [ ] Read-only: Segmente zeigen statischen Text, keine leeren Inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)