### PR TITLE
fix: SegmentBar in Segmente-Card + HR-Inputs ohne native Spinner (#619)

### DIFF
--- a/frontend/src/components/route-editor/SegmentTable.tsx
+++ b/frontend/src/components/route-editor/SegmentTable.tsx
@@ -148,31 +148,29 @@ function SegmentRowEdit({
         <span className="text-xs text-[var(--color-text-muted)]">/km</span>
       </div>
 
-      {/* HR */}
+      {/* HR — type="text" mit inputMode="numeric" vermeidet native Browser-Spinner */}
       <div className="flex items-center gap-1">
         <Input
-          placeholder="HR"
-          type="number"
+          placeholder="140"
+          type="text"
+          inputMode="numeric"
           value={segment.target_hr_min ?? ''}
-          onChange={(e) =>
-            onUpdate(index, {
-              ...segment,
-              target_hr_min: e.target.value ? Number(e.target.value) : null,
-            })
-          }
+          onChange={(e) => {
+            const val = e.target.value.replace(/\D/g, '');
+            onUpdate(index, { ...segment, target_hr_min: val ? Number(val) : null });
+          }}
           className="w-14 text-xs"
         />
         <span className="text-xs text-[var(--color-text-muted)]">–</span>
         <Input
-          placeholder="HR"
-          type="number"
+          placeholder="160"
+          type="text"
+          inputMode="numeric"
           value={segment.target_hr_max ?? ''}
-          onChange={(e) =>
-            onUpdate(index, {
-              ...segment,
-              target_hr_max: e.target.value ? Number(e.target.value) : null,
-            })
-          }
+          onChange={(e) => {
+            const val = e.target.value.replace(/\D/g, '');
+            onUpdate(index, { ...segment, target_hr_max: val ? Number(val) : null });
+          }}
           className="w-14 text-xs"
         />
         <span className="text-xs text-[var(--color-text-muted)]">bpm</span>

--- a/frontend/src/pages/RouteEditor.tsx
+++ b/frontend/src/pages/RouteEditor.tsx
@@ -115,15 +115,6 @@ function SegmentSection({
 
   return (
     <>
-      {segEditor.segments.length > 0 && (
-        <SegmentBar
-          segments={segEditor.segments}
-          totalDistanceKm={distanceKm}
-          onSegmentClick={segEditor.setActiveSegment}
-          activeSegment={segEditor.activeSegment}
-        />
-      )}
-
       <Card elevation="raised">
         <CardHeader>
           <div className="flex items-center justify-between">
@@ -153,6 +144,15 @@ function SegmentSection({
             )}
           </div>
         </CardHeader>
+        {/* SegmentBar innerhalb der Card — kein floatendes Element auf dem Hintergrund */}
+        {segEditor.segments.length > 0 && (
+          <SegmentBar
+            segments={segEditor.segments}
+            totalDistanceKm={distanceKm}
+            onSegmentClick={segEditor.setActiveSegment}
+            activeSegment={segEditor.activeSegment}
+          />
+        )}
         <CardBody>
           {segEditor.segments.length === 0 ? (
             <p className="text-sm text-[var(--color-text-muted)] text-center py-4">


### PR DESCRIPTION
## Summary

- SegmentBar liegt jetzt als direktes Kind der Card (zwischen CardHeader und CardBody) — kein floatendes Element auf dem Seiten-Hintergrund mehr
- HR-Inputs nutzen `type="text"` + `inputMode="numeric"` statt `type="number"` → keine nativen Browser-Spinner mehr

Closes #619

## Test plan

- [ ] SegmentBar ist visuell Teil der Segmente-Card
- [ ] Segment-Zeilen zeigen keine Pfeil-Spinner bei den HR-Feldern
- [ ] HR-Eingabe akzeptiert nur Ziffern

🤖 Generated with [Claude Code](https://claude.com/claude-code)