### PR TITLE
feat: Apple Sign-In JS SDK Integration (#559)

### DIFF
--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -3,7 +3,8 @@
 import logging
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import RedirectResponse
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -75,13 +76,62 @@ async def apple_sign_in(
     return await _create_token_pair(db, user.id)
 
 
+@router.post("/apple/callback")
+async def apple_callback(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> RedirectResponse:
+    """Verarbeitet Apples Server-Redirect (form POST mit code + id_token)."""
+    form = await request.form()
+    id_token = form.get("id_token")
+
+    if not id_token or not isinstance(id_token, str):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="id_token fehlt",
+        )
+
+    try:
+        claims = await validate_apple_id_token(id_token)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=str(e),
+        ) from e
+
+    user = await find_or_create_user_by_apple(
+        db,
+        apple_sub=claims.sub,
+        email=claims.email,
+        name=None,
+    )
+    tokens = await _create_token_pair(db, user.id)
+
+    # Redirect zum Frontend mit Tokens im URL-Fragment (nicht sichtbar fuer Server)
+    host = request.headers.get("host", "")
+    scheme = "https" if request.url.scheme == "https" or "localhost" not in host else "http"
+    fragment = (
+        f"access_token={tokens.access_token}"
+        f"&refresh_token={tokens.refresh_token}"
+        f"&expires_in={tokens.expires_in}"
+    )
+    redirect_url = f"{scheme}://{host}/login#auth={fragment}"
+    return RedirectResponse(url=redirect_url, status_code=303)
+
+
 @router.get("/status", response_model=AuthStatusResponse)
-async def auth_status() -> AuthStatusResponse:
+async def auth_status(request: Request) -> AuthStatusResponse:
     """Gibt den Auth-Status zurueck (fuer App-Initialisierung)."""
+    host = request.headers.get("host", "")
+    scheme = "https" if request.url.scheme == "https" or "localhost" not in host else "http"
     return AuthStatusResponse(
         auth_enabled=settings.auth_enabled,
         authenticated=False,
         user=None,
+        apple_client_id=settings.apple_client_id if settings.auth_enabled else None,
+        redirect_uri=f"{scheme}://{host}/api/v1/auth/apple/callback"
+        if settings.auth_enabled
+        else None,
     )
 
 

--- a/backend/app/models/auth.py
+++ b/backend/app/models/auth.py
@@ -46,3 +46,5 @@ class AuthStatusResponse(BaseModel):
     auth_enabled: bool
     authenticated: bool
     user: UserResponse | None = None
+    apple_client_id: str | None = None
+    redirect_uri: str | None = None

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -26,6 +26,10 @@
       />
     </noscript>
     <title>Training Analyzer</title>
+    <script
+      type="text/javascript"
+      src="https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js"
+    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -19,6 +19,8 @@ export interface AuthStatusResponse {
   auth_enabled: boolean;
   authenticated: boolean;
   user: UserResponse | null;
+  apple_client_id: string | null;
+  redirect_uri: string | null;
 }
 
 /** Apple Sign-In: ID-Token gegen Access/Refresh-Token tauschen. */

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -19,6 +19,10 @@ interface AuthState {
   refreshToken: string | null;
   /** Fehler-Nachricht. */
   error: string | null;
+  /** Apple Client ID vom Backend (fuer SDK-Init). */
+  appleClientId: string | null;
+  /** Apple Redirect URI vom Backend (fuer SDK-Init). */
+  appleRedirectUri: string | null;
 
   /** Auth-Status vom Backend laden. */
   checkStatus: () => Promise<void>;
@@ -42,12 +46,18 @@ export const useAuth = create<AuthState>()(
       accessToken: null,
       refreshToken: null,
       error: null,
+      appleClientId: null,
+      appleRedirectUri: null,
 
       checkStatus: async () => {
         set({ isLoading: true, error: null });
         try {
           const status = await getAuthStatus();
-          set({ authEnabled: status.auth_enabled });
+          set({
+            authEnabled: status.auth_enabled,
+            appleClientId: status.apple_client_id ?? null,
+            appleRedirectUri: status.redirect_uri ?? null,
+          });
 
           if (!status.auth_enabled) {
             // Kein Auth → Default-User laden

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,17 +1,60 @@
+import { useEffect, useRef, useState } from 'react';
 import { Card, Button, Spinner } from '@nordlig/components';
 import { useAuth } from '@/hooks/useAuth';
 
 export default function Login() {
-  const { isLoading, error, clearError } = useAuth();
+  const { isLoading, error, clearError, appleClientId, appleRedirectUri, signInWithApple } =
+    useAuth();
+
+  const [sdkReady, setSdkReady] = useState(false);
+  const initDone = useRef(false);
+
+  // Apple JS SDK initialisieren sobald clientId vorhanden
+  useEffect(() => {
+    if (!appleClientId || !appleRedirectUri || initDone.current) return;
+
+    const initSdk = () => {
+      if (typeof AppleID === 'undefined') return;
+      AppleID.auth.init({
+        clientId: appleClientId,
+        scope: 'name email',
+        redirectURI: appleRedirectUri,
+        usePopup: true,
+      });
+      initDone.current = true;
+      setSdkReady(true);
+    };
+
+    // SDK ist moeglicherweise schon geladen
+    if (typeof AppleID !== 'undefined') {
+      initSdk();
+    } else {
+      // Auf das Script warten
+      const checkInterval = setInterval(() => {
+        if (typeof AppleID !== 'undefined') {
+          clearInterval(checkInterval);
+          initSdk();
+        }
+      }, 100);
+      return () => clearInterval(checkInterval);
+    }
+  }, [appleClientId, appleRedirectUri]);
 
   const handleAppleSignIn = async () => {
     clearError();
-    // In der nativen iOS App wird das Apple Sign-In SDK aufgerufen
-    // und das ID-Token + Authorization Code hier uebergeben.
-    // Fuer die Web-Version: Apple JS SDK Integration.
-    // Placeholder fuer die tatsaechliche Apple Sign-In Integration:
-    const event = new CustomEvent('apple-sign-in-request');
-    window.dispatchEvent(event);
+    try {
+      const response = await AppleID.auth.signIn();
+      const { id_token, code } = response.authorization;
+      const firstName = response.user?.name?.firstName;
+      await signInWithApple(id_token, code, firstName);
+    } catch (err) {
+      // User hat Popup geschlossen oder anderer Fehler
+      if (err instanceof Error && err.message !== 'popup_closed_by_user') {
+        useAuth.setState({
+          error: 'Apple-Anmeldung fehlgeschlagen. Bitte erneut versuchen.',
+        });
+      }
+    }
   };
 
   return (
@@ -41,7 +84,7 @@ export default function Login() {
             size="lg"
             className="w-full"
             onClick={handleAppleSignIn}
-            disabled={isLoading}
+            disabled={isLoading || !sdkReady}
           >
             {isLoading ? (
               <Spinner size="sm" />

--- a/frontend/src/types/apple-auth.d.ts
+++ b/frontend/src/types/apple-auth.d.ts
@@ -1,0 +1,17 @@
+declare namespace AppleID {
+  interface AuthI {
+    init(config: { clientId: string; scope: string; redirectURI: string; usePopup: boolean }): void;
+    signIn(): Promise<{
+      authorization: {
+        code: string;
+        id_token: string;
+        state?: string;
+      };
+      user?: {
+        email?: string;
+        name?: { firstName?: string; lastName?: string };
+      };
+    }>;
+  }
+  const auth: AuthI;
+}


### PR DESCRIPTION
## Zusammenfassung

Vollständige Apple Sign-In Integration für Web (Popup-Flow).

### Frontend
- Apple JS SDK in `index.html` geladen
- `Login.tsx`: `AppleID.auth.init()` + `signIn()` mit Popup
- `useAuth`: `appleClientId` + `appleRedirectUri` aus Backend
- TypeScript Declarations für `AppleID` Namespace

### Backend
- `/auth/status` liefert `apple_client_id` + `redirect_uri`
- `POST /auth/apple/callback` für Apple Server-Redirect (Fallback)

### Apple Developer Konfiguration
- App ID: `app.training-analyzer`
- Services ID: `app.training-analyzer.web`
- Key ID: `325ZFW23Q5`
- Domain: `training.89.167.78.223.sslip.io`

## Test-Plan
- [x] TSC, ESLint, Vitest 182 Tests grün
- [x] Ruff, Mypy grün
- [ ] E2E: auth_enabled=true → Login-Screen → Apple Sign-In → Daten verknüpft

🤖 Generated with [Claude Code](https://claude.com/claude-code)