### PR TITLE
feat: API-Endpoints mit current_user absichern (#562)

### DIFF
--- a/backend/app/api/v1/ai.py
+++ b/backend/app/api/v1/ai.py
@@ -16,11 +16,13 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.api_key_resolver import resolve_claude_api_key
+from app.core.dependencies import get_current_user
 from app.infrastructure.ai.ai_service import AIProviderFactory, ai_service
 from app.infrastructure.database.models import (
     PlanChangeLogModel,
     PlannedSessionModel,
     TrainingPlanModel,
+    UserModel,
     WeeklyPlanDayModel,
 )
 from app.infrastructure.database.session import get_db
@@ -76,7 +78,11 @@ async def get_providers():
 
 
 @router.post("/ai/chat")
-async def chat(request: ChatRequest, db: AsyncSession = Depends(get_db)):
+async def chat(
+    request: ChatRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+):
     """Chat with AI trainer (User-Key → .env Fallback)."""
     try:
         claude_key = await resolve_claude_api_key(db)

--- a/backend/app/api/v1/ai_log.py
+++ b/backend/app/api/v1/ai_log.py
@@ -7,7 +7,8 @@ from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.infrastructure.database.models import AIAnalysisLogModel, WorkoutModel
+from app.core.dependencies import get_current_user
+from app.infrastructure.database.models import AIAnalysisLogModel, UserModel, WorkoutModel
 from app.infrastructure.database.session import get_db
 
 router = APIRouter(prefix="/ai/log")
@@ -46,18 +47,24 @@ class AILogListResponse(BaseModel):
 @router.get("", response_model=AILogListResponse)
 async def list_ai_logs(
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
     limit: int = Query(default=20, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
 ) -> AILogListResponse:
     """Paginierte Liste aller KI-Analyse-Logs (neueste zuerst)."""
     # Total count
-    count_result = await db.execute(select(func.count(AIAnalysisLogModel.id)))
+    count_result = await db.execute(
+        select(func.count(AIAnalysisLogModel.id)).where(
+            AIAnalysisLogModel.user_id == current_user.id
+        )
+    )
     total = count_result.scalar_one()
 
     # Logs mit optionalem Workout LEFT JOIN
     stmt = (
         select(AIAnalysisLogModel, WorkoutModel.date, WorkoutModel.workout_type)
         .outerjoin(WorkoutModel, AIAnalysisLogModel.workout_id == WorkoutModel.id)
+        .where(AIAnalysisLogModel.user_id == current_user.id)
         .order_by(AIAnalysisLogModel.created_at.desc())
         .offset(offset)
         .limit(limit)
@@ -97,12 +104,16 @@ async def list_ai_logs(
 async def get_ai_log_detail(
     log_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> AILogDetail:
     """Einzelner Log-Eintrag mit vollem Prompt und Response."""
     stmt = (
         select(AIAnalysisLogModel, WorkoutModel.date, WorkoutModel.workout_type)
         .outerjoin(WorkoutModel, AIAnalysisLogModel.workout_id == WorkoutModel.id)
-        .where(AIAnalysisLogModel.id == log_id)
+        .where(
+            AIAnalysisLogModel.id == log_id,
+            AIAnalysisLogModel.user_id == current_user.id,
+        )
     )
     result = await db.execute(stmt)
     row = result.one_or_none()

--- a/backend/app/api/v1/athlete.py
+++ b/backend/app/api/v1/athlete.py
@@ -4,7 +4,8 @@ from fastapi import APIRouter, Depends
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.infrastructure.database.models import AthleteModel, ThresholdTestModel
+from app.core.dependencies import get_current_user
+from app.infrastructure.database.models import AthleteModel, ThresholdTestModel, UserModel
 from app.infrastructure.database.session import get_db
 from app.models.athlete import AthleteSettingsRequest, AthleteSettingsResponse
 from app.services.hr_zone_calculator import calculate_friel_zones, calculate_karvonen_zones
@@ -12,35 +13,38 @@ from app.services.hr_zone_calculator import calculate_friel_zones, calculate_kar
 router = APIRouter(prefix="/athlete", tags=["athlete"])
 
 
-async def _get_or_create_athlete(db: AsyncSession) -> AthleteModel:
-    """Holt den Athleten oder erstellt einen neuen (Singleton)."""
-    result = await db.execute(select(AthleteModel).limit(1))
+async def _get_or_create_athlete(db: AsyncSession, user_id: int) -> AthleteModel:
+    """Holt den Athleten oder erstellt einen neuen (Singleton pro User)."""
+    result = await db.execute(select(AthleteModel).where(AthleteModel.user_id == user_id).limit(1))
     athlete = result.scalar_one_or_none()
     if not athlete:
-        athlete = AthleteModel()
+        athlete = AthleteModel(user_id=user_id)
         db.add(athlete)
         await db.commit()
         await db.refresh(athlete)
     return athlete
 
 
-async def _get_latest_lthr(db: AsyncSession) -> int | None:
-    """Holt die LTHR aus dem neuesten Schwellentest."""
+async def _get_latest_lthr(db: AsyncSession, user_id: int) -> int | None:
+    """Holt die LTHR aus dem neuesten Schwellentest des Users."""
     result = await db.execute(
-        select(ThresholdTestModel.lthr).order_by(ThresholdTestModel.test_date.desc()).limit(1)
+        select(ThresholdTestModel.lthr)
+        .where(ThresholdTestModel.user_id == user_id)
+        .order_by(ThresholdTestModel.test_date.desc())
+        .limit(1)
     )
     return result.scalar_one_or_none()
 
 
 async def _build_settings_response(
-    athlete: AthleteModel, db: AsyncSession
+    athlete: AthleteModel, db: AsyncSession, user_id: int
 ) -> AthleteSettingsResponse:
     """Erstellt AthleteSettingsResponse mit Zonen (Friel bevorzugt)."""
     karvonen_zones = None
     if athlete.resting_hr and athlete.max_hr:
         karvonen_zones = calculate_karvonen_zones(athlete.resting_hr, athlete.max_hr)
 
-    lthr = await _get_latest_lthr(db)
+    lthr = await _get_latest_lthr(db, user_id)
     friel_zones = calculate_friel_zones(lthr) if lthr else None
 
     return AthleteSettingsResponse.from_db(
@@ -54,19 +58,21 @@ async def _build_settings_response(
 @router.get("/settings", response_model=AthleteSettingsResponse)
 async def get_settings(
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> AthleteSettingsResponse:
     """Gibt aktuelle Athleten-Einstellungen zurück."""
-    athlete = await _get_or_create_athlete(db)
-    return await _build_settings_response(athlete, db)
+    athlete = await _get_or_create_athlete(db, current_user.id)
+    return await _build_settings_response(athlete, db, current_user.id)
 
 
 @router.put("/settings", response_model=AthleteSettingsResponse)
 async def update_settings(
     body: AthleteSettingsRequest,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> AthleteSettingsResponse:
     """Aktualisiert Athleten-Einstellungen (Ruhe-HR, Max-HR)."""
-    athlete = await _get_or_create_athlete(db)
+    athlete = await _get_or_create_athlete(db, current_user.id)
 
     if body.resting_hr is not None:
         athlete.resting_hr = body.resting_hr
@@ -79,4 +85,4 @@ async def update_settings(
 
     await db.commit()
     await db.refresh(athlete)
-    return await _build_settings_response(athlete, db)
+    return await _build_settings_response(athlete, db, current_user.id)

--- a/backend/app/api/v1/exercise_library.py
+++ b/backend/app/api/v1/exercise_library.py
@@ -7,10 +7,11 @@ from pathlib import Path
 from typing import Optional
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.infrastructure.database.models import ExerciseModel
+from app.core.dependencies import get_current_user
+from app.infrastructure.database.models import ExerciseModel, UserModel
 from app.infrastructure.database.session import get_db
 from app.models.exercise_library import (
     EnrichRequest,
@@ -545,11 +546,16 @@ async def list_exercises(
     search: Optional[str] = Query(None, description="Suche nach Name"),
     favorites_only: bool = Query(False, description="Nur Favoriten"),
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> ExerciseListResponse:
     """Liste aller Übungen mit Filtern."""
     await _ensure_seed_data(db)
 
-    query = select(ExerciseModel).where(ExerciseModel.is_hidden.is_(False))
+    # Zeige geteilte Übungen (user_id=NULL) und eigene Übungen des Users
+    query = select(ExerciseModel).where(
+        ExerciseModel.is_hidden.is_(False),
+        or_(ExerciseModel.user_id.is_(None), ExerciseModel.user_id == current_user.id),
+    )
 
     if category and category in VALID_CATEGORIES:
         query = query.where(ExerciseModel.category == category)
@@ -581,6 +587,7 @@ async def search_exercise_db(
     equipment: Optional[str] = Query(None, description="Filter nach Equipment"),
     limit: int = Query(50, ge=1, le=100),
     offset: int = Query(0, ge=0),
+    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
 ) -> ExerciseDbSearchResponse:
     """Durchsucht die free-exercise-db (873 Übungen).
 
@@ -645,12 +652,14 @@ async def search_exercise_db(
 async def get_exercise(
     exercise_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> ExerciseResponse:
     """Einzelne Übung mit allen Details."""
     result = await db.execute(
         select(ExerciseModel).where(
             ExerciseModel.id == exercise_id,
             ExerciseModel.is_hidden.is_(False),
+            or_(ExerciseModel.user_id.is_(None), ExerciseModel.user_id == current_user.id),
         )
     )
     exercise = result.scalar_one_or_none()
@@ -663,6 +672,7 @@ async def get_exercise(
 async def create_exercise(
     body: ExerciseCreate,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> ExerciseResponse:
     """Erstellt eine neue benutzerdefinierte Übung."""
     if body.category not in VALID_CATEGORIES:
@@ -681,6 +691,7 @@ async def create_exercise(
         category=body.category,
         is_custom=True,
         is_favorite=False,
+        user_id=current_user.id,
     )
 
     # Try to enrich from free-exercise-db, then Claude API fallback
@@ -706,9 +717,15 @@ async def update_exercise(
     exercise_id: int,
     body: ExerciseUpdate,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
 ) -> ExerciseResponse:
     """Aktualisiert eine Übung (Name, Kategorie, Favorit, Anleitung, Muskeln)."""
-    result = await db.execute(select(ExerciseModel).where(ExerciseModel.id == exercise_id))
+    result = await db.execute(
+        select(ExerciseModel).where(
+            ExerciseModel.id == exercise_id,
+            or_(ExerciseModel.user_id.is_(None), ExerciseModel.user_id == current_user.id),
+        )
+    )
     exercise = result.scalar_one_or_none()
     if not exercise:
         raise HTTPException(status_code=404, detail="Übung nicht gefunden.")
@@ -764,9 +781,15 @@ async def update_exercise(
 async def toggle_favorite(
     exercise_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
 ) -> ExerciseResponse:
     """Togglet den Favoriten-Status einer Übung."""
-    result = await db.execute(select(ExerciseModel).where(ExerciseModel.id == exercise_id))
+    result = await db.execute(
+        select(ExerciseModel).where(
+            ExerciseModel.id == exercise_id,
+            or_(ExerciseModel.user_id.is_(None), ExerciseModel.user_id == current_user.id),
+        )
+    )
     exercise = result.scalar_one_or_none()
     if not exercise:
         raise HTTPException(status_code=404, detail="Übung nicht gefunden.")
@@ -782,6 +805,7 @@ async def toggle_favorite(
 async def delete_exercise(
     exercise_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
 ) -> None:
     """Löscht eine Übung aus der Bibliothek.
 
@@ -789,7 +813,12 @@ async def delete_exercise(
     Default-Übungen werden soft-deleted (is_hidden=True), damit das Seeding
     sie nicht sofort wieder erstellt.
     """
-    result = await db.execute(select(ExerciseModel).where(ExerciseModel.id == exercise_id))
+    result = await db.execute(
+        select(ExerciseModel).where(
+            ExerciseModel.id == exercise_id,
+            or_(ExerciseModel.user_id.is_(None), ExerciseModel.user_id == current_user.id),
+        )
+    )
     exercise = result.scalar_one_or_none()
     if not exercise:
         raise HTTPException(status_code=404, detail="Übung nicht gefunden.")
@@ -805,6 +834,7 @@ async def delete_exercise(
 async def enrich_all_exercises(
     force: bool = False,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
 ) -> dict:
     """Reichert alle unangereicherten Übungen per KI an.
 
@@ -863,13 +893,19 @@ async def enrich_exercise(
     exercise_id: int,
     body: Optional[EnrichRequest] = None,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
 ) -> ExerciseResponse:
     """Reichert eine Übung mit free-exercise-db Daten an.
 
     Mit exercise_db_id im Body: direkte Zuordnung.
     Ohne Body: Name-basiertes Matching (abwärtskompatibel).
     """
-    result = await db.execute(select(ExerciseModel).where(ExerciseModel.id == exercise_id))
+    result = await db.execute(
+        select(ExerciseModel).where(
+            ExerciseModel.id == exercise_id,
+            or_(ExerciseModel.user_id.is_(None), ExerciseModel.user_id == current_user.id),
+        )
+    )
     exercise = result.scalar_one_or_none()
     if not exercise:
         raise HTTPException(status_code=404, detail="Übung nicht gefunden.")
@@ -912,9 +948,15 @@ async def upload_exercise_images(
     image_0: UploadFile = File(..., description="Startposition (Pflicht)"),
     image_1: UploadFile | None = File(None, description="Endposition (Optional)"),
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
 ) -> ExerciseResponse:
     """Lädt Bilder für eine Custom-Übung hoch (Start- und optional Endposition)."""
-    result = await db.execute(select(ExerciseModel).where(ExerciseModel.id == exercise_id))
+    result = await db.execute(
+        select(ExerciseModel).where(
+            ExerciseModel.id == exercise_id,
+            or_(ExerciseModel.user_id.is_(None), ExerciseModel.user_id == current_user.id),
+        )
+    )
     exercise = result.scalar_one_or_none()
     if not exercise:
         raise HTTPException(status_code=404, detail="Übung nicht gefunden.")
@@ -955,9 +997,15 @@ async def upload_exercise_images(
 async def delete_exercise_images(
     exercise_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
 ) -> None:
     """Löscht alle hochgeladenen Bilder einer Custom-Übung."""
-    result = await db.execute(select(ExerciseModel).where(ExerciseModel.id == exercise_id))
+    result = await db.execute(
+        select(ExerciseModel).where(
+            ExerciseModel.id == exercise_id,
+            or_(ExerciseModel.user_id.is_(None), ExerciseModel.user_id == current_user.id),
+        )
+    )
     exercise = result.scalar_one_or_none()
     if not exercise:
         raise HTTPException(status_code=404, detail="Übung nicht gefunden.")

--- a/backend/app/api/v1/goals.py
+++ b/backend/app/api/v1/goals.py
@@ -7,9 +7,11 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.dependencies import get_current_user
 from app.infrastructure.database.models import (
     RaceGoalModel,
     TrainingPlanModel,
+    UserModel,
     WorkoutModel,
 )
 from app.infrastructure.database.session import get_db
@@ -61,11 +63,16 @@ async def _goal_to_response(
 @router.get("", response_model=RaceGoalListResponse)
 async def list_goals(
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> RaceGoalListResponse:
     """Liste aller Wettkampf-Ziele (aktive zuerst, dann nach Datum)."""
-    query = select(RaceGoalModel).order_by(
-        RaceGoalModel.is_active.desc(),
-        RaceGoalModel.race_date.asc(),
+    query = (
+        select(RaceGoalModel)
+        .where(RaceGoalModel.user_id == current_user.id)
+        .order_by(
+            RaceGoalModel.is_active.desc(),
+            RaceGoalModel.race_date.asc(),
+        )
     )
     result = await db.execute(query)
     goals = result.scalars().all()
@@ -78,6 +85,7 @@ async def list_goals(
 async def create_goal(
     body: RaceGoalCreate,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> RaceGoalResponse:
     """Erstellt ein neues Wettkampf-Ziel."""
     goal = RaceGoalModel(
@@ -86,6 +94,7 @@ async def create_goal(
         distance_km=body.distance_km,
         target_time_seconds=body.target_time_seconds,
         is_active=True,
+        user_id=current_user.id,
     )
     db.add(goal)
     await db.commit()
@@ -97,9 +106,12 @@ async def create_goal(
 async def get_goal(
     goal_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> RaceGoalResponse:
     """Einzelnes Wettkampf-Ziel."""
-    query = select(RaceGoalModel).where(RaceGoalModel.id == goal_id)
+    query = select(RaceGoalModel).where(
+        RaceGoalModel.id == goal_id, RaceGoalModel.user_id == current_user.id
+    )
     result = await db.execute(query)
     goal = result.scalar_one_or_none()
     if not goal:
@@ -112,9 +124,12 @@ async def update_goal(
     goal_id: int,
     body: RaceGoalUpdate,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> RaceGoalResponse:
     """Aktualisiert ein Wettkampf-Ziel."""
-    query = select(RaceGoalModel).where(RaceGoalModel.id == goal_id)
+    query = select(RaceGoalModel).where(
+        RaceGoalModel.id == goal_id, RaceGoalModel.user_id == current_user.id
+    )
     result = await db.execute(query)
     goal = result.scalar_one_or_none()
     if not goal:
@@ -140,9 +155,12 @@ async def update_goal(
 async def delete_goal(
     goal_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> None:
     """Loescht ein Wettkampf-Ziel."""
-    query = select(RaceGoalModel).where(RaceGoalModel.id == goal_id)
+    query = select(RaceGoalModel).where(
+        RaceGoalModel.id == goal_id, RaceGoalModel.user_id == current_user.id
+    )
     result = await db.execute(query)
     goal = result.scalar_one_or_none()
     if not goal:
@@ -180,13 +198,16 @@ def _format_time_seconds(total_sec: int) -> str:
 async def get_goal_progress(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refactoring
     goal_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> GoalProgressResponse:
     """Berechnet den Fortschritt in Richtung eines Wettkampf-Ziels.
 
     Nutzt die letzten 4 Wochen an Lauf-Sessions (Tempo, Intervals, Long Run)
     um den aktuellen Pace-Stand zu ermitteln.
     """
-    query = select(RaceGoalModel).where(RaceGoalModel.id == goal_id)
+    query = select(RaceGoalModel).where(
+        RaceGoalModel.id == goal_id, RaceGoalModel.user_id == current_user.id
+    )
     result = await db.execute(query)
     goal = result.scalar_one_or_none()
     if not goal:
@@ -211,6 +232,7 @@ async def get_goal_progress(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refact
             WorkoutModel.date,
         )
         .where(
+            WorkoutModel.user_id == current_user.id,
             WorkoutModel.workout_type == "running",
             WorkoutModel.date >= eight_weeks_ago,
             WorkoutModel.pace.isnot(None),

--- a/backend/app/api/v1/pacing.py
+++ b/backend/app/api/v1/pacing.py
@@ -12,10 +12,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
+from app.core.dependencies import get_current_user
 from app.infrastructure.database.models import (
     PacingStrategyModel,
     PlannedSessionModel,
     RaceGoalModel,
+    UserModel,
     WeeklyPlanDayModel,
 )
 from app.infrastructure.database.session import get_db
@@ -55,11 +57,17 @@ _weather_client = ExternalAPIClient(
 async def generate_pacing(
     body: PacingRequest,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> PacingResponse:
     """Generiert eine Pacing-Strategie basierend auf Zielzeit, Hoehenprofil und Wetter."""
     # Wenn goal_id angegeben: Distanz und Zielzeit aus dem Goal laden
     if body.goal_id is not None:
-        result = await db.execute(select(RaceGoalModel).where(RaceGoalModel.id == body.goal_id))
+        result = await db.execute(
+            select(RaceGoalModel).where(
+                RaceGoalModel.id == body.goal_id,
+                RaceGoalModel.user_id == current_user.id,
+            )
+        )
         goal = result.scalar_one_or_none()
         if goal is None:
             raise HTTPException(status_code=404, detail="Ziel nicht gefunden")
@@ -74,7 +82,9 @@ async def generate_pacing(
 
     # Auto-Save: Strategie am Ziel speichern wenn goal_id vorhanden
     if body.goal_id is not None:
-        await _save_pacing_strategy(db, body.goal_id, pacing, body.elevation_preset)
+        await _save_pacing_strategy(
+            db, body.goal_id, pacing, body.elevation_preset, current_user.id
+        )
 
     return pacing
 
@@ -173,11 +183,17 @@ async def parse_gpx(file: UploadFile) -> list[ElevationSegment]:
 async def export_pacing_fit(
     body: PacingRequest,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> Response:
     """Exportiert eine Pacing-Strategie als FIT-Workout-Datei fuer GPS-Uhren."""
     # Goal-ID Aufloesung (wie bei /generate)
     if body.goal_id is not None:
-        result = await db.execute(select(RaceGoalModel).where(RaceGoalModel.id == body.goal_id))
+        result = await db.execute(
+            select(RaceGoalModel).where(
+                RaceGoalModel.id == body.goal_id,
+                RaceGoalModel.user_id == current_user.id,
+            )
+        )
         goal = result.scalar_one_or_none()
         if goal is None:
             raise HTTPException(status_code=404, detail="Ziel nicht gefunden")
@@ -211,10 +227,16 @@ async def export_pacing_fit(
 async def transfer_pacing_to_weekly_plan(
     body: PacingToWeeklyPlanRequest,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> PacingToWeeklyPlanResponse:
     """Uebernimmt eine Pacing-Strategie als Wettkampf-Session in den Wochenplan."""
     # 1) Goal laden → race_date
-    result = await db.execute(select(RaceGoalModel).where(RaceGoalModel.id == body.goal_id))
+    result = await db.execute(
+        select(RaceGoalModel).where(
+            RaceGoalModel.id == body.goal_id,
+            RaceGoalModel.user_id == current_user.id,
+        )
+    )
     goal = result.scalar_one_or_none()
     if goal is None:
         raise HTTPException(status_code=404, detail="Ziel nicht gefunden")
@@ -250,6 +272,7 @@ async def transfer_pacing_to_weekly_plan(
             week_start=week_start,
             day_of_week=day_of_week,
             is_rest_day=False,
+            user_id=current_user.id,
         )
         db.add(day_model)
         await db.flush()  # ID generieren
@@ -296,6 +319,7 @@ async def transfer_pacing_to_weekly_plan(
             run_details_json=run_details_json,
             notes=notes,
             status="active",
+            user_id=current_user.id,
         )
         db.add(race_session)
 
@@ -329,10 +353,12 @@ async def _save_pacing_strategy(
     goal_id: int,
     pacing: PacingResponse,
     elevation_preset: str | None,
+    user_id: int | None = None,
 ) -> PacingStrategyModel:
     """Speichert eine generierte Pacing-Strategie in der DB."""
     model = PacingStrategyModel(
         goal_id=goal_id,
+        user_id=user_id,
         strategy=pacing.strategy,
         strategy_label=pacing.strategy_label,
         distance_km=pacing.distance_km,
@@ -386,11 +412,15 @@ def _db_to_response(model: PacingStrategyModel) -> SavedPacingStrategyResponse:
 async def list_pacing_strategies(
     goal_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> SavedPacingStrategyListResponse:
     """Listet alle gespeicherten Pacing-Strategien fuer ein Ziel."""
     result = await db.execute(
         select(PacingStrategyModel)
-        .where(PacingStrategyModel.goal_id == goal_id)
+        .where(
+            PacingStrategyModel.goal_id == goal_id,
+            PacingStrategyModel.user_id == current_user.id,
+        )
         .order_by(PacingStrategyModel.created_at.desc())
     )
     models = result.scalars().all()
@@ -405,12 +435,14 @@ async def get_pacing_strategy(
     goal_id: int,
     strategy_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> SavedPacingStrategyResponse:
     """Gibt eine einzelne gespeicherte Pacing-Strategie zurueck."""
     result = await db.execute(
         select(PacingStrategyModel).where(
             PacingStrategyModel.id == strategy_id,
             PacingStrategyModel.goal_id == goal_id,
+            PacingStrategyModel.user_id == current_user.id,
         )
     )
     model = result.scalar_one_or_none()
@@ -424,12 +456,14 @@ async def delete_pacing_strategy(
     goal_id: int,
     strategy_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> None:
     """Loescht eine gespeicherte Pacing-Strategie."""
     result = await db.execute(
         select(PacingStrategyModel).where(
             PacingStrategyModel.id == strategy_id,
             PacingStrategyModel.goal_id == goal_id,
+            PacingStrategyModel.user_id == current_user.id,
         )
     )
     model = result.scalar_one_or_none()

--- a/backend/app/api/v1/session_templates.py
+++ b/backend/app/api/v1/session_templates.py
@@ -10,7 +10,8 @@ from fastapi.responses import Response
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.infrastructure.database.models import SessionTemplateModel, WorkoutModel
+from app.core.dependencies import get_current_user
+from app.infrastructure.database.models import SessionTemplateModel, UserModel, WorkoutModel
 from app.infrastructure.database.session import get_db
 from app.models.session_template import (
     SessionTemplateCreate,
@@ -84,16 +85,23 @@ def _model_to_summary(tmpl: SessionTemplateModel) -> SessionTemplateSummary:
 async def list_templates(
     session_type: Optional[str] = None,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> SessionTemplateListResponse:
     """List all session templates."""
-    query = select(SessionTemplateModel).order_by(SessionTemplateModel.updated_at.desc())
+    query = (
+        select(SessionTemplateModel)
+        .where(SessionTemplateModel.user_id == current_user.id)
+        .order_by(SessionTemplateModel.updated_at.desc())
+    )
     if session_type:
         query = query.where(SessionTemplateModel.session_type == session_type)
 
     result = await db.execute(query)
     templates = list(result.scalars().all())
 
-    count_query = select(func.count(SessionTemplateModel.id))
+    count_query = select(func.count(SessionTemplateModel.id)).where(
+        SessionTemplateModel.user_id == current_user.id
+    )
     if session_type:
         count_query = count_query.where(SessionTemplateModel.session_type == session_type)
     total = (await db.execute(count_query)).scalar() or 0
@@ -108,10 +116,14 @@ async def list_templates(
 async def get_template(
     template_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> SessionTemplateResponse:
     """Get a session template with exercises."""
     result = await db.execute(
-        select(SessionTemplateModel).where(SessionTemplateModel.id == template_id)
+        select(SessionTemplateModel).where(
+            SessionTemplateModel.id == template_id,
+            SessionTemplateModel.user_id == current_user.id,
+        )
     )
     tmpl = result.scalar_one_or_none()
     if not tmpl:
@@ -123,6 +135,7 @@ async def get_template(
 async def create_template(
     data: SessionTemplateCreate,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> SessionTemplateResponse:
     """Create a new session template."""
     if data.session_type == "strength" and not data.exercises:
@@ -151,6 +164,7 @@ async def create_template(
         exercises_json=exercises_data,
         run_details_json=run_details_data,
         is_template=True,
+        user_id=current_user.id,
     )
     db.add(tmpl)
     await db.commit()
@@ -163,10 +177,14 @@ async def update_template(
     template_id: int,
     data: SessionTemplateUpdate,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> SessionTemplateResponse:
     """Update a session template."""
     result = await db.execute(
-        select(SessionTemplateModel).where(SessionTemplateModel.id == template_id)
+        select(SessionTemplateModel).where(
+            SessionTemplateModel.id == template_id,
+            SessionTemplateModel.user_id == current_user.id,
+        )
     )
     tmpl = result.scalar_one_or_none()
     if not tmpl:
@@ -190,10 +208,14 @@ async def update_template(
 async def delete_template(
     template_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> None:
     """Delete a session template."""
     result = await db.execute(
-        select(SessionTemplateModel).where(SessionTemplateModel.id == template_id)
+        select(SessionTemplateModel).where(
+            SessionTemplateModel.id == template_id,
+            SessionTemplateModel.user_id == current_user.id,
+        )
     )
     tmpl = result.scalar_one_or_none()
     if not tmpl:
@@ -207,10 +229,14 @@ async def delete_template(
 async def duplicate_template(
     template_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> SessionTemplateResponse:
     """Duplicate a session template."""
     result = await db.execute(
-        select(SessionTemplateModel).where(SessionTemplateModel.id == template_id)
+        select(SessionTemplateModel).where(
+            SessionTemplateModel.id == template_id,
+            SessionTemplateModel.user_id == current_user.id,
+        )
     )
     tmpl = result.scalar_one_or_none()
     if not tmpl:
@@ -223,6 +249,7 @@ async def duplicate_template(
         exercises_json=tmpl.exercises_json,
         run_details_json=tmpl.run_details_json,
         is_template=True,
+        user_id=current_user.id,
     )
     db.add(new_tmpl)
     await db.commit()
@@ -234,10 +261,14 @@ async def duplicate_template(
 async def export_template_fit(
     template_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> Response:
     """Export eines Lauf-Templates als FIT-Workout-Datei fuer HealthFit/Garmin."""
     result = await db.execute(
-        select(SessionTemplateModel).where(SessionTemplateModel.id == template_id)
+        select(SessionTemplateModel).where(
+            SessionTemplateModel.id == template_id,
+            SessionTemplateModel.user_id == current_user.id,
+        )
     )
     tmpl = result.scalar_one_or_none()
     if not tmpl:
@@ -309,9 +340,15 @@ def _classify_run_type(
 async def create_from_session(
     session_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> SessionTemplateResponse:
     """Create a template from an existing session."""
-    result = await db.execute(select(WorkoutModel).where(WorkoutModel.id == session_id))
+    result = await db.execute(
+        select(WorkoutModel).where(
+            WorkoutModel.id == session_id,
+            WorkoutModel.user_id == current_user.id,
+        )
+    )
     session = result.scalar_one_or_none()
     if not session:
         raise HTTPException(status_code=404, detail="Session nicht gefunden")
@@ -349,6 +386,7 @@ async def create_from_session(
             session_type="strength",
             exercises_json=exercises_data,
             is_template=True,
+            user_id=current_user.id,
         )
     else:
         training_type = str(session.training_type_override or session.training_type_auto or "")
@@ -393,6 +431,7 @@ async def create_from_session(
             session_type="running",
             run_details_json=json.dumps(run_details),
             is_template=True,
+            user_id=current_user.id,
         )
 
     db.add(tmpl)

--- a/backend/app/api/v1/sessions.py
+++ b/backend/app/api/v1/sessions.py
@@ -21,9 +21,11 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
+from app.core.dependencies import get_current_user
 from app.infrastructure.database.models import (
     AthleteModel,
     PlannedSessionModel,
+    UserModel,
     WeeklyPlanDayModel,
     WorkoutModel,
 )
@@ -258,6 +260,7 @@ def _build_workout_model(
     form: SessionUploadForm,
     parsed: dict,
     csv_data: str | None,
+    user_id: int | None = None,
 ) -> WorkoutModel:
     """Erstellt WorkoutModel aus Form-Daten und Parse-Ergebnis."""
     summary = parsed["summary"]
@@ -290,6 +293,7 @@ def _build_workout_model(
         athlete_max_hr=parsed["max_hr"],
         notes=form.notes,
         rpe=form.rpe,
+        user_id=user_id,
     )
 
 
@@ -351,7 +355,7 @@ async def _save_and_respond(
     )
 
 
-async def _upload_session(
+async def _upload_session(  # noqa: PLR0913
     content: bytes,
     parser: TrainingCSVParser | TrainingFITParser,
     form: SessionUploadForm,
@@ -360,6 +364,7 @@ async def _upload_session(
     file_name: str | None = None,
     file_format: str | None = None,
     background_tasks: BackgroundTasks | None = None,
+    user_id: int | None = None,
 ) -> SessionUploadResponse:
     """Gemeinsame Upload-Logik für CSV und FIT."""
     parsed = await _parse_and_classify(
@@ -369,7 +374,7 @@ async def _upload_session(
         return SessionUploadResponse(success=False, errors=parsed["errors"])
 
     _apply_lap_overrides(parsed["laps"], form.lap_overrides_json)
-    workout = _build_workout_model(form, parsed, csv_data)
+    workout = _build_workout_model(form, parsed, csv_data, user_id=user_id)
 
     # Originaldatei mitspeichern fuer Reparse (#349)
     workout.original_file_content = content
@@ -411,6 +416,7 @@ async def parse_csv(
     training_subtype: Optional[TrainingSubType] = Form(None, description="Unter-Typ"),
     notes: Optional[str] = Form(None, description="Notizen"),  # noqa: ARG001
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
 ) -> SessionParseResponse:
     """Parse CSV und klassifiziere — ohne Session zu erstellen."""
     content = await _validate_upload_file(csv_file, ".csv", "CSV")
@@ -425,6 +431,7 @@ async def parse_fit(
     training_subtype: Optional[TrainingSubType] = Form(None, description="Unter-Typ"),
     notes: Optional[str] = Form(None, description="Notizen"),  # noqa: ARG001
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
 ) -> SessionParseResponse:
     """Parse FIT file und klassifiziere — ohne Session zu erstellen."""
     content = await _validate_upload_file(fit_file, ".fit", "FIT")
@@ -437,6 +444,7 @@ async def upload_csv(
     form: SessionUploadForm = Depends(),
     background_tasks: BackgroundTasks = BackgroundTasks(),
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> SessionUploadResponse:
     """Upload Apple Watch CSV und speichere als Session."""
     content = await _validate_upload_file(csv_file, ".csv", "CSV")
@@ -449,6 +457,7 @@ async def upload_csv(
         file_name=csv_file.filename,
         file_format="csv",
         background_tasks=background_tasks,
+        user_id=current_user.id,
     )
 
 
@@ -458,6 +467,7 @@ async def upload_fit(
     form: SessionUploadForm = Depends(),
     background_tasks: BackgroundTasks = BackgroundTasks(),
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> SessionUploadResponse:
     """Upload FIT file und speichere als Session."""
     content = await _validate_upload_file(fit_file, ".fit", "FIT")
@@ -469,11 +479,12 @@ async def upload_fit(
         file_name=fit_file.filename,
         file_format="fit",
         background_tasks=background_tasks,
+        user_id=current_user.id,
     )
 
 
 @router.get("", response_model=SessionListResponse)
-async def list_sessions(
+async def list_sessions(  # noqa: PLR0913
     page: int = Query(1, ge=1, description="Seitennummer"),
     page_size: int = Query(20, ge=1, le=100, description="Eintraege pro Seite"),
     workout_type: Optional[TrainingType] = Query(None, description="Filter nach Workout-Typ"),
@@ -482,12 +493,13 @@ async def list_sessions(
     date_to: Optional[date] = Query(None, description="Datum bis (inklusiv)"),
     search: Optional[str] = Query(None, description="Freitext-Suche (Notizen)"),
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> SessionListResponse:
     """Liste aller Sessions mit Paginierung und Filtern."""
     from app.models.session import SessionListItem
 
     # Build shared filter conditions
-    conditions = []
+    conditions = [WorkoutModel.user_id == current_user.id]
     if workout_type:
         conditions.append(WorkoutModel.workout_type == workout_type.value)
     if date_from:
@@ -533,9 +545,12 @@ async def list_sessions(
 async def get_session(
     session_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> SessionResponse:
     """Einzelne Session mit allen Details."""
-    query = select(WorkoutModel).where(WorkoutModel.id == session_id)
+    query = select(WorkoutModel).where(
+        WorkoutModel.id == session_id, WorkoutModel.user_id == current_user.id
+    )
     result = await db.execute(query)
     workout = result.scalar_one_or_none()
 
@@ -549,9 +564,12 @@ async def get_session(
 async def get_session_track(
     session_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> dict:
     """GPS Track einer Session (separater Endpoint fuer Performance)."""
-    query = select(WorkoutModel).where(WorkoutModel.id == session_id)
+    query = select(WorkoutModel).where(
+        WorkoutModel.id == session_id, WorkoutModel.user_id == current_user.id
+    )
     result = await db.execute(query)
     workout = result.scalar_one_or_none()
 
@@ -582,9 +600,12 @@ async def _get_athlete_elevation_factors(
 async def get_km_splits(
     session_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> dict:
     """Per-Kilometer Splits berechnet aus GPS Track."""
-    query = select(WorkoutModel).where(WorkoutModel.id == session_id)
+    query = select(WorkoutModel).where(
+        WorkoutModel.id == session_id, WorkoutModel.user_id == current_user.id
+    )
     result = await db.execute(query)
     workout = result.scalar_one_or_none()
 
@@ -615,9 +636,12 @@ async def get_km_splits(
 async def get_working_zones(
     session_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> dict:
     """Berechnet Working-Laps HR-Zonen (ohne DB-Schreibzugriff)."""
-    query = select(WorkoutModel).where(WorkoutModel.id == session_id)
+    query = select(WorkoutModel).where(
+        WorkoutModel.id == session_id, WorkoutModel.user_id == current_user.id
+    )
     result = await db.execute(query)
     workout = result.scalar_one_or_none()
 
@@ -645,9 +669,12 @@ async def get_working_zones(
 async def get_session_comparison(
     session_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> ComparisonResponse:
     """Soll/Ist-Vergleich: matcht geplante Segmente mit tatsächlichen Laps."""
-    query = select(WorkoutModel).where(WorkoutModel.id == session_id)
+    query = select(WorkoutModel).where(
+        WorkoutModel.id == session_id, WorkoutModel.user_id == current_user.id
+    )
     result = await db.execute(query)
     workout = result.scalar_one_or_none()
 
@@ -705,9 +732,12 @@ async def update_lap_overrides(
     session_id: int,
     body: LapOverrideRequest,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> LapOverrideResponse:
     """Aktualisiert Lap-Type Overrides und berechnet Working-Laps Metriken."""
-    query = select(WorkoutModel).where(WorkoutModel.id == session_id)
+    query = select(WorkoutModel).where(
+        WorkoutModel.id == session_id, WorkoutModel.user_id == current_user.id
+    )
     result = await db.execute(query)
     workout = result.scalar_one_or_none()
 
@@ -759,6 +789,7 @@ async def update_training_type(
     session_id: int,
     body: TrainingTypeOverrideRequest,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> SessionResponse:
     """Setzt manuellen Training Type Override."""
     if body.training_type not in VALID_TRAINING_TYPES:
@@ -767,7 +798,9 @@ async def update_training_type(
             detail=f"Ungültiger Training Type. Erlaubt: {', '.join(sorted(VALID_TRAINING_TYPES))}",
         )
 
-    query = select(WorkoutModel).where(WorkoutModel.id == session_id)
+    query = select(WorkoutModel).where(
+        WorkoutModel.id == session_id, WorkoutModel.user_id == current_user.id
+    )
     result = await db.execute(query)
     workout = result.scalar_one_or_none()
 
@@ -786,9 +819,12 @@ async def update_notes(
     session_id: int,
     body: NotesUpdateRequest,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> SessionResponse:
     """Aktualisiert die Notizen einer Session."""
-    query = select(WorkoutModel).where(WorkoutModel.id == session_id)
+    query = select(WorkoutModel).where(
+        WorkoutModel.id == session_id, WorkoutModel.user_id == current_user.id
+    )
     result = await db.execute(query)
     workout = result.scalar_one_or_none()
 
@@ -807,9 +843,12 @@ async def update_rpe(
     session_id: int,
     body: RpeUpdateRequest,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> SessionResponse:
     """Aktualisiert die RPE einer Session."""
-    query = select(WorkoutModel).where(WorkoutModel.id == session_id)
+    query = select(WorkoutModel).where(
+        WorkoutModel.id == session_id, WorkoutModel.user_id == current_user.id
+    )
     result = await db.execute(query)
     workout = result.scalar_one_or_none()
 
@@ -828,9 +867,12 @@ async def update_date(
     session_id: int,
     body: DateUpdateRequest,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> SessionResponse:
     """Aktualisiert das Datum einer Session."""
-    query = select(WorkoutModel).where(WorkoutModel.id == session_id)
+    query = select(WorkoutModel).where(
+        WorkoutModel.id == session_id, WorkoutModel.user_id == current_user.id
+    )
     result = await db.execute(query)
     workout = result.scalar_one_or_none()
 
@@ -849,9 +891,12 @@ async def update_planned_entry(
     session_id: int,
     body: PlannedEntryUpdateRequest,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> SessionResponse:
     """Aktualisiert die Zuordnung zu einer geplanten Session."""
-    query = select(WorkoutModel).where(WorkoutModel.id == session_id)
+    query = select(WorkoutModel).where(
+        WorkoutModel.id == session_id, WorkoutModel.user_id == current_user.id
+    )
     result = await db.execute(query)
     workout = result.scalar_one_or_none()
 
@@ -878,9 +923,12 @@ async def update_planned_entry(
 async def delete_session(
     session_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> None:
     """Loescht eine Session."""
-    query = select(WorkoutModel).where(WorkoutModel.id == session_id)
+    query = select(WorkoutModel).where(
+        WorkoutModel.id == session_id, WorkoutModel.user_id == current_user.id
+    )
     result = await db.execute(query)
     workout = result.scalar_one_or_none()
 
@@ -896,6 +944,7 @@ async def analyze_session(
     session_id: int,
     body: Optional[AnalyzeRequest] = None,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
 ) -> SessionAnalysisResponse:
     """KI-gestützte Analyse einer Session (Cache-First)."""
     from app.services.session_analysis_service import (
@@ -919,6 +968,7 @@ async def generate_recommendations(
     session_id: int,
     body: Optional[AnalyzeRequest] = None,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
 ) -> RecommendationsListResponse:
     """Generiert KI-gestuetzte Trainingsempfehlungen basierend auf Session-Analyse."""
     from app.services.recommendation_service import (
@@ -940,6 +990,7 @@ async def generate_recommendations(
 async def get_session_recommendations(
     session_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
 ) -> RecommendationsListResponse:
     """Laedt gespeicherte Empfehlungen fuer eine Session."""
     from app.services.recommendation_service import get_recommendations
@@ -952,6 +1003,7 @@ async def update_recommendation_status(
     recommendation_id: int,
     body: RecommendationStatusUpdate,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
 ) -> RecommendationResponse:
     """Aktualisiert den Status einer Empfehlung (applied/dismissed)."""
     from app.services.recommendation_service import (
@@ -969,12 +1021,15 @@ async def recalculate_session_zones(
     session_id: int,
     body: Optional[RecalculateZonesRequest] = None,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> dict:
     """Berechnet HR-Zonen einer einzelnen Session neu.
 
     Optionale HR-Werte im Body; ohne Body werden aktuelle Athleten-Einstellungen verwendet.
     """
-    query = select(WorkoutModel).where(WorkoutModel.id == session_id)
+    query = select(WorkoutModel).where(
+        WorkoutModel.id == session_id, WorkoutModel.user_id == current_user.id
+    )
     result = await db.execute(query)
     workout = result.scalar_one_or_none()
 
@@ -1285,13 +1340,16 @@ def _extract_working_hr_from_timeseries(
 async def reparse_session(
     session_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> dict:
     """Parst eine Session neu aus der gespeicherten Originaldatei.
 
     Aktualisiert Laps, HR-Daten, HR-Zonen, GPS. Behaelt User-Overrides
     (Segment-Types, Training-Type-Override, Notes, RPE, geplanter Eintrag).
     """
-    query = select(WorkoutModel).where(WorkoutModel.id == session_id)
+    query = select(WorkoutModel).where(
+        WorkoutModel.id == session_id, WorkoutModel.user_id == current_user.id
+    )
     result = await db.execute(query)
     workout = result.scalar_one_or_none()
     if not workout:
@@ -1309,12 +1367,14 @@ async def reparse_session(
 @router.post("/reparse-all")
 async def reparse_all_sessions(
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> dict:
     """Parst alle Sessions mit gespeicherter Originaldatei neu.
 
     Nuetzlich nach Parser-Fixes um alle bestehenden Sessions zu aktualisieren.
     """
     query = select(WorkoutModel).where(
+        WorkoutModel.user_id == current_user.id,
         WorkoutModel.original_file_content.isnot(None),
         WorkoutModel.original_file_format.isnot(None),
     )
@@ -1464,6 +1524,7 @@ async def _reparse_workout(
 async def export_session_fit(
     session_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> Response:
     """Export einer Lauf-Session als FIT-Workout-Datei.
 
@@ -1475,7 +1536,9 @@ async def export_session_fit(
     from app.models.segment import laps_to_template_segments
     from app.services.fit_export import export_template_to_fit
 
-    query = select(WorkoutModel).where(WorkoutModel.id == session_id)
+    query = select(WorkoutModel).where(
+        WorkoutModel.id == session_id, WorkoutModel.user_id == current_user.id
+    )
     result = await db.execute(query)
     workout = result.scalar_one_or_none()
     if not workout:
@@ -1533,9 +1596,12 @@ async def enrich_session(
     session_id: int,
     background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> dict:
     """Enrichment fuer eine einzelne Session triggern."""
-    query = select(WorkoutModel).where(WorkoutModel.id == session_id)
+    query = select(WorkoutModel).where(
+        WorkoutModel.id == session_id, WorkoutModel.user_id == current_user.id
+    )
     result = await db.execute(query)
     workout = result.scalar_one_or_none()
     if not workout:
@@ -1556,10 +1622,12 @@ async def enrich_session(
 async def enrich_batch(
     background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> dict:
     """Batch-Enrichment fuer alle pending Sessions triggern."""
     count_result = await db.execute(
         select(func.count(WorkoutModel.id)).where(
+            WorkoutModel.user_id == current_user.id,
             WorkoutModel.enrichment_status == "pending",
             WorkoutModel.has_gps.is_(True),
         )
@@ -1584,6 +1652,7 @@ async def enrich_batch(
 async def get_race_report(
     session_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
 ) -> dict:
     """Generiert Post-Race Analyse fuer eine Wettkampf-Session."""
     from app.services.race_report_service import generate_race_report
@@ -1597,9 +1666,14 @@ async def update_race_goal(
     session_id: int,
     body: dict,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> dict:
     """Verknuepft oder entknuepft eine Session mit einem Race Goal."""
-    result = await db.execute(select(WorkoutModel).where(WorkoutModel.id == session_id))
+    result = await db.execute(
+        select(WorkoutModel).where(
+            WorkoutModel.id == session_id, WorkoutModel.user_id == current_user.id
+        )
+    )
     workout = result.scalar_one_or_none()
     if not workout:
         raise HTTPException(status_code=404, detail="Session nicht gefunden.")
@@ -1615,6 +1689,7 @@ async def update_race_goal(
 async def analyze_race(
     session_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
 ) -> dict:
     """KI-Analyse speziell fuer Wettkampf-Sessions."""
     from app.services.race_report_service import generate_race_report

--- a/backend/app/api/v1/streak.py
+++ b/backend/app/api/v1/streak.py
@@ -6,7 +6,8 @@ from fastapi import APIRouter, Depends
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.infrastructure.database.models import WorkoutModel
+from app.core.dependencies import get_current_user
+from app.infrastructure.database.models import UserModel, WorkoutModel
 from app.infrastructure.database.session import get_db
 from app.models.streak import StreakResponse
 
@@ -16,6 +17,7 @@ router = APIRouter(prefix="/streak", tags=["analytics"])
 @router.get("", response_model=StreakResponse)
 async def get_streak(
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> StreakResponse:
     """Get training streak statistics with 90-day calendar heatmap."""
     today = date.today()
@@ -26,6 +28,7 @@ async def get_streak(
             func.date(WorkoutModel.date).label("training_date"),
             func.count().label("session_count"),
         )
+        .where(WorkoutModel.user_id == current_user.id)
         .group_by(func.date(WorkoutModel.date))
         .order_by(func.date(WorkoutModel.date).desc())
     )

--- a/backend/app/api/v1/strength.py
+++ b/backend/app/api/v1/strength.py
@@ -9,7 +9,8 @@ from pydantic import TypeAdapter
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.infrastructure.database.models import WorkoutModel
+from app.core.dependencies import get_current_user
+from app.infrastructure.database.models import UserModel, WorkoutModel
 from app.infrastructure.database.session import get_db
 from app.models.strength import (
     ExerciseInput,
@@ -91,7 +92,7 @@ def _parse_training_file(content: bytes, filename: str) -> Optional[dict]:
 
 
 @router.post("", status_code=201)
-async def create_strength_session(
+async def create_strength_session(  # noqa: PLR0913
     exercises_json: str = Form(..., description="JSON-Array der Übungen"),
     training_date: date = Form(..., description="Datum (YYYY-MM-DD)"),
     duration_minutes: int = Form(..., ge=1, le=600, description="Dauer in Minuten"),
@@ -102,6 +103,7 @@ async def create_strength_session(
         None, description="Manuelle Zuordnung zu geplanter Session"
     ),
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> dict:
     """Erstellt eine neue Krafttraining-Session.
 
@@ -178,6 +180,7 @@ async def create_strength_session(
         notes=combined_notes,
         rpe=rpe,
         planned_entry_id=planned_entry_id,
+        user_id=current_user.id,
     )
 
     db.add(workout)
@@ -212,12 +215,17 @@ async def update_strength_exercises(
     session_id: int,
     exercises_json: str = Form(..., description="JSON-Array der Übungen"),
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> dict:
     """Aktualisiert die Übungen einer bestehenden Krafttraining-Session."""
     from pydantic import ValidationError
 
     # Session laden
-    result = await db.execute(select(WorkoutModel).where(WorkoutModel.id == session_id))
+    result = await db.execute(
+        select(WorkoutModel).where(
+            WorkoutModel.id == session_id, WorkoutModel.user_id == current_user.id
+        )
+    )
     workout = result.scalar_one_or_none()
     if not workout:
         raise HTTPException(status_code=404, detail="Session nicht gefunden.")
@@ -268,11 +276,15 @@ async def update_strength_exercises(
 @router.get("/last-complete")
 async def get_last_complete_session(
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> dict:
     """Gibt die letzte vollstaendige Strength-Session zurueck (fuer Clone + Tonnage-Delta)."""
     query = (
         select(WorkoutModel)
-        .where(WorkoutModel.workout_type == "strength")
+        .where(
+            WorkoutModel.user_id == current_user.id,
+            WorkoutModel.workout_type == "strength",
+        )
         .where(WorkoutModel.exercises_json.isnot(None))
         .order_by(WorkoutModel.date.desc())
         .limit(1)
@@ -304,11 +316,15 @@ async def get_last_complete_session(
 async def get_last_exercises(
     exercise_name: str = Query(..., min_length=1, description="Name der Übung"),
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> dict:
     """Gibt die letzten Sätze einer Übung zurück (Quick-Add)."""
     query = (
         select(WorkoutModel)
-        .where(WorkoutModel.workout_type == "strength")
+        .where(
+            WorkoutModel.user_id == current_user.id,
+            WorkoutModel.workout_type == "strength",
+        )
         .where(WorkoutModel.exercises_json.isnot(None))
         .order_by(WorkoutModel.date.desc())
         .limit(20)
@@ -340,14 +356,15 @@ async def get_last_exercises(
 # --- Progression Tracking (Issue #17) ---
 
 
-async def _load_strength_sessions(db: AsyncSession) -> list[dict]:
+async def _load_strength_sessions(db: AsyncSession, user_id: int | None = None) -> list[dict]:
     """Laedt alle Strength-Sessions mit geparsten Exercises."""
-    query = (
-        select(WorkoutModel)
-        .where(WorkoutModel.workout_type == "strength")
-        .where(WorkoutModel.exercises_json.isnot(None))
-        .order_by(WorkoutModel.date.asc())
-    )
+    conditions = [
+        WorkoutModel.workout_type == "strength",
+        WorkoutModel.exercises_json.isnot(None),
+    ]
+    if user_id is not None:
+        conditions.append(WorkoutModel.user_id == user_id)
+    query = select(WorkoutModel).where(*conditions).order_by(WorkoutModel.date.asc())
     result = await db.execute(query)
     workouts = result.scalars().all()
 
@@ -373,11 +390,12 @@ async def _load_strength_sessions(db: AsyncSession) -> list[dict]:
 @router.get("/exercises")
 async def list_exercises(
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> dict:
     """Liste aller verwendeten Übungen mit Metadaten."""
     from app.services.progression_tracker import get_all_exercise_names
 
-    sessions = await _load_strength_sessions(db)
+    sessions = await _load_strength_sessions(db, user_id=current_user.id)
     exercises = get_all_exercise_names(sessions)
     return {"exercises": exercises}
 
@@ -386,11 +404,12 @@ async def list_exercises(
 async def get_exercise_progression(
     exercise_name: str = Query(..., min_length=1, description="Name der Übung"),
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> dict:
     """Progressionsverlauf einer Übung über die Zeit (typ-differenziert)."""
     from app.services.progression_tracker import get_exercise_history
 
-    sessions = await _load_strength_sessions(db)
+    sessions = await _load_strength_sessions(db, user_id=current_user.id)
     history = get_exercise_history(exercise_name, sessions)
 
     if not history:
@@ -457,11 +476,12 @@ async def get_exercise_progression(
 async def get_personal_records(
     session_id: Optional[int] = Query(None, description="Nur PRs dieser Session"),
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> dict:
     """Persönliche Bestleistungen (PRs) pro Übung."""
     from app.services.progression_tracker import detect_personal_records
 
-    sessions = await _load_strength_sessions(db)
+    sessions = await _load_strength_sessions(db, user_id=current_user.id)
     all_prs = detect_personal_records(sessions)
 
     if session_id is not None:
@@ -475,6 +495,7 @@ async def get_personal_records(
 async def get_tonnage_trend(
     days: int = Query(default=90, ge=7, le=365, description="Zeitraum in Tagen"),
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> dict:
     """Woechentlicher Tonnage-Trend fuer Krafttraining."""
     from app.services.progression_tracker import calculate_weekly_tonnage
@@ -483,7 +504,10 @@ async def get_tonnage_trend(
     cutoff = datetime.utcnow() - timedelta(days=days)
     query = (
         select(WorkoutModel)
-        .where(WorkoutModel.workout_type == "strength")
+        .where(
+            WorkoutModel.user_id == current_user.id,
+            WorkoutModel.workout_type == "strength",
+        )
         .where(WorkoutModel.exercises_json.isnot(None))
         .where(WorkoutModel.date >= cutoff)
         .order_by(WorkoutModel.date.asc())
@@ -535,6 +559,7 @@ async def get_tonnage_trend(
 async def get_category_tonnage_trend(
     days: int = Query(default=90, ge=7, le=365, description="Zeitraum in Tagen"),
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> dict:
     """Woechentliche Tonnage nach Kategorie (push/pull/legs/core/...)."""
     from app.services.progression_tracker import calculate_weekly_category_tonnage
@@ -542,7 +567,10 @@ async def get_category_tonnage_trend(
     cutoff = datetime.utcnow() - timedelta(days=days)
     query = (
         select(WorkoutModel)
-        .where(WorkoutModel.workout_type == "strength")
+        .where(
+            WorkoutModel.user_id == current_user.id,
+            WorkoutModel.workout_type == "strength",
+        )
         .where(WorkoutModel.exercises_json.isnot(None))
         .where(WorkoutModel.date >= cutoff)
         .order_by(WorkoutModel.date.asc())

--- a/backend/app/api/v1/threshold_tests.py
+++ b/backend/app/api/v1/threshold_tests.py
@@ -10,7 +10,8 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.v1.athlete import _get_or_create_athlete
-from app.infrastructure.database.models import ThresholdTestModel, WorkoutModel
+from app.core.dependencies import get_current_user
+from app.infrastructure.database.models import ThresholdTestModel, UserModel, WorkoutModel
 from app.infrastructure.database.session import get_db
 from app.models.threshold_test import (
     ThresholdAnalysisResponse,
@@ -38,10 +39,13 @@ def _build_response(test: ThresholdTestModel) -> ThresholdTestResponse:
 @router.get("", response_model=ThresholdTestListResponse)
 async def list_tests(
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> ThresholdTestListResponse:
     """Gibt alle Schwellentests zurück (neueste zuerst)."""
     result = await db.execute(
-        select(ThresholdTestModel).order_by(ThresholdTestModel.test_date.desc())
+        select(ThresholdTestModel)
+        .where(ThresholdTestModel.user_id == current_user.id)
+        .order_by(ThresholdTestModel.test_date.desc())
     )
     tests = result.scalars().all()
     return ThresholdTestListResponse(
@@ -53,10 +57,14 @@ async def list_tests(
 @router.get("/latest", response_model=ThresholdTestResponse)
 async def get_latest_test(
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> ThresholdTestResponse:
     """Gibt den neuesten Schwellentest zurück."""
     result = await db.execute(
-        select(ThresholdTestModel).order_by(ThresholdTestModel.test_date.desc()).limit(1)
+        select(ThresholdTestModel)
+        .where(ThresholdTestModel.user_id == current_user.id)
+        .order_by(ThresholdTestModel.test_date.desc())
+        .limit(1)
     )
     test = result.scalar_one_or_none()
     if not test:
@@ -68,6 +76,7 @@ async def get_latest_test(
 async def create_test(
     body: ThresholdTestCreate,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> ThresholdTestResponse:
     """Erstellt einen neuen Schwellentest und aktualisiert das Athletenprofil."""
     test = ThresholdTestModel(
@@ -77,12 +86,13 @@ async def create_test(
         avg_pace_sec=body.avg_pace_sec,
         session_id=body.session_id,
         notes=body.notes,
+        user_id=current_user.id,
     )
     db.add(test)
 
     # Max-HR im Athletenprofil aktualisieren wenn höher als bisheriger Wert
     if body.max_hr_measured:
-        athlete = await _get_or_create_athlete(db)
+        athlete = await _get_or_create_athlete(db, current_user.id)
         if athlete.max_hr is None or body.max_hr_measured > athlete.max_hr:
             athlete.max_hr = body.max_hr_measured
 
@@ -95,13 +105,18 @@ async def create_test(
 async def analyze_session(
     session_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> ThresholdAnalysisResponse:
     """Berechnet LTHR aus einer Session (Ø HR der letzten 20 Min).
 
     Basiert auf dem 30-Min-Friel-Test: Der Athlet läuft 30 Min maximal,
     die Durchschnitts-HR der letzten 20 Min entspricht der LTHR.
     """
-    result = await db.execute(select(WorkoutModel).where(WorkoutModel.id == session_id))
+    result = await db.execute(
+        select(WorkoutModel).where(
+            WorkoutModel.id == session_id, WorkoutModel.user_id == current_user.id
+        )
+    )
     workout = result.scalar_one_or_none()
     if not workout:
         raise HTTPException(status_code=404, detail="Session nicht gefunden")
@@ -176,9 +191,14 @@ def _extract_avg_pace(workout: WorkoutModel) -> float | None:
 async def delete_test(
     test_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> None:
     """Löscht einen Schwellentest."""
-    result = await db.execute(select(ThresholdTestModel).where(ThresholdTestModel.id == test_id))
+    result = await db.execute(
+        select(ThresholdTestModel).where(
+            ThresholdTestModel.id == test_id, ThresholdTestModel.user_id == current_user.id
+        )
+    )
     test = result.scalar_one_or_none()
     if not test:
         raise HTTPException(status_code=404, detail="Schwellentest nicht gefunden")

--- a/backend/app/api/v1/training_balance.py
+++ b/backend/app/api/v1/training_balance.py
@@ -10,7 +10,8 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.infrastructure.database.models import WorkoutModel
+from app.core.dependencies import get_current_user
+from app.infrastructure.database.models import UserModel, WorkoutModel
 from app.infrastructure.database.session import get_db
 from app.models.training_balance import (
     BalanceInsight,
@@ -42,6 +43,7 @@ CATEGORY_TO_MUSCLE = {
 async def get_training_balance(
     days: int = Query(default=28, ge=7, le=365),
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> TrainingBalanceResponse:
     """Analyse the training balance over a given period."""
     cutoff = datetime.utcnow() - timedelta(days=days)
@@ -59,7 +61,7 @@ async def get_training_balance(
                 WorkoutModel.training_type_auto,
             ).label("effective_type"),
         )
-        .where(WorkoutModel.date >= cutoff)
+        .where(WorkoutModel.user_id == current_user.id, WorkoutModel.date >= cutoff)
         .order_by(WorkoutModel.date.asc())
     )
     sessions = result.all()

--- a/backend/app/api/v1/training_plans.py
+++ b/backend/app/api/v1/training_plans.py
@@ -14,6 +14,7 @@ from pydantic import ValidationError
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.dependencies import get_current_user
 from app.infrastructure.database.models import (
     ExerciseModel,
     PlanChangeLogModel,
@@ -21,6 +22,7 @@ from app.infrastructure.database.models import (
     RaceGoalModel,
     TrainingPhaseModel,
     TrainingPlanModel,
+    UserModel,
     WeeklyPlanDayModel,
     WorkoutModel,
 )
@@ -350,16 +352,23 @@ def _changelog_to_response(entry: PlanChangeLogModel) -> PlanChangeLogEntry:
 async def list_plans(
     status: Optional[str] = None,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> TrainingPlanListResponse:
     """List all training plans, optionally filtered by status."""
-    query = select(TrainingPlanModel).order_by(TrainingPlanModel.updated_at.desc())
+    query = (
+        select(TrainingPlanModel)
+        .where(TrainingPlanModel.user_id == current_user.id)
+        .order_by(TrainingPlanModel.updated_at.desc())
+    )
     if status:
         query = query.where(TrainingPlanModel.status == status)
 
     result = await db.execute(query)
     plans = list(result.scalars().all())
 
-    count_query = select(func.count(TrainingPlanModel.id))
+    count_query = select(func.count(TrainingPlanModel.id)).where(
+        TrainingPlanModel.user_id == current_user.id
+    )
     if status:
         count_query = count_query.where(TrainingPlanModel.status == status)
     total = (await db.execute(count_query)).scalar() or 0
@@ -372,6 +381,7 @@ async def list_plans(
 async def create_plan(
     data: TrainingPlanCreate,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> TrainingPlanResponse:
     """Create a new training plan with optional phases and auto-create goal."""
     if data.end_date <= data.start_date:
@@ -385,7 +395,10 @@ async def create_plan(
     if data.goal and not goal_id:
         # Check if a goal with this title already exists
         existing_result = await db.execute(
-            select(RaceGoalModel).where(func.lower(RaceGoalModel.title) == data.goal.title.lower())
+            select(RaceGoalModel).where(
+                func.lower(RaceGoalModel.title) == data.goal.title.lower(),
+                RaceGoalModel.user_id == current_user.id,
+            )
         )
         existing_goal = existing_result.scalar_one_or_none()
         if existing_goal:
@@ -399,6 +412,7 @@ async def create_plan(
                 distance_km=data.goal.distance_km,
                 target_time_seconds=data.goal.target_time_seconds,
                 is_active=True,
+                user_id=current_user.id,
                 created_at=datetime.utcnow(),
                 updated_at=datetime.utcnow(),
             )
@@ -419,6 +433,7 @@ async def create_plan(
         target_event_date=data.target_event_date,
         weekly_structure_json=weekly_structure_json,
         status=data.status or "draft",
+        user_id=current_user.id,
         created_at=datetime.utcnow(),
         updated_at=datetime.utcnow(),
     )
@@ -798,6 +813,7 @@ async def get_template_yaml() -> FileResponse:
 async def validate_yaml_endpoint(
     yaml_file: UploadFile = File(..., description="YAML-Trainingsplan (.yaml/.yml)"),
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
 ) -> YamlValidationResult:
     """Validate a YAML training plan file and return structured errors/warnings."""
     if not yaml_file.filename or not yaml_file.filename.lower().endswith((".yaml", ".yml")):
@@ -872,6 +888,7 @@ async def import_plan_from_yaml(
         description='JSON mapping {"OldName": "ExistingName"} for exercise name substitutions',
     ),
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> TrainingPlanResponse:
     """Import a training plan from a YAML file."""
     if not yaml_file.filename or not yaml_file.filename.lower().endswith((".yaml", ".yml")):
@@ -922,7 +939,10 @@ async def import_plan_from_yaml(
     goal_title = raw.get("goal_title")
     if goal_title and not raw.get("goal_id") and not raw.get("goal"):
         result = await db.execute(
-            select(RaceGoalModel.id).where(func.lower(RaceGoalModel.title) == goal_title.lower())
+            select(RaceGoalModel.id).where(
+                func.lower(RaceGoalModel.title) == goal_title.lower(),
+                RaceGoalModel.user_id == current_user.id,
+            )
         )
         found_goal_id = result.scalar_one_or_none()
         if found_goal_id:
@@ -943,7 +963,7 @@ async def import_plan_from_yaml(
             detail=f"Validierungsfehler: {exc}",
         ) from None
 
-    created_plan = await create_plan(data=plan_data, db=db)
+    created_plan = await create_plan(data=plan_data, db=db, current_user=current_user)
     await log_plan_change(
         db,
         created_plan.id,
@@ -967,9 +987,15 @@ async def import_plan_from_yaml(
 async def get_generation_preview(
     plan_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> GenerationPreviewResponse:
     """Preview what re-generation would affect: count edited vs unedited weeks."""
-    result = await db.execute(select(TrainingPlanModel).where(TrainingPlanModel.id == plan_id))
+    result = await db.execute(
+        select(TrainingPlanModel).where(
+            TrainingPlanModel.id == plan_id,
+            TrainingPlanModel.user_id == current_user.id,
+        )
+    )
     plan = result.scalar_one_or_none()
     if not plan:
         raise HTTPException(status_code=404, detail="Trainingsplan nicht gefunden")
@@ -1008,13 +1034,17 @@ async def get_generation_preview(
 async def _load_generation_context(
     db: AsyncSession,
     plan_id: int,
+    user_id: int | None = None,
 ) -> tuple[TrainingPlanModel, list[TrainingPhaseModel], Optional[RaceGoalModel], list[int]]:
     """Load plan, phases, goal, and rest_days for weekly plan generation.
 
     Raises HTTPException if plan not found or has no phases.
     Returns (plan, phases, goal, rest_days).
     """
-    result = await db.execute(select(TrainingPlanModel).where(TrainingPlanModel.id == plan_id))
+    q = select(TrainingPlanModel).where(TrainingPlanModel.id == plan_id)
+    if user_id is not None:
+        q = q.where(TrainingPlanModel.user_id == user_id)
+    result = await db.execute(q)
     plan = result.scalar_one_or_none()
     if not plan:
         raise HTTPException(status_code=404, detail="Trainingsplan nicht gefunden")
@@ -1067,6 +1097,7 @@ async def _persist_generated_weeks(
     plan_id: int,
     weekly_plans: list[tuple[date, list]],
     skip_weeks: set[date] | None = None,
+    user_id: int | None = None,
 ) -> int:
     """Delete old and insert new weekly plan days + sessions.
 
@@ -1112,6 +1143,7 @@ async def _persist_generated_weeks(
                 is_rest_day=plan_entry.is_rest_day,
                 notes=plan_entry.notes,
                 edited=False,
+                user_id=user_id,
                 created_at=datetime.utcnow(),
                 updated_at=datetime.utcnow(),
             )
@@ -1133,6 +1165,7 @@ async def _persist_generated_weeks(
                     run_details_json=run_details_str,
                     exercises_json=exercises_str,
                     notes=sess.notes,
+                    user_id=user_id,
                     created_at=datetime.utcnow(),
                     updated_at=datetime.utcnow(),
                 )
@@ -1150,6 +1183,7 @@ async def generate_plan_weeks(
     plan_id: int,
     strategy: str = "all",
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> GenerateWeeklyPlansResponse:
     """Generate weekly plans from a training plan's phases.
 
@@ -1162,11 +1196,15 @@ async def generate_plan_weeks(
             detail="strategy muss 'all' oder 'unedited_only' sein.",
         )
 
-    plan, phases, goal, rest_days = await _load_generation_context(db, plan_id)
+    plan, phases, goal, rest_days = await _load_generation_context(
+        db, plan_id, user_id=current_user.id
+    )
     weekly_plans = generate_weekly_plans(plan, phases, rest_days, goal)
 
     skip_weeks = await _get_edited_weeks(db, plan_id) if strategy == "unedited_only" else set()
-    weeks_generated = await _persist_generated_weeks(db, plan_id, weekly_plans, skip_weeks)
+    weeks_generated = await _persist_generated_weeks(
+        db, plan_id, weekly_plans, skip_weeks, user_id=current_user.id
+    )
 
     # Fehlende Übungen automatisch anlegen (darf Generierung nicht blockieren)
     exercises_created = 0
@@ -1200,9 +1238,15 @@ async def generate_plan_weeks(
 async def get_plan(
     plan_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> TrainingPlanResponse:
     """Get a training plan with its phases and goal summary."""
-    result = await db.execute(select(TrainingPlanModel).where(TrainingPlanModel.id == plan_id))
+    result = await db.execute(
+        select(TrainingPlanModel).where(
+            TrainingPlanModel.id == plan_id,
+            TrainingPlanModel.user_id == current_user.id,
+        )
+    )
     plan = result.scalar_one_or_none()
     if not plan:
         raise HTTPException(status_code=404, detail="Trainingsplan nicht gefunden")
@@ -1214,9 +1258,15 @@ async def update_plan(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refactoring
     plan_id: int,
     data: TrainingPlanUpdate,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> TrainingPlanResponse:
     """Update a training plan."""
-    result = await db.execute(select(TrainingPlanModel).where(TrainingPlanModel.id == plan_id))
+    result = await db.execute(
+        select(TrainingPlanModel).where(
+            TrainingPlanModel.id == plan_id,
+            TrainingPlanModel.user_id == current_user.id,
+        )
+    )
     plan = result.scalar_one_or_none()
     if not plan:
         raise HTTPException(status_code=404, detail="Trainingsplan nicht gefunden")
@@ -1344,14 +1394,16 @@ async def update_plan(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refactoring
         if has_phases and has_dates:
             strategy = "all" if old_status == "draft" else "unedited_only"
             gen_plan, gen_phases, gen_goal, gen_rest_days = await _load_generation_context(
-                db, plan_id
+                db, plan_id, user_id=current_user.id
             )
             weekly_plans = generate_weekly_plans(gen_plan, gen_phases, gen_rest_days, gen_goal)
 
             skip_weeks = (
                 await _get_edited_weeks(db, plan_id) if strategy == "unedited_only" else set()
             )
-            weeks_generated = await _persist_generated_weeks(db, plan_id, weekly_plans, skip_weeks)
+            weeks_generated = await _persist_generated_weeks(
+                db, plan_id, weekly_plans, skip_weeks, user_id=current_user.id
+            )
 
             await log_plan_change(
                 db,
@@ -1383,6 +1435,7 @@ async def delete_plan(
     plan_id: int,
     include_weekly_plans: bool = False,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> None:
     """Delete a training plan and cascade-delete its phases.
 
@@ -1390,7 +1443,12 @@ async def delete_plan(
     days (and their planned sessions). Workout references are cleared.
     Changelog entries are always cleaned up.
     """
-    result = await db.execute(select(TrainingPlanModel).where(TrainingPlanModel.id == plan_id))
+    result = await db.execute(
+        select(TrainingPlanModel).where(
+            TrainingPlanModel.id == plan_id,
+            TrainingPlanModel.user_id == current_user.id,
+        )
+    )
     plan = result.scalar_one_or_none()
     if not plan:
         raise HTTPException(status_code=404, detail="Trainingsplan nicht gefunden")
@@ -1458,11 +1516,15 @@ async def delete_plan(
 async def list_phases(
     plan_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> list[TrainingPhaseResponse]:
     """List all phases of a training plan."""
-    # Verify plan exists
+    # Verify plan exists and belongs to user
     plan_result = await db.execute(
-        select(TrainingPlanModel.id).where(TrainingPlanModel.id == plan_id)
+        select(TrainingPlanModel.id).where(
+            TrainingPlanModel.id == plan_id,
+            TrainingPlanModel.user_id == current_user.id,
+        )
     )
     if not plan_result.scalar_one_or_none():
         raise HTTPException(status_code=404, detail="Trainingsplan nicht gefunden")
@@ -1484,9 +1546,15 @@ async def create_phase(
     plan_id: int,
     data: TrainingPhaseCreate,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> TrainingPhaseResponse:
     """Add a phase to a training plan."""
-    plan_result = await db.execute(select(TrainingPlanModel).where(TrainingPlanModel.id == plan_id))
+    plan_result = await db.execute(
+        select(TrainingPlanModel).where(
+            TrainingPlanModel.id == plan_id,
+            TrainingPlanModel.user_id == current_user.id,
+        )
+    )
     if not plan_result.scalar_one_or_none():
         raise HTTPException(status_code=404, detail="Trainingsplan nicht gefunden")
 
@@ -1526,8 +1594,19 @@ async def update_phase(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refactoring
     phase_id: int,
     data: TrainingPhaseUpdate,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> TrainingPhaseResponse:
     """Update a phase in a training plan."""
+    # Verify plan belongs to user
+    plan_check = await db.execute(
+        select(TrainingPlanModel.id).where(
+            TrainingPlanModel.id == plan_id,
+            TrainingPlanModel.user_id == current_user.id,
+        )
+    )
+    if not plan_check.scalar_one_or_none():
+        raise HTTPException(status_code=404, detail="Trainingsplan nicht gefunden")
+
     result = await db.execute(
         select(TrainingPhaseModel).where(
             TrainingPhaseModel.id == phase_id,
@@ -1644,7 +1723,10 @@ async def update_phase(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refactoring
     auto_regen: Optional[AutoRegenerationResult] = None
     if has_content_change:
         plan_result = await db.execute(
-            select(TrainingPlanModel).where(TrainingPlanModel.id == plan_id)
+            select(TrainingPlanModel).where(
+                TrainingPlanModel.id == plan_id,
+                TrainingPlanModel.user_id == current_user.id,
+            )
         )
         parent_plan = plan_result.scalar_one_or_none()
         if parent_plan and str(parent_plan.status) == "active" and parent_plan.start_date:
@@ -1673,13 +1755,15 @@ async def update_phase(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refactoring
             if future_weeks:
                 # Regenerate ALL future weeks (bidirectional sync — no edited filter)
                 gen_plan, gen_phases, gen_goal, gen_rest_days = await _load_generation_context(
-                    db, plan_id
+                    db, plan_id, user_id=current_user.id
                 )
                 weekly_plans = generate_weekly_plans(gen_plan, gen_phases, gen_rest_days, gen_goal)
 
                 # Only persist weeks that belong to this phase and are in scope
                 phase_plans = [(ws, entries) for ws, entries in weekly_plans if ws in future_weeks]
-                weeks_regenerated = await _persist_generated_weeks(db, plan_id, phase_plans)
+                weeks_regenerated = await _persist_generated_weeks(
+                    db, plan_id, phase_plans, user_id=current_user.id
+                )
 
                 past_weeks = len(phase_week_starts) - len(future_weeks)
 
@@ -1714,8 +1798,19 @@ async def delete_phase(
     plan_id: int,
     phase_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> None:
     """Delete a phase from a training plan."""
+    # Verify plan belongs to user
+    plan_check = await db.execute(
+        select(TrainingPlanModel.id).where(
+            TrainingPlanModel.id == plan_id,
+            TrainingPlanModel.user_id == current_user.id,
+        )
+    )
+    if not plan_check.scalar_one_or_none():
+        raise HTTPException(status_code=404, detail="Trainingsplan nicht gefunden")
+
     result = await db.execute(
         select(TrainingPhaseModel).where(
             TrainingPhaseModel.id == phase_id,
@@ -1752,11 +1847,15 @@ async def get_changelog(
     offset: int = 0,
     category: Optional[str] = None,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> PlanChangeLogResponse:
     """Get the change log for a training plan (paginated, newest first)."""
-    # Verify plan exists
+    # Verify plan exists and belongs to user
     plan_result = await db.execute(
-        select(TrainingPlanModel.id).where(TrainingPlanModel.id == plan_id)
+        select(TrainingPlanModel.id).where(
+            TrainingPlanModel.id == plan_id,
+            TrainingPlanModel.user_id == current_user.id,
+        )
     )
     if not plan_result.scalar_one_or_none():
         raise HTTPException(status_code=404, detail="Trainingsplan nicht gefunden")
@@ -1792,8 +1891,19 @@ async def update_changelog_reason(
     log_id: int,
     data: PlanChangeLogReasonUpdate,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> PlanChangeLogEntry:
     """Set or update the reason on a changelog entry."""
+    # Verify plan belongs to user
+    plan_check = await db.execute(
+        select(TrainingPlanModel.id).where(
+            TrainingPlanModel.id == plan_id,
+            TrainingPlanModel.user_id == current_user.id,
+        )
+    )
+    if not plan_check.scalar_one_or_none():
+        raise HTTPException(status_code=404, detail="Trainingsplan nicht gefunden")
+
     result = await db.execute(
         select(PlanChangeLogModel).where(
             PlanChangeLogModel.id == log_id,

--- a/backend/app/api/v1/training_routes.py
+++ b/backend/app/api/v1/training_routes.py
@@ -8,9 +8,11 @@ from fastapi.responses import Response
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.dependencies import get_current_user
 from app.infrastructure.database.models import (
     SessionTemplateModel,
     TrainingRouteModel,
+    UserModel,
     WorkoutModel,
 )
 from app.infrastructure.database.session import get_db
@@ -135,6 +137,7 @@ def _model_to_summary(route: TrainingRouteModel) -> TrainingRouteSummary:
 async def create_route(
     data: TrainingRouteCreate,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> TrainingRouteResponse:
     """Neue Trainingsroute erstellen."""
     # FK-Validierung
@@ -168,6 +171,7 @@ async def create_route(
         linked_session_template_id=data.linked_session_template_id,
         tags_json=json.dumps(data.tags) if data.tags else None,
         is_favorite=data.is_favorite,
+        user_id=current_user.id,
     )
     db.add(route)
     await db.commit()
@@ -181,9 +185,14 @@ async def list_routes(
     tag: Optional[str] = None,
     search: Optional[str] = None,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> TrainingRouteListResponse:
     """Alle Trainingsrouten auflisten (ohne Waypoints)."""
-    query = select(TrainingRouteModel).order_by(TrainingRouteModel.updated_at.desc())
+    query = (
+        select(TrainingRouteModel)
+        .where(TrainingRouteModel.user_id == current_user.id)
+        .order_by(TrainingRouteModel.updated_at.desc())
+    )
 
     if is_favorite is not None:
         query = query.where(TrainingRouteModel.is_favorite == is_favorite)
@@ -201,7 +210,9 @@ async def list_routes(
     routes = list(result.scalars().all())
 
     # Total count (same filters)
-    count_q = select(func.count(TrainingRouteModel.id))
+    count_q = select(func.count(TrainingRouteModel.id)).where(
+        TrainingRouteModel.user_id == current_user.id
+    )
     if is_favorite is not None:
         count_q = count_q.where(TrainingRouteModel.is_favorite == is_favorite)
     if tag:
@@ -225,9 +236,15 @@ async def create_route_from_session(
     session_id: int,
     name: Optional[str] = None,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> TrainingRouteResponse:
     """Route aus einer bestehenden Session mit GPS-Daten erstellen."""
-    result = await db.execute(select(WorkoutModel).where(WorkoutModel.id == session_id))
+    result = await db.execute(
+        select(WorkoutModel).where(
+            WorkoutModel.id == session_id,
+            WorkoutModel.user_id == current_user.id,
+        )
+    )
     workout = result.scalar_one_or_none()
     if not workout:
         raise HTTPException(status_code=404, detail="Session nicht gefunden")
@@ -251,6 +268,7 @@ async def create_route_from_session(
         route_segments_json=(
             json.dumps(route_data["route_segments"]) if route_data["route_segments"] else None
         ),
+        user_id=current_user.id,
     )
     db.add(route)
     await db.commit()
@@ -265,6 +283,7 @@ async def route_from_template(
     template_id: int,
     data: RouteFromTemplateRequest,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> RouteFromTemplatePreview:
     """Route-Vorschau aus Session Template generieren (#571).
 
@@ -274,7 +293,10 @@ async def route_from_template(
     Feinanpassung an und speichert ggf. via POST /routes.
     """
     result = await db.execute(
-        select(SessionTemplateModel).where(SessionTemplateModel.id == template_id)
+        select(SessionTemplateModel).where(
+            SessionTemplateModel.id == template_id,
+            SessionTemplateModel.user_id == current_user.id,
+        )
     )
     template = result.scalar_one_or_none()
     if not template:
@@ -318,7 +340,10 @@ async def route_from_template(
 
 
 @router.post("/snap", response_model=RouteSnapResponse)
-async def snap_route(data: RouteSnapRequest) -> RouteSnapResponse:
+async def snap_route(
+    data: RouteSnapRequest,
+    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+) -> RouteSnapResponse:
     """Waypoints auf Wege snappen via OSRM."""
     osrm = OSRMClient()
     try:
@@ -341,7 +366,10 @@ async def snap_route(data: RouteSnapRequest) -> RouteSnapResponse:
 
 
 @router.post("/generate-round-trip", response_model=RoundTripResponse)
-async def generate_round_trip(data: RoundTripRequest) -> RoundTripResponse:
+async def generate_round_trip(
+    data: RoundTripRequest,
+    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+) -> RoundTripResponse:
     """Rundkurs-Vorschläge generieren ab Startpunkt."""
     osrm = OSRMClient()
     try:
@@ -376,9 +404,15 @@ async def generate_round_trip(data: RoundTripRequest) -> RoundTripResponse:
 async def get_route(
     route_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> TrainingRouteResponse:
     """Einzelne Route mit allen Details abrufen."""
-    result = await db.execute(select(TrainingRouteModel).where(TrainingRouteModel.id == route_id))
+    result = await db.execute(
+        select(TrainingRouteModel).where(
+            TrainingRouteModel.id == route_id,
+            TrainingRouteModel.user_id == current_user.id,
+        )
+    )
     route = result.scalar_one_or_none()
     if not route:
         raise HTTPException(status_code=404, detail="Route nicht gefunden")
@@ -390,9 +424,15 @@ async def update_route(
     route_id: int,
     data: TrainingRouteUpdate,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> TrainingRouteResponse:
     """Route teilweise aktualisieren."""
-    result = await db.execute(select(TrainingRouteModel).where(TrainingRouteModel.id == route_id))
+    result = await db.execute(
+        select(TrainingRouteModel).where(
+            TrainingRouteModel.id == route_id,
+            TrainingRouteModel.user_id == current_user.id,
+        )
+    )
     route = result.scalar_one_or_none()
     if not route:
         raise HTTPException(status_code=404, detail="Route nicht gefunden")
@@ -425,13 +465,19 @@ async def calculate_pacing(
     route_id: int,
     data: RoutePacingRequest,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> RoutePacingResponse:
     """Pacing-Ziele für alle Segmente einer Route berechnen (#548).
 
     Nutzt die bestehende Pacing-Engine mit Elevation-Daten aus den Waypoints.
     Mappt km-genaue Splits auf die Route-Segmente.
     """
-    result = await db.execute(select(TrainingRouteModel).where(TrainingRouteModel.id == route_id))
+    result = await db.execute(
+        select(TrainingRouteModel).where(
+            TrainingRouteModel.id == route_id,
+            TrainingRouteModel.user_id == current_user.id,
+        )
+    )
     route = result.scalar_one_or_none()
     if not route:
         raise HTTPException(status_code=404, detail="Route nicht gefunden")
@@ -459,6 +505,7 @@ async def calculate_pacing(
 async def export_route_gpx(
     route_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> Response:
     """Route als GPX-Datei mit Training-Extensions exportieren (#553).
 
@@ -467,7 +514,12 @@ async def export_route_gpx(
     - <ta:segments> Extension im <trk> (Segment-Übersicht)
     - <ta:training> Extension pro Trackpoint (aktives Segment)
     """
-    result = await db.execute(select(TrainingRouteModel).where(TrainingRouteModel.id == route_id))
+    result = await db.execute(
+        select(TrainingRouteModel).where(
+            TrainingRouteModel.id == route_id,
+            TrainingRouteModel.user_id == current_user.id,
+        )
+    )
     route = result.scalar_one_or_none()
     if not route:
         raise HTTPException(status_code=404, detail="Route nicht gefunden")
@@ -500,6 +552,7 @@ async def export_route_gpx(
 async def export_route_fit(
     route_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> Response:
     """Route als FIT Course File exportieren (#577).
 
@@ -507,7 +560,12 @@ async def export_route_fit(
     - Waypoints (Position, Distanz, Höhe)
     - Einem Lap für die Gesamtroute
     """
-    result = await db.execute(select(TrainingRouteModel).where(TrainingRouteModel.id == route_id))
+    result = await db.execute(
+        select(TrainingRouteModel).where(
+            TrainingRouteModel.id == route_id,
+            TrainingRouteModel.user_id == current_user.id,
+        )
+    )
     route = result.scalar_one_or_none()
     if not route:
         raise HTTPException(status_code=404, detail="Route nicht gefunden")
@@ -535,9 +593,15 @@ async def export_route_fit(
 async def delete_route(
     route_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> None:
     """Route löschen."""
-    result = await db.execute(select(TrainingRouteModel).where(TrainingRouteModel.id == route_id))
+    result = await db.execute(
+        select(TrainingRouteModel).where(
+            TrainingRouteModel.id == route_id,
+            TrainingRouteModel.user_id == current_user.id,
+        )
+    )
     route = result.scalar_one_or_none()
     if not route:
         raise HTTPException(status_code=404, detail="Route nicht gefunden")

--- a/backend/app/api/v1/trends.py
+++ b/backend/app/api/v1/trends.py
@@ -9,7 +9,8 @@ from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.infrastructure.database.models import WorkoutModel
+from app.core.dependencies import get_current_user
+from app.infrastructure.database.models import UserModel, WorkoutModel
 from app.infrastructure.database.session import get_db
 from app.models.trend import TrendInsight, TrendResponse, WeeklyDataPoint
 
@@ -28,6 +29,7 @@ def _parse_pace_to_seconds(pace_str: str) -> float:
 async def get_trends(
     days: int = Query(default=28, ge=7, le=365),
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> TrendResponse:
     """Aggregierte Trainingsdaten fuer Trend-Analyse.
 
@@ -51,6 +53,7 @@ async def get_trends(
             ).label("effective_type"),
         )
         .where(
+            WorkoutModel.user_id == current_user.id,
             WorkoutModel.date >= cutoff,
             WorkoutModel.workout_type == "running",
         )
@@ -224,12 +227,14 @@ class WeatherCorrelationResponse(BaseModel):
 async def get_weather_correlation(
     days: int = Query(default=90, ge=14, le=365),
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> WeatherCorrelationResponse:
     """Korrelation zwischen Wetter und Laufleistung."""
     cutoff = datetime.utcnow() - timedelta(days=days)
     query = (
         select(WorkoutModel)
         .where(
+            WorkoutModel.user_id == current_user.id,
             WorkoutModel.date >= cutoff,
             WorkoutModel.workout_type == "running",
             WorkoutModel.weather_json.isnot(None),

--- a/backend/app/api/v1/user_settings.py
+++ b/backend/app/api/v1/user_settings.py
@@ -7,20 +7,21 @@ from fastapi import APIRouter, Depends
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.dependencies import get_current_user
 from app.core.encryption import encrypt_api_key
-from app.infrastructure.database.models import AthleteModel
+from app.infrastructure.database.models import AthleteModel, UserModel
 from app.infrastructure.database.session import get_db
 from app.models.user_settings import UserSettingsRequest, UserSettingsResponse
 
 router = APIRouter(prefix="/user", tags=["user-settings"])
 
 
-async def _get_or_create_athlete(db: AsyncSession) -> AthleteModel:
-    """Singleton-Athlete laden oder erstellen (wie in athlete.py)."""
-    result = await db.execute(select(AthleteModel).limit(1))
+async def _get_or_create_athlete(db: AsyncSession, user_id: int) -> AthleteModel:
+    """Athlete für einen User laden oder erstellen."""
+    result = await db.execute(select(AthleteModel).where(AthleteModel.user_id == user_id).limit(1))
     athlete = result.scalar_one_or_none()
     if not athlete:
-        athlete = AthleteModel()
+        athlete = AthleteModel(user_id=user_id)
         db.add(athlete)
         await db.commit()
         await db.refresh(athlete)
@@ -30,9 +31,10 @@ async def _get_or_create_athlete(db: AsyncSession) -> AthleteModel:
 @router.get("/settings", response_model=UserSettingsResponse)
 async def get_user_settings(
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> UserSettingsResponse:
     """Gibt User-Settings mit maskierten API Keys zurück."""
-    athlete = await _get_or_create_athlete(db)
+    athlete = await _get_or_create_athlete(db, current_user.id)
     return UserSettingsResponse.from_db(athlete)
 
 
@@ -40,6 +42,7 @@ async def get_user_settings(
 async def update_user_settings(
     body: UserSettingsRequest,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> UserSettingsResponse:
     """Aktualisiert API Keys (verschlüsselt in DB).
 
@@ -47,7 +50,7 @@ async def update_user_settings(
     - Leerer String '' → Key löschen
     - Wert → Key verschlüsseln und speichern
     """
-    athlete = await _get_or_create_athlete(db)
+    athlete = await _get_or_create_athlete(db, current_user.id)
 
     if body.claude_api_key is not None:
         if body.claude_api_key == "":

--- a/backend/app/api/v1/weekly_plan.py
+++ b/backend/app/api/v1/weekly_plan.py
@@ -10,12 +10,14 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.v1.training_plans import log_plan_change
+from app.core.dependencies import get_current_user
 from app.infrastructure.database.models import (
     PlanChangeLogModel,
     PlannedSessionModel,
     SessionTemplateModel,
     TrainingPhaseModel,
     TrainingPlanModel,
+    UserModel,
     WeeklyPlanDayModel,
     WorkoutModel,
 )
@@ -126,13 +128,13 @@ def _parse_exercises(raw: Optional[str]) -> Optional[list[TemplateExercise]]:
 async def _load_days_with_sessions(
     db: AsyncSession,
     week_start: date,
+    user_id: Optional[int] = None,
 ) -> dict[int, tuple[WeeklyPlanDayModel, list[PlannedSessionModel]]]:
     """Load all days and their sessions for a week. Returns {day_of_week: (day, sessions)}."""
-    day_result = await db.execute(
-        select(WeeklyPlanDayModel)
-        .where(WeeklyPlanDayModel.week_start == week_start)
-        .order_by(WeeklyPlanDayModel.day_of_week)
-    )
+    q = select(WeeklyPlanDayModel).where(WeeklyPlanDayModel.week_start == week_start)
+    if user_id is not None:
+        q = q.where(WeeklyPlanDayModel.user_id == user_id)
+    day_result = await db.execute(q.order_by(WeeklyPlanDayModel.day_of_week))
     days = {int(d.day_of_week): d for d in day_result.scalars().all()}
 
     if not days:
@@ -283,6 +285,7 @@ def _build_entry_from_db(
 async def get_weekly_plan(
     week_start: Optional[date] = None,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> WeeklyPlanResponse:
     """Get the weekly plan for a given week (defaults to current week)."""
     if week_start is None:
@@ -290,7 +293,7 @@ async def get_weekly_plan(
     else:
         week_start = _monday_of_week(week_start)
 
-    days_data = await _load_days_with_sessions(db, week_start)
+    days_data = await _load_days_with_sessions(db, week_start, user_id=current_user.id)
 
     # Collect template IDs for name lookup
     template_ids: list[int] = []
@@ -487,6 +490,7 @@ async def _auto_sync_week_to_plan(
     db: AsyncSession,
     plan_id: int,
     week_start: date,
+    user_id: Optional[int] = None,
 ) -> None:
     """Auto-sync weekly plan changes back to training plan phase template.
 
@@ -517,7 +521,7 @@ async def _auto_sync_week_to_plan(
     if not phase:
         return  # Week outside plan range
 
-    days_data = await _load_days_with_sessions(db, week_start)
+    days_data = await _load_days_with_sessions(db, week_start, user_id=user_id)
 
     template_ids: list[int] = []
     for _, (_, db_sessions) in days_data.items():
@@ -566,6 +570,7 @@ async def _auto_sync_week_to_plan(
 async def save_weekly_plan(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refactoring
     data: WeeklyPlanSaveRequest,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> WeeklyPlanResponse:
     """Save/update the weekly plan. Upserts all provided day entries."""
     week_start = _monday_of_week(data.week_start)
@@ -581,7 +586,7 @@ async def save_weekly_plan(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refacto
         seen_days.add(entry.day_of_week)
 
     # Fetch existing days + sessions BEFORE deletion (for plan_id + edited preservation)
-    old_data = await _load_days_with_sessions(db, week_start)
+    old_data = await _load_days_with_sessions(db, week_start, user_id=current_user.id)
 
     # Capture snapshot for undo (before any deletion)
     undo_phase_id, undo_phase_json = await _load_linked_phase_template(
@@ -630,6 +635,7 @@ async def save_weekly_plan(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refacto
             notes=entry.notes,
             plan_id=plan_id,
             edited=edited,
+            user_id=current_user.id,
         )
         db.add(db_day)
         await db.flush()  # Get db_day.id
@@ -652,6 +658,7 @@ async def save_weekly_plan(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refacto
                 exercises_json=exercises_str,
                 notes=session.notes,
                 status=session.status,
+                user_id=current_user.id,
             )
             db.add(db_session)
 
@@ -698,18 +705,19 @@ async def save_weekly_plan(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refacto
     if changed_plan_days:
         await db.flush()  # Ensure new days/sessions are persisted before sync reads them
         for pid in changed_plan_days:
-            await _auto_sync_week_to_plan(db, pid, week_start)
+            await _auto_sync_week_to_plan(db, pid, week_start, user_id=current_user.id)
 
     await db.commit()
 
     # Return the saved plan
-    return await get_weekly_plan(week_start=week_start, db=db)
+    return await get_weekly_plan(week_start=week_start, db=db, current_user=current_user)
 
 
 @router.delete("")
 async def clear_weekly_plan(
     week_start: Optional[date] = None,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> dict[str, bool]:
     """Clear all entries for a given week."""
     if week_start is None:
@@ -719,7 +727,10 @@ async def clear_weekly_plan(
 
     # Load days to get IDs for session cleanup
     day_result = await db.execute(
-        select(WeeklyPlanDayModel).where(WeeklyPlanDayModel.week_start == week_start)
+        select(WeeklyPlanDayModel).where(
+            WeeklyPlanDayModel.week_start == week_start,
+            WeeklyPlanDayModel.user_id == current_user.id,
+        )
     )
     days = day_result.scalars().all()
 
@@ -793,6 +804,7 @@ def _determine_status(  # noqa: PLR0911  # TODO: E16 Refactoring
 async def get_compliance(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refactoring
     week_start: Optional[date] = None,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> ComplianceResponse:
     """Get compliance tracking for a given week (plan vs. actual sessions)."""
     if week_start is None:
@@ -803,12 +815,13 @@ async def get_compliance(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refactori
     week_end = week_start + timedelta(days=6)
 
     # Fetch plan days + sessions
-    days_data = await _load_days_with_sessions(db, week_start)
+    days_data = await _load_days_with_sessions(db, week_start, user_id=current_user.id)
 
     # Fetch all workouts for this week
     session_result = await db.execute(
         select(WorkoutModel)
         .where(
+            WorkoutModel.user_id == current_user.id,
             WorkoutModel.date >= datetime.combine(week_start, datetime.min.time()),
             WorkoutModel.date <= datetime.combine(week_end, datetime.max.time()),
         )
@@ -954,6 +967,7 @@ async def get_compliance(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refactori
         prev_week_end = week_start - timedelta(days=1)
         prev_result = await db.execute(
             select(WorkoutModel).where(
+                WorkoutModel.user_id == current_user.id,
                 WorkoutModel.workout_type == "strength",
                 WorkoutModel.exercises_json.isnot(None),
                 WorkoutModel.date >= datetime.combine(prev_week_start, datetime.min.time()),
@@ -1011,6 +1025,7 @@ async def get_compliance(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refactori
 async def get_sessions_for_date(
     target_date: date = Query(..., alias="date"),
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> list[PlannedSessionOption]:
     """Get planned sessions for a specific date (for upload linking)."""
     week_start = _monday_of_week(target_date)
@@ -1021,6 +1036,7 @@ async def get_sessions_for_date(
         select(WeeklyPlanDayModel).where(
             WeeklyPlanDayModel.week_start == week_start,
             WeeklyPlanDayModel.day_of_week == day_of_week,
+            WeeklyPlanDayModel.user_id == current_user.id,
         )
     )
     day = day_result.scalar_one_or_none()
@@ -1062,13 +1078,17 @@ async def get_sessions_for_date(
 async def sync_to_plan(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refactoring
     data: SyncToPlanRequest,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> SyncToPlanResponse:
     """Sync edited weekly plan entries back to training plan phase template."""
     week_start = _monday_of_week(data.week_start)
 
-    # Load training plan
+    # Load training plan (verify ownership)
     plan_result = await db.execute(
-        select(TrainingPlanModel).where(TrainingPlanModel.id == data.plan_id)
+        select(TrainingPlanModel).where(
+            TrainingPlanModel.id == data.plan_id,
+            TrainingPlanModel.user_id == current_user.id,
+        )
     )
     plan = plan_result.scalar_one_or_none()
     if not plan:
@@ -1101,7 +1121,7 @@ async def sync_to_plan(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refactoring
         )
 
     # Load weekly plan days + sessions
-    days_data = await _load_days_with_sessions(db, week_start)
+    days_data = await _load_days_with_sessions(db, week_start, user_id=current_user.id)
 
     # Resolve template names for all sessions
     sync_template_ids: list[int] = []
@@ -1259,6 +1279,7 @@ async def _find_undoable_entry(
 async def get_undo_status(
     week_start: date = Query(...),
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
 ) -> UndoStatusResponse:
     """Check if undo is available for a given week."""
     week_start = _monday_of_week(week_start)
@@ -1281,6 +1302,7 @@ async def get_undo_status(
 async def undo_weekly_plan(
     week_start: date = Query(...),
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> UndoResponse:
     """Undo the most recent change to a weekly plan (within 24h window)."""
     week_start = _monday_of_week(week_start)
@@ -1295,7 +1317,7 @@ async def undo_weekly_plan(
         raise HTTPException(status_code=409, detail="Snapshot-Daten fehlen oder sind ungültig.")
 
     # Capture current state before restoring (for audit trail)
-    current_data = await _load_days_with_sessions(db, week_start)
+    current_data = await _load_days_with_sessions(db, week_start, user_id=current_user.id)
     current_phase_id, current_phase_json = await _load_linked_phase_template(
         db,
         current_data,
@@ -1327,6 +1349,7 @@ async def undo_weekly_plan(
             notes=snap_day.get("notes"),
             plan_id=plan_id,
             edited=snap_day.get("edited", False),
+            user_id=current_user.id,
         )
         db.add(db_day)
         await db.flush()
@@ -1341,6 +1364,7 @@ async def undo_weekly_plan(
                 exercises_json=snap_session.get("exercises_json"),
                 notes=snap_session.get("notes"),
                 status=snap_session.get("status", "active"),
+                user_id=current_user.id,
             )
             db.add(db_session)
 
@@ -1391,6 +1415,7 @@ async def undo_weekly_plan(
 async def apply_recommendations(
     data: ApplyRecommendationsRequest,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
 ) -> ApplyRecommendationsResponse:
     """Konvertiert KI-Review-Empfehlungen in Plan-Sessions für die Folgewoche."""
     from app.services.recommendation_to_plan_service import (
@@ -1415,6 +1440,7 @@ async def apply_recommendations(
 async def export_planned_session_fit(
     entry_id: int,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> Response:
     """Export eines geplanten Lauftrainings als FIT-Workout-Datei.
 
@@ -1425,7 +1451,12 @@ async def export_planned_session_fit(
 
     from app.services.fit_export import export_template_to_fit
 
-    result = await db.execute(select(PlannedSessionModel).where(PlannedSessionModel.id == entry_id))
+    result = await db.execute(
+        select(PlannedSessionModel).where(
+            PlannedSessionModel.id == entry_id,
+            PlannedSessionModel.user_id == current_user.id,
+        )
+    )
     entry = result.scalar_one_or_none()
     if not entry:
         raise HTTPException(status_code=404, detail="Geplanter Eintrag nicht gefunden.")

--- a/backend/app/api/v1/weekly_review.py
+++ b/backend/app/api/v1/weekly_review.py
@@ -5,6 +5,8 @@ from datetime import date
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.dependencies import get_current_user
+from app.infrastructure.database.models import UserModel
 from app.infrastructure.database.session import get_db
 from app.models.weekly_review import WeeklyReviewGenerateRequest, WeeklyReviewResponse
 from app.services.weekly_review_service import generate_weekly_review, get_weekly_review
@@ -16,6 +18,7 @@ router = APIRouter()
 async def generate_review(
     request: WeeklyReviewGenerateRequest,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> WeeklyReviewResponse:
     """Generiert ein wöchentliches KI-Trainingsreview.
 
@@ -33,7 +36,7 @@ async def generate_review(
 
     try:
         return await generate_weekly_review(
-            week_start_date, db, force_refresh=request.force_refresh
+            week_start_date, db, force_refresh=request.force_refresh, user_id=current_user.id
         )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
@@ -48,6 +51,7 @@ async def generate_review(
 async def get_review(
     week_start: str,
     db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
 ) -> WeeklyReviewResponse:
     """Lädt ein gespeichertes Wochen-Review.
 
@@ -63,7 +67,7 @@ async def get_review(
         ) from e
 
     try:
-        review = await get_weekly_review(week_start_date, db)
+        review = await get_weekly_review(week_start_date, db, user_id=current_user.id)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 

--- a/backend/app/api/v1/workouts.py
+++ b/backend/app/api/v1/workouts.py
@@ -12,15 +12,20 @@ from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.api_key_resolver import resolve_claude_api_key
+from app.core.dependencies import get_current_user
 from app.infrastructure.ai.ai_service import ai_service
-from app.infrastructure.database.models import WorkoutModel
+from app.infrastructure.database.models import UserModel, WorkoutModel
 from app.infrastructure.database.session import get_db
 
 router = APIRouter()
 
 
 @router.post("/workouts/upload")
-async def upload_workout(csv_file: UploadFile = File(...), db: AsyncSession = Depends(get_db)):
+async def upload_workout(
+    csv_file: UploadFile = File(...),
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
     """
     Upload and analyze workout from CSV file
 
@@ -61,6 +66,7 @@ async def upload_workout(csv_file: UploadFile = File(...), db: AsyncSession = De
             hr_min=workout_data.get("hr_min"),
             csv_data=csv_text,
             ai_analysis=ai_analysis,
+            user_id=current_user.id,
         )
 
         db.add(workout)
@@ -86,11 +92,22 @@ async def upload_workout(csv_file: UploadFile = File(...), db: AsyncSession = De
 
 
 @router.get("/workouts")
-async def get_workouts(limit: int = 20, offset: int = 0, db: AsyncSession = Depends(get_db)):
+async def get_workouts(
+    limit: int = 20,
+    offset: int = 0,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
     """Get list of workouts"""
     from sqlalchemy import select
 
-    query = select(WorkoutModel).order_by(WorkoutModel.date.desc()).limit(limit).offset(offset)
+    query = (
+        select(WorkoutModel)
+        .where(WorkoutModel.user_id == current_user.id)
+        .order_by(WorkoutModel.date.desc())
+        .limit(limit)
+        .offset(offset)
+    )
     result = await db.execute(query)
     workouts = result.scalars().all()
 
@@ -113,11 +130,17 @@ async def get_workouts(limit: int = 20, offset: int = 0, db: AsyncSession = Depe
 
 
 @router.get("/workouts/{workout_id}")
-async def get_workout(workout_id: int, db: AsyncSession = Depends(get_db)):
+async def get_workout(
+    workout_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
     """Get single workout with AI analysis"""
     from sqlalchemy import select
 
-    query = select(WorkoutModel).where(WorkoutModel.id == workout_id)
+    query = select(WorkoutModel).where(
+        WorkoutModel.id == workout_id, WorkoutModel.user_id == current_user.id
+    )
     result = await db.execute(query)
     workout = result.scalar_one_or_none()
 

--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -11,6 +11,7 @@ from app.core.config import settings
 from app.core.security import decode_access_token
 from app.infrastructure.database.models import UserModel
 from app.infrastructure.database.session import get_db
+from app.services.data_migration_service import assign_orphaned_data
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +33,10 @@ async def _ensure_default_user(db: AsyncSession) -> UserModel:
     await db.commit()
     await db.refresh(user)
     logger.info("Default-User erstellt (auth_enabled=False): id=%s", user.id)
+
+    # Verwaiste Daten (user_id=NULL) dem Fallback-User zuweisen
+    await assign_orphaned_data(db, user.id)
+
     return user
 
 

--- a/backend/app/services/data_migration_service.py
+++ b/backend/app/services/data_migration_service.py
@@ -49,6 +49,28 @@ _TABLES_WITH_USER_ID = [
 ]
 
 
+async def reassign_user_data(
+    db: AsyncSession, from_user_id: int, to_user_id: int
+) -> dict[str, int]:
+    """Weist alle Daten eines Users einem anderen zu (z.B. Fallback → echter User)."""
+    from sqlalchemy import update as sql_update
+
+    counts: dict[str, int] = {}
+    for model in _TABLES_WITH_USER_ID:
+        result = await db.execute(
+            sql_update(model)
+            .where(model.user_id == from_user_id)  # type: ignore[attr-defined]
+            .values(user_id=to_user_id)
+        )
+        count = getattr(result, "rowcount", 0) or 0
+        if count > 0:
+            counts[model.__tablename__] = count
+
+    await db.commit()
+    logger.info("Datentransfer: user_id=%s → user_id=%s: %s", from_user_id, to_user_id, counts)
+    return counts
+
+
 async def assign_orphaned_data(db: AsyncSession, user_id: int) -> dict[str, int]:
     """Weist alle Datensaetze mit user_id=NULL dem gegebenen User zu.
 

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -7,7 +7,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.infrastructure.database.models import UserModel
-from app.services.data_migration_service import assign_orphaned_data
+from app.services.data_migration_service import assign_orphaned_data, reassign_user_data
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +87,14 @@ async def find_or_create_user_by_apple(
     # assign_orphaned_data ist idempotent — greift nur Zeilen ohne user_id an.
     if is_first_real_user:
         await assign_orphaned_data(db, user.id)
+
+        # Fallback-User-Daten übernehmen (falls Fallback bereits existierte)
+        fallback_result = await db.execute(
+            select(UserModel).where(UserModel.email == _FALLBACK_USER_EMAIL)
+        )
+        fallback_user = fallback_result.scalar_one_or_none()
+        if fallback_user is not None and fallback_user.id != user.id:
+            await reassign_user_data(db, fallback_user.id, user.id)
 
     return user
 

--- a/backend/app/services/weekly_review_service.py
+++ b/backend/app/services/weekly_review_service.py
@@ -54,18 +54,19 @@ async def generate_weekly_review(
     db: AsyncSession,
     *,
     force_refresh: bool = False,
+    user_id: int | None = None,
 ) -> WeeklyReviewResponse:
     """Generiert ein wöchentliches KI-Trainingsreview."""
     _validate_week_start(week_start)
 
     # Cache prüfen
     if not force_refresh:
-        cached = await _load_cached_review(week_start, db)
+        cached = await _load_cached_review(week_start, db, user_id=user_id)
         if cached:
             return _model_to_response(cached, is_cached=True)
 
     # Kontext laden
-    context = await _load_weekly_context(week_start, db)
+    context = await _load_weekly_context(week_start, db, user_id=user_id)
 
     # Prompt bauen und AI aufrufen
     prompt = _build_review_prompt(context)
@@ -81,8 +82,8 @@ async def generate_weekly_review(
     parsed = _parse_review_json(raw, context)
 
     # Altes Review löschen, neues speichern
-    await _delete_existing_review(week_start, db)
-    model = await _save_review(week_start, parsed, provider, context, db)
+    await _delete_existing_review(week_start, db, user_id=user_id)
+    model = await _save_review(week_start, parsed, provider, context, db, user_id=user_id)
 
     # Log
     await log_ai_call(
@@ -105,10 +106,12 @@ async def generate_weekly_review(
 async def get_weekly_review(
     week_start: date,
     db: AsyncSession,
+    *,
+    user_id: int | None = None,
 ) -> WeeklyReviewResponse | None:
     """Lädt ein gespeichertes Wochen-Review."""
     _validate_week_start(week_start)
-    model = await _load_cached_review(week_start, db)
+    model = await _load_cached_review(week_start, db, user_id=user_id)
     if not model:
         return None
     return _model_to_response(model, is_cached=True)
@@ -144,12 +147,16 @@ def _validate_week_start(week_start: date) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def _load_weekly_context(week_start: date, db: AsyncSession) -> WeeklyContext:
+async def _load_weekly_context(
+    week_start: date,
+    db: AsyncSession,
+    user_id: int | None = None,
+) -> WeeklyContext:
     """Lädt den vollständigen Kontext für eine Trainingswoche."""
     week_end = week_start + timedelta(days=6)
 
     # Alle Sessions der Woche
-    sessions = await _load_week_sessions(week_start, week_end, db)
+    sessions = await _load_week_sessions(week_start, week_end, db, user_id=user_id)
 
     # Volumen berechnen
     volume = _calculate_volume(sessions)
@@ -177,16 +184,16 @@ async def _load_week_sessions(
     week_start: date,
     week_end: date,
     db: AsyncSession,
+    user_id: int | None = None,
 ) -> list[WorkoutModel]:
     """Lädt alle Sessions einer Woche."""
-    result = await db.execute(
-        select(WorkoutModel)
-        .where(
-            WorkoutModel.date >= datetime.combine(week_start, datetime.min.time()),
-            WorkoutModel.date <= datetime.combine(week_end, datetime.max.time()),
-        )
-        .order_by(WorkoutModel.date)
-    )
+    conditions = [
+        WorkoutModel.date >= datetime.combine(week_start, datetime.min.time()),
+        WorkoutModel.date <= datetime.combine(week_end, datetime.max.time()),
+    ]
+    if user_id is not None:
+        conditions.append(WorkoutModel.user_id == user_id)
+    result = await db.execute(select(WorkoutModel).where(*conditions).order_by(WorkoutModel.date))
     return list(result.scalars().all())
 
 
@@ -341,19 +348,28 @@ async def _load_current_phase(ref_date: date, db: AsyncSession) -> dict | None:
 async def _load_cached_review(
     week_start: date,
     db: AsyncSession,
+    user_id: int | None = None,
 ) -> WeeklyReviewModel | None:
     """Lädt ein gecachtes Review für eine Woche."""
-    result = await db.execute(
-        select(WeeklyReviewModel).where(WeeklyReviewModel.week_start == week_start)
-    )
+    conditions = [WeeklyReviewModel.week_start == week_start]
+    if user_id is not None:
+        conditions.append(WeeklyReviewModel.user_id == user_id)
+    result = await db.execute(select(WeeklyReviewModel).where(*conditions))
     return result.scalar_one_or_none()
 
 
-async def _delete_existing_review(week_start: date, db: AsyncSession) -> None:
+async def _delete_existing_review(
+    week_start: date,
+    db: AsyncSession,
+    user_id: int | None = None,
+) -> None:
     """Löscht ein bestehendes Review für eine Woche."""
     from sqlalchemy import delete
 
-    await db.execute(delete(WeeklyReviewModel).where(WeeklyReviewModel.week_start == week_start))
+    conditions = [WeeklyReviewModel.week_start == week_start]
+    if user_id is not None:
+        conditions.append(WeeklyReviewModel.user_id == user_id)
+    await db.execute(delete(WeeklyReviewModel).where(*conditions))
 
 
 async def _save_review(
@@ -362,6 +378,7 @@ async def _save_review(
     provider: str,
     context: WeeklyContext,
     db: AsyncSession,
+    user_id: int | None = None,
 ) -> WeeklyReviewModel:
     """Speichert ein geparstes Review in der DB."""
     model = WeeklyReviewModel(
@@ -375,6 +392,7 @@ async def _save_review(
         fatigue_assessment=parsed["fatigue_assessment"],
         session_count=context.volume["session_count"],
         provider=provider,
+        user_id=user_id,
     )
     db.add(model)
     await db.flush()

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from app.infrastructure.database.models import Base
+from app.infrastructure.database.models import Base, UserModel
 from app.infrastructure.database.session import get_db
 from app.main import app
 
@@ -25,9 +25,17 @@ def event_loop():
 
 @pytest.fixture(autouse=True)
 async def setup_db():
-    """Create tables before each test, drop after."""
+    """Create tables before each test, drop after. Pre-creates the fallback user."""
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+
+    # Pre-create the fallback user (same as get_current_user with auth_enabled=False).
+    # Tests that create data directly in the DB brauchen diesen user_id.
+    async with TestSessionLocal() as session:
+        user = UserModel(email="local@training-analyzer.app", name="Test User", is_active=True)
+        session.add(user)
+        await session.commit()
+
     yield
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)

--- a/backend/app/tests/test_auth.py
+++ b/backend/app/tests/test_auth.py
@@ -79,9 +79,10 @@ class TestUserService:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_get_user_count_empty(self, db_session: AsyncSession) -> None:
+    async def test_get_user_count_with_fallback(self, db_session: AsyncSession) -> None:
+        # conftest pre-creates the fallback user
         count = await get_user_count(db_session)
-        assert count == 0
+        assert count == 1
 
     @pytest.mark.asyncio
     async def test_find_or_create_user_creates_new(self, db_session: AsyncSession) -> None:

--- a/backend/app/tests/test_exercise_library.py
+++ b/backend/app/tests/test_exercise_library.py
@@ -19,6 +19,7 @@ class TestExerciseLibraryUnit:
             category="push",
             is_custom=True,
             is_favorite=False,
+            user_id=1,
         )
         db_session.add(exercise)
         await db_session.commit()

--- a/backend/app/tests/test_pacing_persistence.py
+++ b/backend/app/tests/test_pacing_persistence.py
@@ -19,6 +19,7 @@ async def _create_goal(db: AsyncSession) -> RaceGoalModel:
         distance_km=21.0975,
         target_time_seconds=6600,  # 1:50:00
         is_active=True,
+        user_id=1,
     )
     db.add(goal)
     await db.commit()

--- a/backend/app/tests/test_plan_generator.py
+++ b/backend/app/tests/test_plan_generator.py
@@ -61,6 +61,7 @@ def _make_plan(
         status="draft",
         created_at=datetime.utcnow(),
         updated_at=datetime.utcnow(),
+        user_id=1,
     )
     db.add(plan)
     return plan
@@ -102,6 +103,7 @@ def _make_goal(
         is_active=True,
         created_at=datetime.utcnow(),
         updated_at=datetime.utcnow(),
+        user_id=1,
     )
     db.add(goal)
     return goal
@@ -125,6 +127,7 @@ class TestHelpers:
             is_active=True,
             created_at=datetime.utcnow(),
             updated_at=datetime.utcnow(),
+            user_id=1,
         )
         pace = _compute_race_pace(goal)
         assert pace is not None

--- a/backend/app/tests/test_recommendations.py
+++ b/backend/app/tests/test_recommendations.py
@@ -75,6 +75,7 @@ async def _create_test_workout(
         hr_avg=145,
         hr_max=162,
         hr_min=120,
+        user_id=1,
     )
     if with_analysis:
         workout.ai_analysis = json.dumps(MOCK_ANALYSIS)

--- a/backend/app/tests/test_session_analysis.py
+++ b/backend/app/tests/test_session_analysis.py
@@ -43,6 +43,7 @@ async def _create_test_workout(db: AsyncSession) -> WorkoutModel:
         hr_max=162,
         hr_min=120,
         cadence_avg=178,
+        user_id=1,
         laps_json=json.dumps(
             [
                 {

--- a/backend/app/tests/test_session_templates.py
+++ b/backend/app/tests/test_session_templates.py
@@ -305,6 +305,7 @@ async def test_from_session_strength(
         workout_type="strength",
         duration_sec=3600,
         exercises_json=json.dumps(exercises),
+        user_id=1,
     )
     db_session.add(workout)
     await db_session.commit()
@@ -333,6 +334,7 @@ async def test_from_session_running(
         distance_km=8.5,
         pace="5:18",
         training_type_auto="easy",
+        user_id=1,
     )
     db_session.add(workout)
     await db_session.commit()
@@ -358,6 +360,7 @@ async def test_from_session_long_run(
         duration_sec=5400,
         distance_km=18.0,
         pace="5:00",
+        user_id=1,
     )
     db_session.add(workout)
     await db_session.commit()

--- a/backend/app/tests/test_streak.py
+++ b/backend/app/tests/test_streak.py
@@ -17,6 +17,7 @@ async def _add_session(db: AsyncSession, days_ago: int) -> None:
         workout_type="running",
         duration_sec=2700,
         distance_km=5.0,
+        user_id=1,
     )
     db.add(workout)
     await db.commit()

--- a/backend/app/tests/test_training_balance.py
+++ b/backend/app/tests/test_training_balance.py
@@ -25,6 +25,7 @@ async def _add_running(
         distance_km=distance_km,
         duration_sec=duration_sec,
         pace="5:30",
+        user_id=1,
     )
     db.add(workout)
     await db.commit()
@@ -41,6 +42,7 @@ async def _add_strength(
         workout_type="strength",
         duration_sec=3600,
         exercises_json=json.dumps(exercises),
+        user_id=1,
     )
     db.add(workout)
     await db.commit()

--- a/backend/app/tests/test_training_plans.py
+++ b/backend/app/tests/test_training_plans.py
@@ -313,6 +313,7 @@ async def test_create_plan_with_goal(
         race_date=datetime(2026, 7, 5),
         distance_km=21.1,
         target_time_seconds=7200,
+        user_id=1,
     )
     db_session.add(goal)
     await db_session.commit()
@@ -343,6 +344,7 @@ async def test_delete_plan_clears_goal_link(
         race_date=datetime(2026, 7, 5),
         distance_km=21.1,
         target_time_seconds=7200,
+        user_id=1,
     )
     db_session.add(goal)
     await db_session.commit()
@@ -424,6 +426,7 @@ async def test_import_yaml_with_goal_title(
         race_date=datetime(2026, 7, 26),
         distance_km=21.1,
         target_time_seconds=7200,
+        user_id=1,
     )
     db_session.add(goal)
     await db_session.commit()
@@ -794,6 +797,7 @@ async def test_create_plan_auto_create_uses_existing_goal(
         race_date=datetime(2026, 7, 5),
         distance_km=21.1,
         target_time_seconds=7200,
+        user_id=1,
     )
     db_session.add(goal)
     await db_session.commit()
@@ -849,6 +853,7 @@ async def test_create_plan_goal_id_takes_precedence(
         race_date=datetime(2026, 7, 5),
         distance_km=21.1,
         target_time_seconds=7200,
+        user_id=1,
     )
     db_session.add(goal)
     await db_session.commit()
@@ -914,6 +919,7 @@ async def test_import_yaml_goal_uses_existing(
         race_date=datetime(2026, 7, 26),
         distance_km=21.1,
         target_time_seconds=7200,
+        user_id=1,
     )
     db_session.add(goal)
     await db_session.commit()

--- a/backend/app/tests/test_training_routes.py
+++ b/backend/app/tests/test_training_routes.py
@@ -391,6 +391,7 @@ async def _create_session_with_gps(
         laps_json=json.dumps(LAPS_DATA) if with_laps else None,
         location_name=location,
         surface_json=json.dumps(surface) if surface else None,
+        user_id=1,
     )
     db.add(workout)
     await db.commit()

--- a/backend/app/tests/test_weekly_plan.py
+++ b/backend/app/tests/test_weekly_plan.py
@@ -435,6 +435,14 @@ async def _create_workout(
     training_type_auto: str = "easy",
 ) -> int:
     """Helper to create a workout directly in DB."""
+    # Fallback-User (id=1, pre-created in conftest) nutzen
+    from sqlalchemy import select
+
+    from app.infrastructure.database.models import UserModel
+
+    result = await db.execute(select(UserModel).limit(1))
+    user = result.scalar_one()
+
     workout = WorkoutModel(
         date=datetime.fromisoformat(date_str),
         workout_type=workout_type,
@@ -442,6 +450,7 @@ async def _create_workout(
         duration_sec=2700,
         distance_km=5.0 if workout_type == "running" else None,
         pace="5:30" if workout_type == "running" else None,
+        user_id=user.id,
     )
     db.add(workout)
     await db.commit()


### PR DESCRIPTION
## Zusammenfassung

S05 von Epic #556: Alle 18 API-Router mit `current_user` Dependency absichern.

> **Abhängigkeit:** Baut auf #588 (Auth-Infrastruktur) auf — nach Merge von #588 rebasen.

### Änderungen

- **18 Router** erhalten `current_user: UserModel = Depends(get_current_user)`
- **SELECT-Queries** filtern nach `user_id == current_user.id` — User A sieht keine Daten von User B
- **CREATE-Operationen** setzen `user_id = current_user.id`
- **Health** (`/health`) und **Auth** (`/auth/*`) bleiben ohne Authentifizierung
- **Fallback-User** (auth_enabled=False): `_ensure_default_user` erstellt User + migriert verwaiste Daten
- **reassign_user_data()**: transferiert Fallback-User-Daten → echten User beim ersten Login
- **Exercises**: `or_(user_id.is_(None), user_id == current_user.id)` für shared + user-owned

### Betroffene Router (18)

workouts, sessions, athlete, goals, training_plans, weekly_plan, weekly_review, exercise_library, strength, session_templates, streak, trends, training_balance, ai, ai_log, user_settings, pacing, threshold_tests, training_routes

### Test-Anpassungen

- `conftest.py`: Pre-creates Fallback-User vor jedem Test
- 10 Test-Dateien: `user_id=1` auf direkte DB-Model-Erstellung
- `test_auth.py`: `test_get_user_count_empty` → `test_get_user_count_with_fallback`

## Test-Plan

- [x] Backend: 1254 Tests grün (Ruff, Mypy, Pytest)
- [x] Frontend: 182 Tests grün (ESLint, TSC, Vitest)
- [x] `auth_enabled=false` (Standard): App funktioniert unverändert via Fallback-User
- [ ] `auth_enabled=true`: User A sieht nur eigene Daten (manueller Test nach Deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)