### PR TITLE
feat: Admin-Rollen, E-Mail/Passwort Auth, Nutzerverwaltung (#633)

### DIFF
--- a/backend/alembic/versions/c048_add_role_and_password_hash.py
+++ b/backend/alembic/versions/c048_add_role_and_password_hash.py
@@ -1,0 +1,41 @@
+"""Fuegt role und password_hash Spalten zur users-Tabelle hinzu.
+
+Bestehende User bekommen role='user'. Der erste echte User
+(nicht der Fallback-User) wird zum Admin befördert.
+
+Revision ID: c048_add_role_and_password_hash
+Revises: c047_cleanup_duplicate_athletes
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "c048_add_role_and_password_hash"
+down_revision = "c047_cleanup_duplicate_athletes"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("role", sa.String(20), server_default="user", nullable=False),
+    )
+    op.add_column(
+        "users",
+        sa.Column("password_hash", sa.String(255), nullable=True),
+    )
+
+    # Ersten echten User (nicht den Fallback) zum Admin machen
+    op.execute(
+        """
+        UPDATE users SET role = 'admin'
+        WHERE id = (
+            SELECT MIN(id) FROM users
+            WHERE email != 'local@training-analyzer.app'
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "password_hash")
+    op.drop_column("users", "role")

--- a/backend/app/api/v1/admin.py
+++ b/backend/app/api/v1/admin.py
@@ -1,0 +1,115 @@
+"""Admin-Router: User-Verwaltung (nur fuer Admins)."""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dependencies import get_current_admin
+from app.infrastructure.database.models import UserModel
+from app.infrastructure.database.session import get_db
+from app.models.admin import AdminUserResponse, AdminUserUpdate
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/admin")
+
+VALID_ROLES = {"admin", "user", "pending"}
+
+
+def _to_admin_response(user: UserModel) -> AdminUserResponse:
+    """Konvertiert ein UserModel in eine AdminUserResponse."""
+    return AdminUserResponse(
+        id=user.id,
+        email=user.email,
+        name=user.name,
+        role=user.role,
+        is_active=user.is_active,
+        has_password=user.password_hash is not None,
+        has_apple=user.apple_sub is not None,
+        created_at=user.created_at,
+        last_login_at=user.last_login_at,
+    )
+
+
+@router.get("/users", response_model=list[AdminUserResponse])
+async def list_users(
+    db: AsyncSession = Depends(get_db),
+    _admin: UserModel = Depends(get_current_admin),
+) -> list[AdminUserResponse]:
+    """Listet alle User auf (nur Admin)."""
+    result = await db.execute(select(UserModel).order_by(UserModel.id))
+    users = result.scalars().all()
+    return [_to_admin_response(u) for u in users]
+
+
+@router.patch("/users/{user_id}", response_model=AdminUserResponse)
+async def update_user(
+    user_id: int,
+    body: AdminUserUpdate,
+    db: AsyncSession = Depends(get_db),
+    admin: UserModel = Depends(get_current_admin),
+) -> AdminUserResponse:
+    """Aktualisiert Role/Status eines Users (nur Admin, nicht sich selbst)."""
+    if user_id == admin.id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Eigenes Konto kann nicht geändert werden",
+        )
+
+    result = await db.execute(select(UserModel).where(UserModel.id == user_id))
+    user = result.scalar_one_or_none()
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Benutzer nicht gefunden",
+        )
+
+    if body.role is not None:
+        if body.role not in VALID_ROLES:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Ungültige Rolle: {body.role}",
+            )
+        user.role = body.role
+
+    if body.is_active is not None:
+        user.is_active = body.is_active
+
+    await db.commit()
+    await db.refresh(user)
+    logger.info(
+        "Admin %s hat User %s aktualisiert: role=%s, active=%s",
+        admin.id,
+        user_id,
+        user.role,
+        user.is_active,
+    )
+    return _to_admin_response(user)
+
+
+@router.delete("/users/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def deactivate_user(
+    user_id: int,
+    db: AsyncSession = Depends(get_db),
+    admin: UserModel = Depends(get_current_admin),
+) -> None:
+    """Deaktiviert einen User (nur Admin, nicht sich selbst)."""
+    if user_id == admin.id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Eigenes Konto kann nicht deaktiviert werden",
+        )
+
+    result = await db.execute(select(UserModel).where(UserModel.id == user_id))
+    user = result.scalar_one_or_none()
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Benutzer nicht gefunden",
+        )
+
+    user.is_active = False
+    await db.commit()
+    logger.info("Admin %s hat User %s deaktiviert", admin.id, user_id)

--- a/backend/app/api/v1/ai.py
+++ b/backend/app/api/v1/ai.py
@@ -16,7 +16,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.api_key_resolver import resolve_claude_api_key
-from app.core.dependencies import get_current_user
+from app.core.dependencies import get_current_active_user
 from app.infrastructure.ai.ai_service import AIProviderFactory, ai_service
 from app.infrastructure.database.models import (
     PlanChangeLogModel,
@@ -81,7 +81,7 @@ async def get_providers():
 async def chat(
     request: ChatRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+    current_user: UserModel = Depends(get_current_active_user),  # noqa: ARG001 — ensures auth
 ):
     """Chat with AI trainer (User-Key → .env Fallback)."""
     try:

--- a/backend/app/api/v1/ai_log.py
+++ b/backend/app/api/v1/ai_log.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.dependencies import get_current_user
+from app.core.dependencies import get_current_active_user
 from app.infrastructure.database.models import AIAnalysisLogModel, UserModel, WorkoutModel
 from app.infrastructure.database.session import get_db
 
@@ -47,7 +47,7 @@ class AILogListResponse(BaseModel):
 @router.get("", response_model=AILogListResponse)
 async def list_ai_logs(
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
     limit: int = Query(default=20, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
 ) -> AILogListResponse:
@@ -104,7 +104,7 @@ async def list_ai_logs(
 async def get_ai_log_detail(
     log_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> AILogDetail:
     """Einzelner Log-Eintrag mit vollem Prompt und Response."""
     stmt = (

--- a/backend/app/api/v1/athlete.py
+++ b/backend/app/api/v1/athlete.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.dependencies import get_current_user
+from app.core.dependencies import get_current_active_user
 from app.infrastructure.database.models import AthleteModel, ThresholdTestModel, UserModel
 from app.infrastructure.database.session import get_db
 from app.models.athlete import AthleteSettingsRequest, AthleteSettingsResponse
@@ -63,7 +63,7 @@ async def _build_settings_response(
 @router.get("/settings", response_model=AthleteSettingsResponse)
 async def get_settings(
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> AthleteSettingsResponse:
     """Gibt aktuelle Athleten-Einstellungen zurück."""
     athlete = await _get_or_create_athlete(db, current_user.id)
@@ -74,7 +74,7 @@ async def get_settings(
 async def update_settings(
     body: AthleteSettingsRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> AthleteSettingsResponse:
     """Aktualisiert Athleten-Einstellungen (Ruhe-HR, Max-HR)."""
     athlete = await _get_or_create_athlete(db, current_user.id)

--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -1,4 +1,4 @@
-"""Auth-Router: Apple Sign-In, Token-Refresh, Status, Logout."""
+"""Auth-Router: Apple Sign-In, E-Mail/Passwort, Token-Refresh, Status, Logout."""
 
 import logging
 from datetime import datetime, timezone
@@ -13,20 +13,29 @@ from app.core.dependencies import get_current_user
 from app.core.security import (
     create_access_token,
     create_refresh_token,
+    hash_password,
     hash_token,
     refresh_token_expires_at,
+    verify_password,
 )
 from app.infrastructure.database.models import RefreshTokenModel, UserModel
 from app.infrastructure.database.session import get_db
 from app.models.auth import (
     AppleAuthRequest,
     AuthStatusResponse,
+    LoginRequest,
     RefreshRequest,
+    RegisterRequest,
     TokenResponse,
     UserResponse,
 )
 from app.services.apple_auth_service import validate_apple_id_token
-from app.services.user_service import find_or_create_user_by_apple
+from app.services.user_service import (
+    _count_real_users,
+    create_user_with_password,
+    find_or_create_user_by_apple,
+    find_user_by_email,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -136,6 +145,63 @@ async def apple_callback(
     return RedirectResponse(url=redirect_url, status_code=303)
 
 
+@router.post("/register", response_model=TokenResponse)
+async def register(
+    body: RegisterRequest,
+    db: AsyncSession = Depends(get_db),
+) -> TokenResponse:
+    """Registriert einen neuen User mit E-Mail und Passwort."""
+    existing = await find_user_by_email(db, body.email)
+    if existing is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="E-Mail-Adresse bereits registriert",
+        )
+
+    is_first = await _count_real_users(db) == 0
+    role = "admin" if is_first else "pending"
+
+    user = await create_user_with_password(
+        db,
+        email=body.email,
+        password_hash=hash_password(body.password),
+        name=body.name,
+        role=role,
+    )
+    return await _create_token_pair(db, user.id)
+
+
+@router.post("/login", response_model=TokenResponse)
+async def login(
+    body: LoginRequest,
+    db: AsyncSession = Depends(get_db),
+) -> TokenResponse:
+    """Authentifiziert einen User mit E-Mail und Passwort."""
+    user = await find_user_by_email(db, body.email)
+    if user is None or user.password_hash is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Ungültige E-Mail oder Passwort",
+        )
+
+    if not verify_password(body.password, user.password_hash):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Ungültige E-Mail oder Passwort",
+        )
+
+    if not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Konto deaktiviert",
+        )
+
+    user.last_login_at = datetime.utcnow()
+    await db.commit()
+
+    return await _create_token_pair(db, user.id)
+
+
 @router.get("/status", response_model=AuthStatusResponse)
 async def auth_status(request: Request) -> AuthStatusResponse:
     """Gibt den Auth-Status zurueck (fuer App-Initialisierung)."""
@@ -149,6 +215,7 @@ async def auth_status(request: Request) -> AuthStatusResponse:
         redirect_uri=f"{scheme}://{host}/api/v1/auth/apple/callback"
         if settings.auth_enabled
         else None,
+        email_auth_enabled=True,
     )
 
 

--- a/backend/app/api/v1/exercise_library.py
+++ b/backend/app/api/v1/exercise_library.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.dependencies import get_current_user
+from app.core.dependencies import get_current_active_user
 from app.infrastructure.database.models import ExerciseModel, UserModel
 from app.infrastructure.database.session import get_db
 from app.models.exercise_library import (
@@ -546,7 +546,7 @@ async def list_exercises(
     search: Optional[str] = Query(None, description="Suche nach Name"),
     favorites_only: bool = Query(False, description="Nur Favoriten"),
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> ExerciseListResponse:
     """Liste aller Übungen mit Filtern."""
     await _ensure_seed_data(db)
@@ -587,7 +587,7 @@ async def search_exercise_db(
     equipment: Optional[str] = Query(None, description="Filter nach Equipment"),
     limit: int = Query(50, ge=1, le=100),
     offset: int = Query(0, ge=0),
-    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+    current_user: UserModel = Depends(get_current_active_user),  # noqa: ARG001 — ensures auth
 ) -> ExerciseDbSearchResponse:
     """Durchsucht die free-exercise-db (873 Übungen).
 
@@ -652,7 +652,7 @@ async def search_exercise_db(
 async def get_exercise(
     exercise_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> ExerciseResponse:
     """Einzelne Übung mit allen Details."""
     result = await db.execute(
@@ -672,7 +672,7 @@ async def get_exercise(
 async def create_exercise(
     body: ExerciseCreate,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> ExerciseResponse:
     """Erstellt eine neue benutzerdefinierte Übung."""
     if body.category not in VALID_CATEGORIES:
@@ -717,7 +717,7 @@ async def update_exercise(
     exercise_id: int,
     body: ExerciseUpdate,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+    current_user: UserModel = Depends(get_current_active_user),  # noqa: ARG001 — ensures auth
 ) -> ExerciseResponse:
     """Aktualisiert eine Übung (Name, Kategorie, Favorit, Anleitung, Muskeln)."""
     result = await db.execute(
@@ -781,7 +781,7 @@ async def update_exercise(
 async def toggle_favorite(
     exercise_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+    current_user: UserModel = Depends(get_current_active_user),  # noqa: ARG001 — ensures auth
 ) -> ExerciseResponse:
     """Togglet den Favoriten-Status einer Übung."""
     result = await db.execute(
@@ -805,7 +805,7 @@ async def toggle_favorite(
 async def delete_exercise(
     exercise_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+    current_user: UserModel = Depends(get_current_active_user),  # noqa: ARG001 — ensures auth
 ) -> None:
     """Löscht eine Übung aus der Bibliothek.
 
@@ -834,7 +834,7 @@ async def delete_exercise(
 async def enrich_all_exercises(
     force: bool = False,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+    current_user: UserModel = Depends(get_current_active_user),  # noqa: ARG001 — ensures auth
 ) -> dict:
     """Reichert alle unangereicherten Übungen per KI an.
 
@@ -893,7 +893,7 @@ async def enrich_exercise(
     exercise_id: int,
     body: Optional[EnrichRequest] = None,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+    current_user: UserModel = Depends(get_current_active_user),  # noqa: ARG001 — ensures auth
 ) -> ExerciseResponse:
     """Reichert eine Übung mit free-exercise-db Daten an.
 
@@ -948,7 +948,7 @@ async def upload_exercise_images(
     image_0: UploadFile = File(..., description="Startposition (Pflicht)"),
     image_1: UploadFile | None = File(None, description="Endposition (Optional)"),
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+    current_user: UserModel = Depends(get_current_active_user),  # noqa: ARG001 — ensures auth
 ) -> ExerciseResponse:
     """Lädt Bilder für eine Custom-Übung hoch (Start- und optional Endposition)."""
     result = await db.execute(
@@ -997,7 +997,7 @@ async def upload_exercise_images(
 async def delete_exercise_images(
     exercise_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+    current_user: UserModel = Depends(get_current_active_user),  # noqa: ARG001 — ensures auth
 ) -> None:
     """Löscht alle hochgeladenen Bilder einer Custom-Übung."""
     result = await db.execute(

--- a/backend/app/api/v1/goals.py
+++ b/backend/app/api/v1/goals.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.dependencies import get_current_user
+from app.core.dependencies import get_current_active_user
 from app.infrastructure.database.models import (
     RaceGoalModel,
     TrainingPlanModel,
@@ -63,7 +63,7 @@ async def _goal_to_response(
 @router.get("", response_model=RaceGoalListResponse)
 async def list_goals(
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> RaceGoalListResponse:
     """Liste aller Wettkampf-Ziele (aktive zuerst, dann nach Datum)."""
     query = (
@@ -85,7 +85,7 @@ async def list_goals(
 async def create_goal(
     body: RaceGoalCreate,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> RaceGoalResponse:
     """Erstellt ein neues Wettkampf-Ziel."""
     goal = RaceGoalModel(
@@ -106,7 +106,7 @@ async def create_goal(
 async def get_goal(
     goal_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> RaceGoalResponse:
     """Einzelnes Wettkampf-Ziel."""
     query = select(RaceGoalModel).where(
@@ -124,7 +124,7 @@ async def update_goal(
     goal_id: int,
     body: RaceGoalUpdate,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> RaceGoalResponse:
     """Aktualisiert ein Wettkampf-Ziel."""
     query = select(RaceGoalModel).where(
@@ -155,7 +155,7 @@ async def update_goal(
 async def delete_goal(
     goal_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> None:
     """Loescht ein Wettkampf-Ziel."""
     query = select(RaceGoalModel).where(
@@ -198,7 +198,7 @@ def _format_time_seconds(total_sec: int) -> str:
 async def get_goal_progress(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refactoring
     goal_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> GoalProgressResponse:
     """Berechnet den Fortschritt in Richtung eines Wettkampf-Ziels.
 

--- a/backend/app/api/v1/pacing.py
+++ b/backend/app/api/v1/pacing.py
@@ -12,7 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
-from app.core.dependencies import get_current_user
+from app.core.dependencies import get_current_active_user
 from app.infrastructure.database.models import (
     PacingStrategyModel,
     PlannedSessionModel,
@@ -57,7 +57,7 @@ _weather_client = ExternalAPIClient(
 async def generate_pacing(
     body: PacingRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> PacingResponse:
     """Generiert eine Pacing-Strategie basierend auf Zielzeit, Hoehenprofil und Wetter."""
     # Wenn goal_id angegeben: Distanz und Zielzeit aus dem Goal laden
@@ -183,7 +183,7 @@ async def parse_gpx(file: UploadFile) -> list[ElevationSegment]:
 async def export_pacing_fit(
     body: PacingRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> Response:
     """Exportiert eine Pacing-Strategie als FIT-Workout-Datei fuer GPS-Uhren."""
     # Goal-ID Aufloesung (wie bei /generate)
@@ -227,7 +227,7 @@ async def export_pacing_fit(
 async def transfer_pacing_to_weekly_plan(
     body: PacingToWeeklyPlanRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> PacingToWeeklyPlanResponse:
     """Uebernimmt eine Pacing-Strategie als Wettkampf-Session in den Wochenplan."""
     # 1) Goal laden → race_date
@@ -412,7 +412,7 @@ def _db_to_response(model: PacingStrategyModel) -> SavedPacingStrategyResponse:
 async def list_pacing_strategies(
     goal_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> SavedPacingStrategyListResponse:
     """Listet alle gespeicherten Pacing-Strategien fuer ein Ziel."""
     result = await db.execute(
@@ -435,7 +435,7 @@ async def get_pacing_strategy(
     goal_id: int,
     strategy_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> SavedPacingStrategyResponse:
     """Gibt eine einzelne gespeicherte Pacing-Strategie zurueck."""
     result = await db.execute(
@@ -456,7 +456,7 @@ async def delete_pacing_strategy(
     goal_id: int,
     strategy_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> None:
     """Loescht eine gespeicherte Pacing-Strategie."""
     result = await db.execute(

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 
 from app.api.v1 import (
+    admin,
     ai,
     ai_log,
     athlete,
@@ -26,6 +27,7 @@ from app.api.v1 import (
 
 api_router = APIRouter()
 api_router.include_router(auth.router, tags=["auth"])
+api_router.include_router(admin.router, tags=["admin"])
 api_router.include_router(health.router, tags=["health"])
 api_router.include_router(workouts.router, tags=["workouts"])
 # strength MUST come before sessions — /sessions/strength must match before /{session_id}

--- a/backend/app/api/v1/session_templates.py
+++ b/backend/app/api/v1/session_templates.py
@@ -10,7 +10,7 @@ from fastapi.responses import Response
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.dependencies import get_current_user
+from app.core.dependencies import get_current_active_user
 from app.infrastructure.database.models import SessionTemplateModel, UserModel, WorkoutModel
 from app.infrastructure.database.session import get_db
 from app.models.session_template import (
@@ -85,7 +85,7 @@ def _model_to_summary(tmpl: SessionTemplateModel) -> SessionTemplateSummary:
 async def list_templates(
     session_type: Optional[str] = None,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> SessionTemplateListResponse:
     """List all session templates."""
     query = (
@@ -116,7 +116,7 @@ async def list_templates(
 async def get_template(
     template_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> SessionTemplateResponse:
     """Get a session template with exercises."""
     result = await db.execute(
@@ -135,7 +135,7 @@ async def get_template(
 async def create_template(
     data: SessionTemplateCreate,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> SessionTemplateResponse:
     """Create a new session template."""
     if data.session_type == "strength" and not data.exercises:
@@ -177,7 +177,7 @@ async def update_template(
     template_id: int,
     data: SessionTemplateUpdate,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> SessionTemplateResponse:
     """Update a session template."""
     result = await db.execute(
@@ -208,7 +208,7 @@ async def update_template(
 async def delete_template(
     template_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> None:
     """Delete a session template."""
     result = await db.execute(
@@ -229,7 +229,7 @@ async def delete_template(
 async def duplicate_template(
     template_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> SessionTemplateResponse:
     """Duplicate a session template."""
     result = await db.execute(
@@ -261,7 +261,7 @@ async def duplicate_template(
 async def export_template_fit(
     template_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> Response:
     """Export eines Lauf-Templates als FIT-Workout-Datei fuer HealthFit/Garmin."""
     result = await db.execute(
@@ -340,7 +340,7 @@ def _classify_run_type(
 async def create_from_session(
     session_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> SessionTemplateResponse:
     """Create a template from an existing session."""
     result = await db.execute(

--- a/backend/app/api/v1/sessions.py
+++ b/backend/app/api/v1/sessions.py
@@ -21,7 +21,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
-from app.core.dependencies import get_current_user
+from app.core.dependencies import get_current_active_user
 from app.infrastructure.database.models import (
     AthleteModel,
     PlannedSessionModel,
@@ -416,7 +416,7 @@ async def parse_csv(
     training_subtype: Optional[TrainingSubType] = Form(None, description="Unter-Typ"),
     notes: Optional[str] = Form(None, description="Notizen"),  # noqa: ARG001
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+    current_user: UserModel = Depends(get_current_active_user),  # noqa: ARG001 — ensures auth
 ) -> SessionParseResponse:
     """Parse CSV und klassifiziere — ohne Session zu erstellen."""
     content = await _validate_upload_file(csv_file, ".csv", "CSV")
@@ -431,7 +431,7 @@ async def parse_fit(
     training_subtype: Optional[TrainingSubType] = Form(None, description="Unter-Typ"),
     notes: Optional[str] = Form(None, description="Notizen"),  # noqa: ARG001
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+    current_user: UserModel = Depends(get_current_active_user),  # noqa: ARG001 — ensures auth
 ) -> SessionParseResponse:
     """Parse FIT file und klassifiziere — ohne Session zu erstellen."""
     content = await _validate_upload_file(fit_file, ".fit", "FIT")
@@ -444,7 +444,7 @@ async def upload_csv(
     form: SessionUploadForm = Depends(),
     background_tasks: BackgroundTasks = BackgroundTasks(),
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> SessionUploadResponse:
     """Upload Apple Watch CSV und speichere als Session."""
     content = await _validate_upload_file(csv_file, ".csv", "CSV")
@@ -467,7 +467,7 @@ async def upload_fit(
     form: SessionUploadForm = Depends(),
     background_tasks: BackgroundTasks = BackgroundTasks(),
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> SessionUploadResponse:
     """Upload FIT file und speichere als Session."""
     content = await _validate_upload_file(fit_file, ".fit", "FIT")
@@ -493,7 +493,7 @@ async def list_sessions(  # noqa: PLR0913
     date_to: Optional[date] = Query(None, description="Datum bis (inklusiv)"),
     search: Optional[str] = Query(None, description="Freitext-Suche (Notizen)"),
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> SessionListResponse:
     """Liste aller Sessions mit Paginierung und Filtern."""
     from app.models.session import SessionListItem
@@ -545,7 +545,7 @@ async def list_sessions(  # noqa: PLR0913
 async def get_session(
     session_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> SessionResponse:
     """Einzelne Session mit allen Details."""
     query = select(WorkoutModel).where(
@@ -564,7 +564,7 @@ async def get_session(
 async def get_session_track(
     session_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> dict:
     """GPS Track einer Session (separater Endpoint fuer Performance)."""
     query = select(WorkoutModel).where(
@@ -600,7 +600,7 @@ async def _get_athlete_elevation_factors(
 async def get_km_splits(
     session_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> dict:
     """Per-Kilometer Splits berechnet aus GPS Track."""
     query = select(WorkoutModel).where(
@@ -636,7 +636,7 @@ async def get_km_splits(
 async def get_working_zones(
     session_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> dict:
     """Berechnet Working-Laps HR-Zonen (ohne DB-Schreibzugriff)."""
     query = select(WorkoutModel).where(
@@ -669,7 +669,7 @@ async def get_working_zones(
 async def get_session_comparison(
     session_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> ComparisonResponse:
     """Soll/Ist-Vergleich: matcht geplante Segmente mit tatsächlichen Laps."""
     query = select(WorkoutModel).where(
@@ -732,7 +732,7 @@ async def update_lap_overrides(
     session_id: int,
     body: LapOverrideRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> LapOverrideResponse:
     """Aktualisiert Lap-Type Overrides und berechnet Working-Laps Metriken."""
     query = select(WorkoutModel).where(
@@ -789,7 +789,7 @@ async def update_training_type(
     session_id: int,
     body: TrainingTypeOverrideRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> SessionResponse:
     """Setzt manuellen Training Type Override."""
     if body.training_type not in VALID_TRAINING_TYPES:
@@ -819,7 +819,7 @@ async def update_notes(
     session_id: int,
     body: NotesUpdateRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> SessionResponse:
     """Aktualisiert die Notizen einer Session."""
     query = select(WorkoutModel).where(
@@ -843,7 +843,7 @@ async def update_rpe(
     session_id: int,
     body: RpeUpdateRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> SessionResponse:
     """Aktualisiert die RPE einer Session."""
     query = select(WorkoutModel).where(
@@ -867,7 +867,7 @@ async def update_date(
     session_id: int,
     body: DateUpdateRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> SessionResponse:
     """Aktualisiert das Datum einer Session."""
     query = select(WorkoutModel).where(
@@ -891,7 +891,7 @@ async def update_planned_entry(
     session_id: int,
     body: PlannedEntryUpdateRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> SessionResponse:
     """Aktualisiert die Zuordnung zu einer geplanten Session."""
     query = select(WorkoutModel).where(
@@ -923,7 +923,7 @@ async def update_planned_entry(
 async def delete_session(
     session_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> None:
     """Loescht eine Session."""
     query = select(WorkoutModel).where(
@@ -944,7 +944,7 @@ async def analyze_session(
     session_id: int,
     body: Optional[AnalyzeRequest] = None,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+    current_user: UserModel = Depends(get_current_active_user),  # noqa: ARG001 — ensures auth
 ) -> SessionAnalysisResponse:
     """KI-gestützte Analyse einer Session (Cache-First)."""
     from app.services.session_analysis_service import (
@@ -968,7 +968,7 @@ async def generate_recommendations(
     session_id: int,
     body: Optional[AnalyzeRequest] = None,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+    current_user: UserModel = Depends(get_current_active_user),  # noqa: ARG001 — ensures auth
 ) -> RecommendationsListResponse:
     """Generiert KI-gestuetzte Trainingsempfehlungen basierend auf Session-Analyse."""
     from app.services.recommendation_service import (
@@ -990,7 +990,7 @@ async def generate_recommendations(
 async def get_session_recommendations(
     session_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+    current_user: UserModel = Depends(get_current_active_user),  # noqa: ARG001 — ensures auth
 ) -> RecommendationsListResponse:
     """Laedt gespeicherte Empfehlungen fuer eine Session."""
     from app.services.recommendation_service import get_recommendations
@@ -1003,7 +1003,7 @@ async def update_recommendation_status(
     recommendation_id: int,
     body: RecommendationStatusUpdate,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+    current_user: UserModel = Depends(get_current_active_user),  # noqa: ARG001 — ensures auth
 ) -> RecommendationResponse:
     """Aktualisiert den Status einer Empfehlung (applied/dismissed)."""
     from app.services.recommendation_service import (
@@ -1021,7 +1021,7 @@ async def recalculate_session_zones(
     session_id: int,
     body: Optional[RecalculateZonesRequest] = None,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> dict:
     """Berechnet HR-Zonen einer einzelnen Session neu.
 
@@ -1340,7 +1340,7 @@ def _extract_working_hr_from_timeseries(
 async def reparse_session(
     session_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> dict:
     """Parst eine Session neu aus der gespeicherten Originaldatei.
 
@@ -1367,7 +1367,7 @@ async def reparse_session(
 @router.post("/reparse-all")
 async def reparse_all_sessions(
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> dict:
     """Parst alle Sessions mit gespeicherter Originaldatei neu.
 
@@ -1524,7 +1524,7 @@ async def _reparse_workout(
 async def export_session_fit(
     session_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> Response:
     """Export einer Lauf-Session als FIT-Workout-Datei.
 
@@ -1596,7 +1596,7 @@ async def enrich_session(
     session_id: int,
     background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> dict:
     """Enrichment fuer eine einzelne Session triggern."""
     query = select(WorkoutModel).where(
@@ -1622,7 +1622,7 @@ async def enrich_session(
 async def enrich_batch(
     background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> dict:
     """Batch-Enrichment fuer alle pending Sessions triggern."""
     count_result = await db.execute(
@@ -1652,7 +1652,7 @@ async def enrich_batch(
 async def get_race_report(
     session_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+    current_user: UserModel = Depends(get_current_active_user),  # noqa: ARG001 — ensures auth
 ) -> dict:
     """Generiert Post-Race Analyse fuer eine Wettkampf-Session."""
     from app.services.race_report_service import generate_race_report
@@ -1666,7 +1666,7 @@ async def update_race_goal(
     session_id: int,
     body: dict,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> dict:
     """Verknuepft oder entknuepft eine Session mit einem Race Goal."""
     result = await db.execute(
@@ -1689,7 +1689,7 @@ async def update_race_goal(
 async def analyze_race(
     session_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+    current_user: UserModel = Depends(get_current_active_user),  # noqa: ARG001 — ensures auth
 ) -> dict:
     """KI-Analyse speziell fuer Wettkampf-Sessions."""
     from app.services.race_report_service import generate_race_report

--- a/backend/app/api/v1/streak.py
+++ b/backend/app/api/v1/streak.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.dependencies import get_current_user
+from app.core.dependencies import get_current_active_user
 from app.infrastructure.database.models import UserModel, WorkoutModel
 from app.infrastructure.database.session import get_db
 from app.models.streak import StreakResponse
@@ -17,7 +17,7 @@ router = APIRouter(prefix="/streak", tags=["analytics"])
 @router.get("", response_model=StreakResponse)
 async def get_streak(
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> StreakResponse:
     """Get training streak statistics with 90-day calendar heatmap."""
     today = date.today()

--- a/backend/app/api/v1/strength.py
+++ b/backend/app/api/v1/strength.py
@@ -9,7 +9,7 @@ from pydantic import TypeAdapter
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.dependencies import get_current_user
+from app.core.dependencies import get_current_active_user
 from app.infrastructure.database.models import UserModel, WorkoutModel
 from app.infrastructure.database.session import get_db
 from app.models.strength import (
@@ -103,7 +103,7 @@ async def create_strength_session(  # noqa: PLR0913
         None, description="Manuelle Zuordnung zu geplanter Session"
     ),
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> dict:
     """Erstellt eine neue Krafttraining-Session.
 
@@ -215,7 +215,7 @@ async def update_strength_exercises(
     session_id: int,
     exercises_json: str = Form(..., description="JSON-Array der Übungen"),
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> dict:
     """Aktualisiert die Übungen einer bestehenden Krafttraining-Session."""
     from pydantic import ValidationError
@@ -276,7 +276,7 @@ async def update_strength_exercises(
 @router.get("/last-complete")
 async def get_last_complete_session(
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> dict:
     """Gibt die letzte vollstaendige Strength-Session zurueck (fuer Clone + Tonnage-Delta)."""
     query = (
@@ -316,7 +316,7 @@ async def get_last_complete_session(
 async def get_last_exercises(
     exercise_name: str = Query(..., min_length=1, description="Name der Übung"),
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> dict:
     """Gibt die letzten Sätze einer Übung zurück (Quick-Add)."""
     query = (
@@ -390,7 +390,7 @@ async def _load_strength_sessions(db: AsyncSession, user_id: int | None = None) 
 @router.get("/exercises")
 async def list_exercises(
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> dict:
     """Liste aller verwendeten Übungen mit Metadaten."""
     from app.services.progression_tracker import get_all_exercise_names
@@ -404,7 +404,7 @@ async def list_exercises(
 async def get_exercise_progression(
     exercise_name: str = Query(..., min_length=1, description="Name der Übung"),
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> dict:
     """Progressionsverlauf einer Übung über die Zeit (typ-differenziert)."""
     from app.services.progression_tracker import get_exercise_history
@@ -476,7 +476,7 @@ async def get_exercise_progression(
 async def get_personal_records(
     session_id: Optional[int] = Query(None, description="Nur PRs dieser Session"),
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> dict:
     """Persönliche Bestleistungen (PRs) pro Übung."""
     from app.services.progression_tracker import detect_personal_records
@@ -495,7 +495,7 @@ async def get_personal_records(
 async def get_tonnage_trend(
     days: int = Query(default=90, ge=7, le=365, description="Zeitraum in Tagen"),
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> dict:
     """Woechentlicher Tonnage-Trend fuer Krafttraining."""
     from app.services.progression_tracker import calculate_weekly_tonnage
@@ -559,7 +559,7 @@ async def get_tonnage_trend(
 async def get_category_tonnage_trend(
     days: int = Query(default=90, ge=7, le=365, description="Zeitraum in Tagen"),
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> dict:
     """Woechentliche Tonnage nach Kategorie (push/pull/legs/core/...)."""
     from app.services.progression_tracker import calculate_weekly_category_tonnage

--- a/backend/app/api/v1/threshold_tests.py
+++ b/backend/app/api/v1/threshold_tests.py
@@ -10,7 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.v1.athlete import _get_or_create_athlete
-from app.core.dependencies import get_current_user
+from app.core.dependencies import get_current_active_user
 from app.infrastructure.database.models import ThresholdTestModel, UserModel, WorkoutModel
 from app.infrastructure.database.session import get_db
 from app.models.threshold_test import (
@@ -39,7 +39,7 @@ def _build_response(test: ThresholdTestModel) -> ThresholdTestResponse:
 @router.get("", response_model=ThresholdTestListResponse)
 async def list_tests(
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> ThresholdTestListResponse:
     """Gibt alle Schwellentests zurück (neueste zuerst)."""
     result = await db.execute(
@@ -57,7 +57,7 @@ async def list_tests(
 @router.get("/latest", response_model=ThresholdTestResponse)
 async def get_latest_test(
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> ThresholdTestResponse:
     """Gibt den neuesten Schwellentest zurück."""
     result = await db.execute(
@@ -76,7 +76,7 @@ async def get_latest_test(
 async def create_test(
     body: ThresholdTestCreate,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> ThresholdTestResponse:
     """Erstellt einen neuen Schwellentest und aktualisiert das Athletenprofil."""
     test = ThresholdTestModel(
@@ -105,7 +105,7 @@ async def create_test(
 async def analyze_session(
     session_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> ThresholdAnalysisResponse:
     """Berechnet LTHR aus einer Session (Ø HR der letzten 20 Min).
 
@@ -191,7 +191,7 @@ def _extract_avg_pace(workout: WorkoutModel) -> float | None:
 async def delete_test(
     test_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> None:
     """Löscht einen Schwellentest."""
     result = await db.execute(

--- a/backend/app/api/v1/training_balance.py
+++ b/backend/app/api/v1/training_balance.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.dependencies import get_current_user
+from app.core.dependencies import get_current_active_user
 from app.infrastructure.database.models import UserModel, WorkoutModel
 from app.infrastructure.database.session import get_db
 from app.models.training_balance import (
@@ -43,7 +43,7 @@ CATEGORY_TO_MUSCLE = {
 async def get_training_balance(
     days: int = Query(default=28, ge=7, le=365),
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> TrainingBalanceResponse:
     """Analyse the training balance over a given period."""
     cutoff = datetime.utcnow() - timedelta(days=days)

--- a/backend/app/api/v1/training_plans.py
+++ b/backend/app/api/v1/training_plans.py
@@ -14,7 +14,7 @@ from pydantic import ValidationError
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.dependencies import get_current_user
+from app.core.dependencies import get_current_active_user
 from app.infrastructure.database.models import (
     ExerciseModel,
     PlanChangeLogModel,
@@ -352,7 +352,7 @@ def _changelog_to_response(entry: PlanChangeLogModel) -> PlanChangeLogEntry:
 async def list_plans(
     status: Optional[str] = None,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> TrainingPlanListResponse:
     """List all training plans, optionally filtered by status."""
     query = (
@@ -381,7 +381,7 @@ async def list_plans(
 async def create_plan(
     data: TrainingPlanCreate,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> TrainingPlanResponse:
     """Create a new training plan with optional phases and auto-create goal."""
     if data.end_date <= data.start_date:
@@ -813,7 +813,7 @@ async def get_template_yaml() -> FileResponse:
 async def validate_yaml_endpoint(
     yaml_file: UploadFile = File(..., description="YAML-Trainingsplan (.yaml/.yml)"),
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+    current_user: UserModel = Depends(get_current_active_user),  # noqa: ARG001 — ensures auth
 ) -> YamlValidationResult:
     """Validate a YAML training plan file and return structured errors/warnings."""
     if not yaml_file.filename or not yaml_file.filename.lower().endswith((".yaml", ".yml")):
@@ -888,7 +888,7 @@ async def import_plan_from_yaml(
         description='JSON mapping {"OldName": "ExistingName"} for exercise name substitutions',
     ),
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> TrainingPlanResponse:
     """Import a training plan from a YAML file."""
     if not yaml_file.filename or not yaml_file.filename.lower().endswith((".yaml", ".yml")):
@@ -987,7 +987,7 @@ async def import_plan_from_yaml(
 async def get_generation_preview(
     plan_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> GenerationPreviewResponse:
     """Preview what re-generation would affect: count edited vs unedited weeks."""
     result = await db.execute(
@@ -1183,7 +1183,7 @@ async def generate_plan_weeks(
     plan_id: int,
     strategy: str = "all",
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> GenerateWeeklyPlansResponse:
     """Generate weekly plans from a training plan's phases.
 
@@ -1238,7 +1238,7 @@ async def generate_plan_weeks(
 async def get_plan(
     plan_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> TrainingPlanResponse:
     """Get a training plan with its phases and goal summary."""
     result = await db.execute(
@@ -1258,7 +1258,7 @@ async def update_plan(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refactoring
     plan_id: int,
     data: TrainingPlanUpdate,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> TrainingPlanResponse:
     """Update a training plan."""
     result = await db.execute(
@@ -1435,7 +1435,7 @@ async def delete_plan(
     plan_id: int,
     include_weekly_plans: bool = False,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> None:
     """Delete a training plan and cascade-delete its phases.
 
@@ -1516,7 +1516,7 @@ async def delete_plan(
 async def list_phases(
     plan_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> list[TrainingPhaseResponse]:
     """List all phases of a training plan."""
     # Verify plan exists and belongs to user
@@ -1546,7 +1546,7 @@ async def create_phase(
     plan_id: int,
     data: TrainingPhaseCreate,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> TrainingPhaseResponse:
     """Add a phase to a training plan."""
     plan_result = await db.execute(
@@ -1594,7 +1594,7 @@ async def update_phase(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refactoring
     phase_id: int,
     data: TrainingPhaseUpdate,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> TrainingPhaseResponse:
     """Update a phase in a training plan."""
     # Verify plan belongs to user
@@ -1798,7 +1798,7 @@ async def delete_phase(
     plan_id: int,
     phase_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> None:
     """Delete a phase from a training plan."""
     # Verify plan belongs to user
@@ -1847,7 +1847,7 @@ async def get_changelog(
     offset: int = 0,
     category: Optional[str] = None,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> PlanChangeLogResponse:
     """Get the change log for a training plan (paginated, newest first)."""
     # Verify plan exists and belongs to user
@@ -1891,7 +1891,7 @@ async def update_changelog_reason(
     log_id: int,
     data: PlanChangeLogReasonUpdate,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> PlanChangeLogEntry:
     """Set or update the reason on a changelog entry."""
     # Verify plan belongs to user

--- a/backend/app/api/v1/training_routes.py
+++ b/backend/app/api/v1/training_routes.py
@@ -8,7 +8,7 @@ from fastapi.responses import Response
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.dependencies import get_current_user
+from app.core.dependencies import get_current_active_user
 from app.infrastructure.database.models import (
     SessionTemplateModel,
     TrainingRouteModel,
@@ -137,7 +137,7 @@ def _model_to_summary(route: TrainingRouteModel) -> TrainingRouteSummary:
 async def create_route(
     data: TrainingRouteCreate,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> TrainingRouteResponse:
     """Neue Trainingsroute erstellen."""
     # FK-Validierung
@@ -185,7 +185,7 @@ async def list_routes(
     tag: Optional[str] = None,
     search: Optional[str] = None,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> TrainingRouteListResponse:
     """Alle Trainingsrouten auflisten (ohne Waypoints)."""
     query = (
@@ -236,7 +236,7 @@ async def create_route_from_session(
     session_id: int,
     name: Optional[str] = None,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> TrainingRouteResponse:
     """Route aus einer bestehenden Session mit GPS-Daten erstellen."""
     result = await db.execute(
@@ -283,7 +283,7 @@ async def route_from_template(
     template_id: int,
     data: RouteFromTemplateRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> RouteFromTemplatePreview:
     """Route-Vorschau aus Session Template generieren (#571).
 
@@ -342,7 +342,7 @@ async def route_from_template(
 @router.post("/snap", response_model=RouteSnapResponse)
 async def snap_route(
     data: RouteSnapRequest,
-    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+    current_user: UserModel = Depends(get_current_active_user),  # noqa: ARG001 — ensures auth
 ) -> RouteSnapResponse:
     """Waypoints auf Wege snappen via OSRM."""
     osrm = OSRMClient()
@@ -368,7 +368,7 @@ async def snap_route(
 @router.post("/generate-round-trip", response_model=RoundTripResponse)
 async def generate_round_trip(
     data: RoundTripRequest,
-    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+    current_user: UserModel = Depends(get_current_active_user),  # noqa: ARG001 — ensures auth
 ) -> RoundTripResponse:
     """Rundkurs-Vorschläge generieren ab Startpunkt."""
     osrm = OSRMClient()
@@ -404,7 +404,7 @@ async def generate_round_trip(
 async def get_route(
     route_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> TrainingRouteResponse:
     """Einzelne Route mit allen Details abrufen."""
     result = await db.execute(
@@ -424,7 +424,7 @@ async def update_route(
     route_id: int,
     data: TrainingRouteUpdate,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> TrainingRouteResponse:
     """Route teilweise aktualisieren."""
     result = await db.execute(
@@ -465,7 +465,7 @@ async def calculate_pacing(
     route_id: int,
     data: RoutePacingRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> RoutePacingResponse:
     """Pacing-Ziele für alle Segmente einer Route berechnen (#548).
 
@@ -505,7 +505,7 @@ async def calculate_pacing(
 async def export_route_gpx(
     route_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> Response:
     """Route als GPX-Datei mit Training-Extensions exportieren (#553).
 
@@ -552,7 +552,7 @@ async def export_route_gpx(
 async def export_route_fit(
     route_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> Response:
     """Route als FIT Course File exportieren (#577).
 
@@ -593,7 +593,7 @@ async def export_route_fit(
 async def delete_route(
     route_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> None:
     """Route löschen."""
     result = await db.execute(

--- a/backend/app/api/v1/trends.py
+++ b/backend/app/api/v1/trends.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.dependencies import get_current_user
+from app.core.dependencies import get_current_active_user
 from app.infrastructure.database.models import UserModel, WorkoutModel
 from app.infrastructure.database.session import get_db
 from app.models.trend import TrendInsight, TrendResponse, WeeklyDataPoint
@@ -29,7 +29,7 @@ def _parse_pace_to_seconds(pace_str: str) -> float:
 async def get_trends(
     days: int = Query(default=28, ge=7, le=365),
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> TrendResponse:
     """Aggregierte Trainingsdaten fuer Trend-Analyse.
 
@@ -227,7 +227,7 @@ class WeatherCorrelationResponse(BaseModel):
 async def get_weather_correlation(
     days: int = Query(default=90, ge=14, le=365),
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> WeatherCorrelationResponse:
     """Korrelation zwischen Wetter und Laufleistung."""
     cutoff = datetime.utcnow() - timedelta(days=days)

--- a/backend/app/api/v1/user_settings.py
+++ b/backend/app/api/v1/user_settings.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.dependencies import get_current_user
+from app.core.dependencies import get_current_active_user
 from app.core.encryption import encrypt_api_key
 from app.infrastructure.database.models import AthleteModel, UserModel
 from app.infrastructure.database.session import get_db
@@ -36,7 +36,7 @@ async def _get_or_create_athlete(db: AsyncSession, user_id: int) -> AthleteModel
 @router.get("/settings", response_model=UserSettingsResponse)
 async def get_user_settings(
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> UserSettingsResponse:
     """Gibt User-Settings mit maskierten API Keys zurück."""
     athlete = await _get_or_create_athlete(db, current_user.id)
@@ -47,7 +47,7 @@ async def get_user_settings(
 async def update_user_settings(
     body: UserSettingsRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> UserSettingsResponse:
     """Aktualisiert API Keys (verschlüsselt in DB).
 

--- a/backend/app/api/v1/weekly_plan.py
+++ b/backend/app/api/v1/weekly_plan.py
@@ -10,7 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.v1.training_plans import log_plan_change
-from app.core.dependencies import get_current_user
+from app.core.dependencies import get_current_active_user
 from app.infrastructure.database.models import (
     PlanChangeLogModel,
     PlannedSessionModel,
@@ -285,7 +285,7 @@ def _build_entry_from_db(
 async def get_weekly_plan(
     week_start: Optional[date] = None,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> WeeklyPlanResponse:
     """Get the weekly plan for a given week (defaults to current week)."""
     if week_start is None:
@@ -570,7 +570,7 @@ async def _auto_sync_week_to_plan(
 async def save_weekly_plan(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refactoring
     data: WeeklyPlanSaveRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> WeeklyPlanResponse:
     """Save/update the weekly plan. Upserts all provided day entries."""
     week_start = _monday_of_week(data.week_start)
@@ -717,7 +717,7 @@ async def save_weekly_plan(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refacto
 async def clear_weekly_plan(
     week_start: Optional[date] = None,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> dict[str, bool]:
     """Clear all entries for a given week."""
     if week_start is None:
@@ -804,7 +804,7 @@ def _determine_status(  # noqa: PLR0911  # TODO: E16 Refactoring
 async def get_compliance(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refactoring
     week_start: Optional[date] = None,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> ComplianceResponse:
     """Get compliance tracking for a given week (plan vs. actual sessions)."""
     if week_start is None:
@@ -1025,7 +1025,7 @@ async def get_compliance(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refactori
 async def get_sessions_for_date(
     target_date: date = Query(..., alias="date"),
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> list[PlannedSessionOption]:
     """Get planned sessions for a specific date (for upload linking)."""
     week_start = _monday_of_week(target_date)
@@ -1078,7 +1078,7 @@ async def get_sessions_for_date(
 async def sync_to_plan(  # noqa: C901, PLR0912, PLR0915  # TODO: E16 Refactoring
     data: SyncToPlanRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> SyncToPlanResponse:
     """Sync edited weekly plan entries back to training plan phase template."""
     week_start = _monday_of_week(data.week_start)
@@ -1279,7 +1279,7 @@ async def _find_undoable_entry(
 async def get_undo_status(
     week_start: date = Query(...),
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+    current_user: UserModel = Depends(get_current_active_user),  # noqa: ARG001 — ensures auth
 ) -> UndoStatusResponse:
     """Check if undo is available for a given week."""
     week_start = _monday_of_week(week_start)
@@ -1302,7 +1302,7 @@ async def get_undo_status(
 async def undo_weekly_plan(
     week_start: date = Query(...),
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> UndoResponse:
     """Undo the most recent change to a weekly plan (within 24h window)."""
     week_start = _monday_of_week(week_start)
@@ -1415,7 +1415,7 @@ async def undo_weekly_plan(
 async def apply_recommendations(
     data: ApplyRecommendationsRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),  # noqa: ARG001 — ensures auth
+    current_user: UserModel = Depends(get_current_active_user),  # noqa: ARG001 — ensures auth
 ) -> ApplyRecommendationsResponse:
     """Konvertiert KI-Review-Empfehlungen in Plan-Sessions für die Folgewoche."""
     from app.services.recommendation_to_plan_service import (
@@ -1440,7 +1440,7 @@ async def apply_recommendations(
 async def export_planned_session_fit(
     entry_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> Response:
     """Export eines geplanten Lauftrainings als FIT-Workout-Datei.
 

--- a/backend/app/api/v1/weekly_review.py
+++ b/backend/app/api/v1/weekly_review.py
@@ -5,7 +5,7 @@ from datetime import date
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.dependencies import get_current_user
+from app.core.dependencies import get_current_active_user
 from app.infrastructure.database.models import UserModel
 from app.infrastructure.database.session import get_db
 from app.models.weekly_review import WeeklyReviewGenerateRequest, WeeklyReviewResponse
@@ -18,7 +18,7 @@ router = APIRouter()
 async def generate_review(
     request: WeeklyReviewGenerateRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> WeeklyReviewResponse:
     """Generiert ein wöchentliches KI-Trainingsreview.
 
@@ -51,7 +51,7 @@ async def generate_review(
 async def get_review(
     week_start: str,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> WeeklyReviewResponse:
     """Lädt ein gespeichertes Wochen-Review.
 

--- a/backend/app/api/v1/workouts.py
+++ b/backend/app/api/v1/workouts.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.api_key_resolver import resolve_claude_api_key
-from app.core.dependencies import get_current_user
+from app.core.dependencies import get_current_active_user
 from app.infrastructure.ai.ai_service import ai_service
 from app.infrastructure.database.models import UserModel, WorkoutModel
 from app.infrastructure.database.session import get_db
@@ -24,7 +24,7 @@ router = APIRouter()
 async def upload_workout(
     csv_file: UploadFile = File(...),
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ):
     """
     Upload and analyze workout from CSV file
@@ -96,7 +96,7 @@ async def get_workouts(
     limit: int = 20,
     offset: int = 0,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ):
     """Get list of workouts"""
     from sqlalchemy import select
@@ -133,7 +133,7 @@ async def get_workouts(
 async def get_workout(
     workout_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_active_user),
 ):
     """Get single workout with AI analysis"""
     from sqlalchemy import select

--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -31,7 +31,9 @@ async def _ensure_default_user(db: AsyncSession) -> UserModel:
     result = await db.execute(select(UserModel).where(UserModel.email == DEFAULT_USER_EMAIL))
     user = result.scalar_one_or_none()
     if user is None:
-        user = UserModel(email=DEFAULT_USER_EMAIL, name="Lokaler Benutzer", is_active=True)
+        user = UserModel(
+            email=DEFAULT_USER_EMAIL, name="Lokaler Benutzer", is_active=True, role="user"
+        )
         db.add(user)
         await db.commit()
         await db.refresh(user)
@@ -80,6 +82,34 @@ async def get_current_user(
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Benutzer nicht gefunden oder deaktiviert",
+        )
+    return user
+
+
+async def get_current_active_user(
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+    db: AsyncSession = Depends(get_db),
+) -> UserModel:
+    """Wie get_current_user, aber lehnt pending-User mit 403 ab."""
+    user = await get_current_user(credentials, db)
+    if user.role == "pending":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Konto wartet auf Freischaltung",
+        )
+    return user
+
+
+async def get_current_admin(
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+    db: AsyncSession = Depends(get_db),
+) -> UserModel:
+    """Erfordert Admin-Rolle."""
+    user = await get_current_user(credentials, db)
+    if user.role != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin-Berechtigung erforderlich",
         )
     return user
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,12 +1,25 @@
-"""JWT-Utilities fuer Access- und Refresh-Tokens."""
+"""JWT-Utilities fuer Access- und Refresh-Tokens, Passwort-Hashing."""
 
 import hashlib
 import secrets
 from datetime import datetime, timedelta
 
 from jose import JWTError, jwt  # type: ignore[import-untyped]
+from passlib.context import CryptContext  # type: ignore[import-untyped]
 
 from app.core.config import settings
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def hash_password(password: str) -> str:
+    """Hasht ein Passwort mit bcrypt."""
+    return pwd_context.hash(password)
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Verifiziert ein Passwort gegen einen bcrypt-Hash."""
+    return pwd_context.verify(plain_password, hashed_password)  # type: ignore[no-any-return]
 
 
 def create_access_token(user_id: int) -> str:

--- a/backend/app/infrastructure/database/models.py
+++ b/backend/app/infrastructure/database/models.py
@@ -29,6 +29,8 @@ class UserModel(Base):
     apple_sub: Mapped[str | None] = mapped_column(String(255), unique=True, default=None)
     google_sub: Mapped[str | None] = mapped_column(String(255), unique=True, default=None)
     is_active: Mapped[bool] = mapped_column(default=True, server_default="true")
+    role: Mapped[str] = mapped_column(String(20), server_default="pending", default="pending")
+    password_hash: Mapped[str | None] = mapped_column(String(255), default=None)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
     last_login_at: Mapped[datetime | None] = mapped_column(DateTime, default=None)
 

--- a/backend/app/models/admin.py
+++ b/backend/app/models/admin.py
@@ -1,0 +1,28 @@
+"""Pydantic-Modelle fuer Admin User-Management."""
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class AdminUserResponse(BaseModel):
+    """User-Daten fuer die Admin-Ansicht."""
+
+    id: int
+    email: str
+    name: str | None
+    role: str
+    is_active: bool
+    has_password: bool
+    has_apple: bool
+    created_at: datetime
+    last_login_at: datetime | None
+
+    model_config = {"from_attributes": True}
+
+
+class AdminUserUpdate(BaseModel):
+    """Felder die ein Admin aendern kann."""
+
+    role: str | None = None
+    is_active: bool | None = None

--- a/backend/app/models/auth.py
+++ b/backend/app/models/auth.py
@@ -13,6 +13,21 @@ class AppleAuthRequest(BaseModel):
     name: str | None = Field(default=None, description="Name des Users (nur beim ersten Login)")
 
 
+class RegisterRequest(BaseModel):
+    """Request-Body fuer E-Mail/Passwort-Registrierung."""
+
+    email: str
+    password: str = Field(..., min_length=8)
+    name: str | None = None
+
+
+class LoginRequest(BaseModel):
+    """Request-Body fuer E-Mail/Passwort-Login."""
+
+    email: str
+    password: str
+
+
 class TokenResponse(BaseModel):
     """Response mit Access- und Refresh-Token."""
 
@@ -35,6 +50,7 @@ class UserResponse(BaseModel):
     email: str
     name: str | None = None
     avatar_url: str | None = None
+    role: str = "user"
     created_at: datetime
 
     model_config = {"from_attributes": True}
@@ -48,3 +64,4 @@ class AuthStatusResponse(BaseModel):
     user: UserResponse | None = None
     apple_client_id: str | None = None
     redirect_uri: str | None = None
+    email_auth_enabled: bool = True

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -76,6 +76,7 @@ async def find_or_create_user_by_apple(
         name=name,
         apple_sub=apple_sub,
         is_active=True,
+        role="admin" if is_first_real_user else "pending",
         last_login_at=datetime.utcnow(),
     )
     db.add(user)
@@ -96,6 +97,29 @@ async def find_or_create_user_by_apple(
         if fallback_user is not None and fallback_user.id != user.id:
             await reassign_user_data(db, fallback_user.id, user.id)
 
+    return user
+
+
+async def create_user_with_password(
+    db: AsyncSession,
+    *,
+    email: str,
+    password_hash: str,
+    name: str | None = None,
+    role: str = "pending",
+) -> UserModel:
+    """Erstellt einen neuen User mit E-Mail/Passwort-Authentifizierung."""
+    user = UserModel(
+        email=email,
+        password_hash=password_hash,
+        name=name,
+        role=role,
+        is_active=True,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    logger.info("Neuer User erstellt via E-Mail: id=%s, email=%s, role=%s", user.id, email, role)
     return user
 
 

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -32,7 +32,9 @@ async def setup_db():
     # Pre-create the fallback user (same as get_current_user with auth_enabled=False).
     # Tests that create data directly in the DB brauchen diesen user_id.
     async with TestSessionLocal() as session:
-        user = UserModel(email="local@training-analyzer.app", name="Test User", is_active=True)
+        user = UserModel(
+            email="local@training-analyzer.app", name="Test User", is_active=True, role="user"
+        )
         session.add(user)
         await session.commit()
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -116,6 +116,9 @@ const RoutesPage = lazy(() => import('./pages/Routes').then((m) => ({ default: m
 const RouteEditorPage = lazy(() =>
   import('./pages/RouteEditor').then((m) => ({ default: m.RouteEditorPage })),
 );
+const AdminUsersPage = lazy(() =>
+  import('./pages/AdminUsers').then((m) => ({ default: m.AdminUsersPage })),
+);
 const NotFoundPage = lazy(() =>
   import('./pages/NotFound').then((m) => ({ default: m.NotFoundPage })),
 );
@@ -170,6 +173,9 @@ function App() {
                       <Route path="routes/new" element={<RouteEditorPage />} />
                       <Route path="routes/:routeId" element={<RouteEditorPage />} />
                     </Route>
+
+                    {/* Admin */}
+                    <Route path="/admin/users" element={<AdminUsersPage />} />
 
                     {/* Profil (formerly Einstellungen > Athletenprofil) */}
                     <Route path="/profile" element={<AthleteProfilePage />} />

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -1,0 +1,21 @@
+import { apiClient } from './client';
+
+export interface AdminUser {
+  id: number;
+  email: string;
+  name: string | null;
+  role: string;
+  is_active: boolean;
+  has_password: boolean;
+  has_apple: boolean;
+  created_at: string;
+  last_login_at: string | null;
+}
+
+export const getUsers = () => apiClient.get<AdminUser[]>('/api/v1/admin/users').then((r) => r.data);
+
+export const updateUser = (id: number, data: { role?: string; is_active?: boolean }) =>
+  apiClient.patch<AdminUser>(`/api/v1/admin/users/${id}`, data).then((r) => r.data);
+
+export const deactivateUser = (id: number) =>
+  apiClient.delete(`/api/v1/admin/users/${id}`).then((r) => r.data);

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -12,6 +12,7 @@ export interface UserResponse {
   email: string;
   name: string | null;
   avatar_url: string | null;
+  role: string;
   created_at: string;
 }
 
@@ -21,6 +22,7 @@ export interface AuthStatusResponse {
   user: UserResponse | null;
   apple_client_id: string | null;
   redirect_uri: string | null;
+  email_auth_enabled?: boolean;
 }
 
 /** Apple Sign-In: ID-Token gegen Access/Refresh-Token tauschen. */
@@ -61,5 +63,28 @@ export async function logout(refreshToken: string): Promise<void> {
 /** Eigene User-Daten abrufen. */
 export async function getMe(): Promise<UserResponse> {
   const { data } = await apiClient.get<UserResponse>('/api/v1/auth/me');
+  return data;
+}
+
+/** Mit E-Mail und Passwort registrieren. */
+export async function registerWithEmail(
+  email: string,
+  password: string,
+  name?: string,
+): Promise<TokenResponse> {
+  const { data } = await apiClient.post<TokenResponse>('/api/v1/auth/register', {
+    email,
+    password,
+    name,
+  });
+  return data;
+}
+
+/** Mit E-Mail und Passwort einloggen. */
+export async function loginWithEmail(email: string, password: string): Promise<TokenResponse> {
+  const { data } = await apiClient.post<TokenResponse>('/api/v1/auth/login', {
+    email,
+    password,
+  });
   return data;
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -36,7 +36,12 @@ function processQueue(error: unknown, token: string | null) {
 
 function isAuthEndpoint(url?: string): boolean {
   if (!url) return false;
-  return url.includes('/auth/refresh') || url.includes('/auth/apple');
+  return (
+    url.includes('/auth/refresh') ||
+    url.includes('/auth/apple') ||
+    url.includes('/auth/login') ||
+    url.includes('/auth/register')
+  );
 }
 
 function shouldAttemptRefresh(error: AxiosError): boolean {

--- a/frontend/src/components/AuthGuard.tsx
+++ b/frontend/src/components/AuthGuard.tsx
@@ -1,7 +1,10 @@
 import { useEffect, type ReactNode } from 'react';
+import { useLocation } from 'react-router-dom';
 import { Spinner } from '@nordlig/components';
 import { useAuth } from '@/hooks/useAuth';
 import Login from '@/pages/Login';
+import Register from '@/pages/Register';
+import PendingApproval from '@/pages/PendingApproval';
 
 interface AuthGuardProps {
   children: ReactNode;
@@ -14,7 +17,8 @@ interface AuthGuardProps {
  * Bei auth_enabled=false wird der Content direkt gerendert.
  */
 export default function AuthGuard({ children }: AuthGuardProps) {
-  const { authEnabled, isAuthenticated, isLoading, checkStatus } = useAuth();
+  const { authEnabled, isAuthenticated, isLoading, isPending, checkStatus } = useAuth();
+  const location = useLocation();
 
   useEffect(() => {
     checkStatus();
@@ -28,11 +32,19 @@ export default function AuthGuard({ children }: AuthGuardProps) {
     );
   }
 
-  // Auth nicht aktiviert oder User eingeloggt → Content anzeigen
-  if (!authEnabled || isAuthenticated) {
-    return <>{children}</>;
+  // Auth aktiviert aber nicht eingeloggt
+  if (authEnabled && !isAuthenticated) {
+    if (location.pathname === '/register') {
+      return <Register />;
+    }
+    return <Login />;
   }
 
-  // Auth aktiviert aber nicht eingeloggt → Login anzeigen
-  return <Login />;
+  // Pending user → Freischaltungs-Bildschirm
+  if (authEnabled && isAuthenticated && isPending) {
+    return <PendingApproval />;
+  }
+
+  // Auth nicht aktiviert oder User eingeloggt → Content anzeigen
+  return <>{children}</>;
 }

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,7 +1,15 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { UserResponse } from '@/api/auth';
-import { appleSignIn, getAuthStatus, getMe, logout as apiLogout, refreshTokens } from '@/api/auth';
+import {
+  appleSignIn,
+  getAuthStatus,
+  getMe,
+  loginWithEmail,
+  logout as apiLogout,
+  refreshTokens,
+  registerWithEmail,
+} from '@/api/auth';
 import { apiClient } from '@/api/client';
 
 interface AuthState {
@@ -23,17 +31,61 @@ interface AuthState {
   appleClientId: string | null;
   /** Apple Redirect URI vom Backend (fuer SDK-Init). */
   appleRedirectUri: string | null;
+  /** Ob E-Mail-Auth im Backend aktiviert ist. */
+  emailAuthEnabled: boolean;
 
   /** Auth-Status vom Backend laden. */
   checkStatus: () => Promise<void>;
   /** Apple Sign-In durchfuehren. */
   signInWithApple: (idToken: string, authCode: string, name?: string) => Promise<void>;
+  /** Mit E-Mail und Passwort einloggen. */
+  signInWithEmail: (email: string, password: string) => Promise<void>;
+  /** Registrierung mit E-Mail und Passwort. */
+  register: (email: string, password: string, name?: string) => Promise<void>;
   /** Ausloggen. */
   logout: () => Promise<void>;
   /** Access-Token erneuern. */
   refresh: () => Promise<boolean>;
   /** Fehler zuruecksetzen. */
   clearError: () => void;
+  /** Ob der User die Rolle 'pending' hat. */
+  isPending: boolean;
+  /** Ob der User die Rolle 'admin' hat. */
+  isAdmin: boolean;
+}
+
+/** Setzt Tokens im Store und im API-Client. */
+function applyTokens(
+  set: (state: Partial<AuthState>) => void,
+  tokens: { access_token: string; refresh_token: string },
+) {
+  set({ accessToken: tokens.access_token, refreshToken: tokens.refresh_token });
+  apiClient.defaults.headers.common['Authorization'] = `Bearer ${tokens.access_token}`;
+}
+
+/** Laedt den User und setzt den authentifizierten Zustand. */
+async function loadUserAndSetState(set: (state: Partial<AuthState>) => void) {
+  const user = await getMe();
+  set({
+    isAuthenticated: true,
+    user,
+    isPending: user.role === 'pending',
+    isAdmin: user.role === 'admin',
+    isLoading: false,
+  });
+}
+
+/** Setzt den abgemeldeten Zustand. */
+function clearAuthState(set: (state: Partial<AuthState>) => void) {
+  set({
+    isAuthenticated: false,
+    user: null,
+    accessToken: null,
+    refreshToken: null,
+    isPending: false,
+    isAdmin: false,
+  });
+  delete apiClient.defaults.headers.common['Authorization'];
 }
 
 export const useAuth = create<AuthState>()(
@@ -48,6 +100,9 @@ export const useAuth = create<AuthState>()(
       error: null,
       appleClientId: null,
       appleRedirectUri: null,
+      emailAuthEnabled: false,
+      isPending: false,
+      isAdmin: false,
 
       checkStatus: async () => {
         set({ isLoading: true, error: null });
@@ -57,12 +112,11 @@ export const useAuth = create<AuthState>()(
             authEnabled: status.auth_enabled,
             appleClientId: status.apple_client_id ?? null,
             appleRedirectUri: status.redirect_uri ?? null,
+            emailAuthEnabled: status.email_auth_enabled ?? false,
           });
 
           if (!status.auth_enabled) {
-            // Kein Auth → Default-User laden
-            const user = await getMe();
-            set({ isAuthenticated: true, user, isLoading: false });
+            await loadUserAndSetState(set);
             return;
           }
 
@@ -71,8 +125,7 @@ export const useAuth = create<AuthState>()(
           if (refreshToken) {
             const success = await get().refresh();
             if (success) {
-              const user = await getMe();
-              set({ isAuthenticated: true, user, isLoading: false });
+              await loadUserAndSetState(set);
               return;
             }
           }
@@ -87,15 +140,32 @@ export const useAuth = create<AuthState>()(
         set({ isLoading: true, error: null });
         try {
           const tokens = await appleSignIn(idToken, authCode, name);
-          set({ accessToken: tokens.access_token, refreshToken: tokens.refresh_token });
-
-          // Auth-Header setzen
-          apiClient.defaults.headers.common['Authorization'] = `Bearer ${tokens.access_token}`;
-
-          const user = await getMe();
-          set({ isAuthenticated: true, user, isLoading: false });
+          applyTokens(set, tokens);
+          await loadUserAndSetState(set);
         } catch (err) {
           const message = err instanceof Error ? err.message : 'Login fehlgeschlagen';
+          set({ error: message, isLoading: false });
+        }
+      },
+
+      signInWithEmail: async (email, password) => {
+        set({ isLoading: true, error: null });
+        try {
+          applyTokens(set, await loginWithEmail(email, password));
+          await loadUserAndSetState(set);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Anmeldung fehlgeschlagen';
+          set({ error: message, isLoading: false });
+        }
+      },
+
+      register: async (email, password, name) => {
+        set({ isLoading: true, error: null });
+        try {
+          applyTokens(set, await registerWithEmail(email, password, name));
+          await loadUserAndSetState(set);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Registrierung fehlgeschlagen';
           set({ error: message, isLoading: false });
         }
       },
@@ -109,13 +179,7 @@ export const useAuth = create<AuthState>()(
             // Ignorieren — Token wird lokal geloescht
           }
         }
-        delete apiClient.defaults.headers.common['Authorization'];
-        set({
-          isAuthenticated: false,
-          user: null,
-          accessToken: null,
-          refreshToken: null,
-        });
+        clearAuthState(set);
       },
 
       refresh: async () => {
@@ -124,18 +188,10 @@ export const useAuth = create<AuthState>()(
 
         try {
           const tokens = await refreshTokens(refreshToken);
-          set({ accessToken: tokens.access_token, refreshToken: tokens.refresh_token });
-          apiClient.defaults.headers.common['Authorization'] = `Bearer ${tokens.access_token}`;
+          applyTokens(set, tokens);
           return true;
         } catch {
-          // Refresh fehlgeschlagen → ausloggen
-          set({
-            isAuthenticated: false,
-            user: null,
-            accessToken: null,
-            refreshToken: null,
-          });
-          delete apiClient.defaults.headers.common['Authorization'];
+          clearAuthState(set);
           return false;
         }
       },

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -14,7 +14,9 @@ import {
   ClipboardList,
   Library,
   Bot,
+  ShieldCheck,
 } from 'lucide-react';
+import { useAuth } from '@/hooks/useAuth';
 import { getChatNotifications } from '@/api/chat';
 import { ChatFAB } from '@/components/ChatFAB';
 import { BottomNav } from './BottomNav';
@@ -50,6 +52,7 @@ const navItems: NavItem[] = [
 function Sidebar() {
   const navigate = useNavigate();
   const location = useLocation();
+  const { isAdmin } = useAuth();
   const [planExpanded, setPlanExpanded] = useState(location.pathname.startsWith('/plan'));
   const [notificationCount, setNotificationCount] = useState(0);
 
@@ -162,6 +165,29 @@ function Sidebar() {
           </button>
         );
       })}
+
+      {/* Admin section */}
+      {isAdmin && (
+        <>
+          <div className="px-5 pt-4 pb-1 text-[10.5px] font-semibold uppercase tracking-[0.9px] text-[var(--color-text-disabled)]">
+            Admin
+          </div>
+          <button
+            onClick={() => navigate('/admin/users')}
+            className={`relative flex items-center gap-[var(--spacing-xs)] px-5 py-[9px] text-[13.5px] select-none transition-colors duration-150 motion-reduce:transition-none ${
+              location.pathname.startsWith('/admin/users')
+                ? 'bg-[var(--color-bg-primary-subtle)] font-medium text-[var(--color-text-primary)]'
+                : 'font-normal text-[var(--color-text-muted)] hover:bg-[var(--color-bg-surface)] hover:text-[var(--color-text-base)]'
+            }`}
+          >
+            <Icon icon={ShieldCheck} size="sm" />
+            Nutzerverwaltung
+            {location.pathname.startsWith('/admin/users') && (
+              <span className="absolute right-0 top-1 bottom-1 w-[3px] rounded-l-sm bg-[var(--color-interactive-primary)]" />
+            )}
+          </button>
+        </>
+      )}
 
       {/* User chip at bottom */}
       <div className="mt-auto border-t border-[var(--color-border-muted)] px-5 py-[var(--spacing-sm)]">

--- a/frontend/src/pages/AdminUsers.tsx
+++ b/frontend/src/pages/AdminUsers.tsx
@@ -1,0 +1,206 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Card, Button, Spinner, Badge, Breadcrumbs, BreadcrumbItem } from '@nordlig/components';
+import { Link } from 'react-router-dom';
+import { getUsers, updateUser, deactivateUser } from '@/api/admin';
+import type { AdminUser } from '@/api/admin';
+import { useAuth } from '@/hooks/useAuth';
+
+/* ------------------------------------------------------------------ */
+/*  Role badge helpers                                                  */
+/* ------------------------------------------------------------------ */
+
+const roleBadgeVariant: Record<string, 'warning' | 'success' | 'info' | 'neutral'> = {
+  pending: 'warning',
+  admin: 'success',
+  user: 'info',
+};
+
+const roleLabel: Record<string, string> = {
+  pending: 'Ausstehend',
+  admin: 'Admin',
+  user: 'Nutzer',
+};
+
+/* ------------------------------------------------------------------ */
+/*  Action hooks                                                        */
+/* ------------------------------------------------------------------ */
+
+function useUserActions(adminUser: AdminUser) {
+  const queryClient = useQueryClient();
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: ['admin', 'users'] });
+
+  const approve = useMutation({
+    mutationFn: () => updateUser(adminUser.id, { role: 'user', is_active: true }),
+    onSuccess: invalidate,
+  });
+  const reject = useMutation({
+    mutationFn: () => deactivateUser(adminUser.id),
+    onSuccess: invalidate,
+  });
+  const toggleRole = useMutation({
+    mutationFn: () =>
+      updateUser(adminUser.id, { role: adminUser.role === 'admin' ? 'user' : 'admin' }),
+    onSuccess: invalidate,
+  });
+  const toggleActive = useMutation({
+    mutationFn: () => updateUser(adminUser.id, { is_active: !adminUser.is_active }),
+    onSuccess: invalidate,
+  });
+
+  const isAnyLoading =
+    approve.isPending || reject.isPending || toggleRole.isPending || toggleActive.isPending;
+
+  return { approve, reject, toggleRole, toggleActive, isAnyLoading };
+}
+
+/* ------------------------------------------------------------------ */
+/*  User row                                                            */
+/* ------------------------------------------------------------------ */
+
+function UserRow({ adminUser, currentUserId }: { adminUser: AdminUser; currentUserId: number }) {
+  const isSelf = adminUser.id === currentUserId;
+  const { approve, reject, toggleRole, toggleActive, isAnyLoading } = useUserActions(adminUser);
+  const isPending = adminUser.role === 'pending';
+
+  return (
+    <div className="flex flex-col gap-3 border-b border-[var(--color-border-muted)] p-4 last:border-b-0 sm:flex-row sm:items-center sm:justify-between">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-[length:var(--font-size-sm)] font-medium text-[var(--color-text-base)]">
+            {adminUser.name || adminUser.email}
+          </span>
+          <Badge variant={roleBadgeVariant[adminUser.role] ?? 'neutral'} size="xs">
+            {roleLabel[adminUser.role] ?? adminUser.role}
+          </Badge>
+          {!adminUser.is_active && (
+            <Badge variant="error" size="xs">
+              Deaktiviert
+            </Badge>
+          )}
+          {isSelf && (
+            <Badge variant="neutral" size="xs">
+              Du
+            </Badge>
+          )}
+        </div>
+        <div className="mt-0.5 flex flex-wrap gap-x-3 text-[length:var(--font-size-xs)] text-[var(--color-text-muted)]">
+          <span>{adminUser.email}</span>
+          {adminUser.has_apple && <span>Apple</span>}
+          {adminUser.has_password && <span>Passwort</span>}
+        </div>
+      </div>
+
+      {!isSelf && (
+        <div className="flex shrink-0 flex-wrap gap-2">
+          {isPending ? (
+            <>
+              <Button
+                size="sm"
+                variant="primary"
+                onClick={() => approve.mutate()}
+                disabled={isAnyLoading}
+              >
+                Freischalten
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => reject.mutate()}
+                disabled={isAnyLoading}
+              >
+                Ablehnen
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => toggleRole.mutate()}
+                disabled={isAnyLoading}
+              >
+                {adminUser.role === 'admin' ? 'Zum Nutzer' : 'Zum Admin'}
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => toggleActive.mutate()}
+                disabled={isAnyLoading}
+              >
+                {adminUser.is_active ? 'Deaktivieren' : 'Aktivieren'}
+              </Button>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Page                                                                */
+/* ------------------------------------------------------------------ */
+
+export function AdminUsersPage() {
+  const { user } = useAuth();
+  const {
+    data: users,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ['admin', 'users'],
+    queryFn: getUsers,
+  });
+
+  const sortedUsers = users?.slice().sort((a, b) => {
+    if (a.role === 'pending' && b.role !== 'pending') return -1;
+    if (a.role !== 'pending' && b.role === 'pending') return 1;
+    return (a.name ?? a.email).localeCompare(b.name ?? b.email);
+  });
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6 p-4 pt-6 md:p-6 md:pt-8">
+      <div className="space-y-2 pb-2">
+        <Breadcrumbs>
+          <BreadcrumbItem>
+            <Link to="/profile">Profil</Link>
+          </BreadcrumbItem>
+          <BreadcrumbItem isCurrent>Nutzerverwaltung</BreadcrumbItem>
+        </Breadcrumbs>
+
+        <h1 className="text-[length:var(--font-size-xl)] font-semibold text-[var(--color-text-primary)]">
+          Nutzerverwaltung
+        </h1>
+      </div>
+
+      {isLoading && (
+        <div className="flex justify-center py-12">
+          <Spinner size="lg" />
+        </div>
+      )}
+
+      {error && (
+        <div
+          role="alert"
+          className="rounded-[var(--radius-md)] bg-[var(--color-bg-error-subtle)] p-4 text-[length:var(--font-size-sm)] text-[var(--color-text-error)]"
+        >
+          Nutzer konnten nicht geladen werden.
+        </div>
+      )}
+
+      {sortedUsers && sortedUsers.length > 0 && (
+        <Card>
+          {sortedUsers.map((u) => (
+            <UserRow key={u.id} adminUser={u} currentUserId={user?.id ?? -1} />
+          ))}
+        </Card>
+      )}
+
+      {sortedUsers && sortedUsers.length === 0 && (
+        <p className="py-8 text-center text-[length:var(--font-size-sm)] text-[var(--color-text-muted)]">
+          Keine Nutzer vorhanden.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,35 +1,33 @@
 import { useEffect, useRef, useState } from 'react';
-import { Card, Button, Spinner } from '@nordlig/components';
+import { Card, Button, Spinner, Input, Label } from '@nordlig/components';
 import { useAuth } from '@/hooks/useAuth';
 
-export default function Login() {
-  const { isLoading, error, clearError, appleClientId, appleRedirectUri, signInWithApple } =
-    useAuth();
+/* ------------------------------------------------------------------ */
+/*  Apple SDK hook                                                      */
+/* ------------------------------------------------------------------ */
 
-  const [sdkReady, setSdkReady] = useState(false);
+function useAppleSdk(clientId: string | null, redirectUri: string | null) {
+  const [ready, setReady] = useState(false);
   const initDone = useRef(false);
 
-  // Apple JS SDK initialisieren sobald clientId vorhanden
   useEffect(() => {
-    if (!appleClientId || !appleRedirectUri || initDone.current) return;
+    if (!clientId || !redirectUri || initDone.current) return;
 
     const initSdk = () => {
       if (typeof AppleID === 'undefined') return;
       AppleID.auth.init({
-        clientId: appleClientId,
+        clientId,
         scope: 'name email',
-        redirectURI: appleRedirectUri,
+        redirectURI: redirectUri,
         usePopup: true,
       });
       initDone.current = true;
-      setSdkReady(true);
+      setReady(true);
     };
 
-    // SDK ist moeglicherweise schon geladen
     if (typeof AppleID !== 'undefined') {
       initSdk();
     } else {
-      // Auf das Script warten
       const checkInterval = setInterval(() => {
         if (typeof AppleID !== 'undefined') {
           clearInterval(checkInterval);
@@ -38,7 +36,92 @@ export default function Login() {
       }, 100);
       return () => clearInterval(checkInterval);
     }
-  }, [appleClientId, appleRedirectUri]);
+  }, [clientId, redirectUri]);
+
+  return ready;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Email form                                                          */
+/* ------------------------------------------------------------------ */
+
+function EmailLoginForm({
+  isLoading,
+  onSubmit,
+}: {
+  isLoading: boolean;
+  onSubmit: (email: string, password: string) => void;
+}) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit(email, password);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-1.5">
+        <Label htmlFor="login-email">E-Mail</Label>
+        <Input
+          id="login-email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="name@beispiel.de"
+          required
+          autoComplete="email"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="login-password">Passwort</Label>
+        <Input
+          id="login-password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Passwort"
+          required
+          autoComplete="current-password"
+        />
+      </div>
+
+      <Button type="submit" variant="primary" size="lg" className="w-full" disabled={isLoading}>
+        {isLoading ? <Spinner size="sm" /> : 'Anmelden'}
+      </Button>
+
+      <p className="text-center text-[length:var(--font-size-sm)] text-[var(--color-text-secondary)]">
+        Noch kein Konto?{' '}
+        <a
+          href="/register"
+          className="font-medium text-[var(--color-text-primary)] hover:underline"
+        >
+          Registrieren
+        </a>
+      </p>
+    </form>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Login page                                                          */
+/* ------------------------------------------------------------------ */
+
+export default function Login() {
+  const {
+    isLoading,
+    error,
+    clearError,
+    appleClientId,
+    appleRedirectUri,
+    emailAuthEnabled,
+    signInWithApple,
+    signInWithEmail,
+  } = useAuth();
+
+  const sdkReady = useAppleSdk(appleClientId, appleRedirectUri);
 
   const handleAppleSignIn = async () => {
     clearError();
@@ -48,13 +131,17 @@ export default function Login() {
       const firstName = response.user?.name?.firstName;
       await signInWithApple(id_token, code, firstName);
     } catch (err) {
-      // User hat Popup geschlossen oder anderer Fehler
       if (err instanceof Error && err.message !== 'popup_closed_by_user') {
         useAuth.setState({
           error: 'Apple-Anmeldung fehlgeschlagen. Bitte erneut versuchen.',
         });
       }
     }
+  };
+
+  const handleEmailSignIn = (email: string, password: string) => {
+    clearError();
+    void signInWithEmail(email, password);
   };
 
   return (
@@ -79,30 +166,46 @@ export default function Login() {
             </div>
           )}
 
-          <Button
-            variant="primary"
-            size="lg"
-            className="w-full"
-            onClick={handleAppleSignIn}
-            disabled={isLoading || !sdkReady}
-          >
-            {isLoading ? (
-              <Spinner size="sm" />
-            ) : (
-              <>
-                <svg
-                  className="mr-2 h-5 w-5"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                  aria-hidden="true"
-                >
-                  <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.52-3.23 0-1.44.65-2.2.46-3.06-.4C3.79 16.17 4.36 9.02 8.93 8.78c1.28.06 2.17.72 2.92.76.89-.18 1.74-.88 2.92-.82 1.53.08 2.59.72 3.24 1.84-2.92 1.75-2.23 5.64.94 6.72-.55 1.43-.82 2.07-1.9 3z" />
-                  <path d="M12.16 8.67c-.14-2.14 1.58-3.99 3.63-4.17.27 2.44-2.14 4.28-3.63 4.17z" />
-                </svg>
-                Mit Apple anmelden
-              </>
-            )}
-          </Button>
+          {appleClientId && (
+            <Button
+              variant="primary"
+              size="lg"
+              className="w-full"
+              onClick={handleAppleSignIn}
+              disabled={isLoading || !sdkReady}
+            >
+              {isLoading ? (
+                <Spinner size="sm" />
+              ) : (
+                <>
+                  <svg
+                    className="mr-2 h-5 w-5"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.52-3.23 0-1.44.65-2.2.46-3.06-.4C3.79 16.17 4.36 9.02 8.93 8.78c1.28.06 2.17.72 2.92.76.89-.18 1.74-.88 2.92-.82 1.53.08 2.59.72 3.24 1.84-2.92 1.75-2.23 5.64.94 6.72-.55 1.43-.82 2.07-1.9 3z" />
+                    <path d="M12.16 8.67c-.14-2.14 1.58-3.99 3.63-4.17.27 2.44-2.14 4.28-3.63 4.17z" />
+                  </svg>
+                  Mit Apple anmelden
+                </>
+              )}
+            </Button>
+          )}
+
+          {emailAuthEnabled && appleClientId && (
+            <div className="flex items-center gap-3">
+              <div className="h-px flex-1 bg-[var(--color-border-muted)]" />
+              <span className="text-[length:var(--font-size-xs)] text-[var(--color-text-muted)]">
+                oder
+              </span>
+              <div className="h-px flex-1 bg-[var(--color-border-muted)]" />
+            </div>
+          )}
+
+          {emailAuthEnabled && (
+            <EmailLoginForm isLoading={isLoading} onSubmit={handleEmailSignIn} />
+          )}
         </div>
       </Card>
     </div>

--- a/frontend/src/pages/PendingApproval.tsx
+++ b/frontend/src/pages/PendingApproval.tsx
@@ -1,0 +1,64 @@
+import { Card, Button, Spinner } from '@nordlig/components';
+import { useAuth } from '@/hooks/useAuth';
+
+export default function PendingApproval() {
+  const { isLoading, checkStatus, logout } = useAuth();
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <Card className="w-full max-w-sm">
+        <div className="space-y-6 p-6 text-center">
+          {/* Hourglass icon */}
+          <div className="flex justify-center">
+            <svg
+              className="h-16 w-16 text-[var(--color-text-muted)]"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M5 22h14" />
+              <path d="M5 2h14" />
+              <path d="M17 22v-4.172a2 2 0 0 0-.586-1.414L12 12l-4.414 4.414A2 2 0 0 0 7 17.828V22" />
+              <path d="M7 2v4.172a2 2 0 0 0 .586 1.414L12 12l4.414-4.414A2 2 0 0 0 17 6.172V2" />
+            </svg>
+          </div>
+
+          <div>
+            <h1 className="text-[length:var(--font-size-lg)] font-semibold text-[var(--color-text-primary)]">
+              Warte auf Freischaltung
+            </h1>
+            <p className="mt-2 text-[length:var(--font-size-sm)] text-[var(--color-text-secondary)]">
+              Dein Konto wurde erstellt. Ein Administrator muss es freischalten.
+            </p>
+          </div>
+
+          <div className="space-y-3">
+            <Button
+              variant="primary"
+              size="lg"
+              className="w-full"
+              onClick={() => checkStatus()}
+              disabled={isLoading}
+            >
+              {isLoading ? <Spinner size="sm" /> : 'Erneut prüfen'}
+            </Button>
+
+            <Button
+              variant="ghost"
+              size="lg"
+              className="w-full"
+              onClick={() => logout()}
+              disabled={isLoading}
+            >
+              Abmelden
+            </Button>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -1,0 +1,157 @@
+import { useState } from 'react';
+import { Card, Button, Spinner, Input, Label } from '@nordlig/components';
+import { useAuth } from '@/hooks/useAuth';
+
+/* ------------------------------------------------------------------ */
+/*  Register form                                                       */
+/* ------------------------------------------------------------------ */
+
+function RegisterForm({
+  isLoading,
+  onSubmit,
+}: {
+  isLoading: boolean;
+  onSubmit: (email: string, password: string, name?: string) => void;
+}) {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [passwordConfirm, setPasswordConfirm] = useState('');
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setLocalError(null);
+
+    if (password.length < 8) {
+      setLocalError('Passwort muss mindestens 8 Zeichen lang sein.');
+      return;
+    }
+    if (password !== passwordConfirm) {
+      setLocalError('Passwörter stimmen nicht überein.');
+      return;
+    }
+
+    onSubmit(email, password, name || undefined);
+  };
+
+  return (
+    <>
+      {localError && (
+        <div
+          role="alert"
+          className="rounded-[var(--radius-md)] bg-[var(--color-bg-error-subtle)] p-3 text-[length:var(--font-size-sm)] text-[var(--color-text-error)]"
+        >
+          {localError}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="register-name">Name (optional)</Label>
+          <Input
+            id="register-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Dein Name"
+            autoComplete="name"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="register-email">E-Mail</Label>
+          <Input
+            id="register-email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="name@beispiel.de"
+            required
+            autoComplete="email"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="register-password">Passwort</Label>
+          <Input
+            id="register-password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Mindestens 8 Zeichen"
+            required
+            minLength={8}
+            autoComplete="new-password"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="register-password-confirm">Passwort bestätigen</Label>
+          <Input
+            id="register-password-confirm"
+            type="password"
+            value={passwordConfirm}
+            onChange={(e) => setPasswordConfirm(e.target.value)}
+            placeholder="Passwort wiederholen"
+            required
+            minLength={8}
+            autoComplete="new-password"
+          />
+        </div>
+
+        <Button type="submit" variant="primary" size="lg" className="w-full" disabled={isLoading}>
+          {isLoading ? <Spinner size="sm" /> : 'Registrieren'}
+        </Button>
+
+        <p className="text-center text-[length:var(--font-size-sm)] text-[var(--color-text-secondary)]">
+          Bereits ein Konto?{' '}
+          <a href="/login" className="font-medium text-[var(--color-text-primary)] hover:underline">
+            Anmelden
+          </a>
+        </p>
+      </form>
+    </>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Page                                                                */
+/* ------------------------------------------------------------------ */
+
+export default function Register() {
+  const { isLoading, error, clearError, register } = useAuth();
+
+  const handleRegister = (email: string, password: string, name?: string) => {
+    clearError();
+    void register(email, password, name);
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <Card className="w-full max-w-sm">
+        <div className="space-y-6 p-6">
+          <div className="text-center">
+            <h1 className="text-[length:var(--font-size-xl)] font-semibold text-[var(--color-text-primary)]">
+              Registrieren
+            </h1>
+            <p className="mt-2 text-[length:var(--font-size-sm)] text-[var(--color-text-secondary)]">
+              Erstelle ein neues Konto
+            </p>
+          </div>
+
+          {error && (
+            <div
+              role="alert"
+              className="rounded-[var(--radius-md)] bg-[var(--color-bg-error-subtle)] p-3 text-[length:var(--font-size-sm)] text-[var(--color-text-error)]"
+            >
+              {error}
+            </div>
+          )}
+
+          <RegisterForm isLoading={isLoading} onSubmit={handleRegister} />
+        </div>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Zusammenfassung

Admin-Rollen, Nutzerfreischaltung und E-Mail/Passwort-Auth als Alternative zu Apple Sign-In.

### Neue Rollen
- **pending** — Standard für neue User, kann App nicht nutzen
- **user** — freigeschaltet, voller Zugriff
- **admin** — kann User verwalten (freischalten/sperren/promoten)

### Backend (19 Dateien)
- Alembic c048: `role` + `password_hash` auf UserModel
- Erster echter User wird automatisch Admin
- `POST /auth/register` + `POST /auth/login` (E-Mail/Passwort)
- `GET/PATCH/DELETE /admin/users` (Admin-only)
- `get_current_active_user` lehnt pending-User mit 403 ab
- Passwort-Hashing via bcrypt (passlib)

### Frontend (7 neue/geänderte Seiten)
- Login: Apple + E-Mail/Passwort nebeneinander
- Register-Seite mit Passwort-Validierung
- PendingApproval: "Warte auf Freischaltung" Screen
- AdminUsers: Nutzerverwaltung mit Freischalten/Sperren

### Ablauf
1. User registriert sich → role="pending"
2. Sieht "Warte auf Freischaltung"
3. Admin öffnet /admin/users → klickt "Freischalten"
4. User kann die App nutzen

## Test-Plan
- [x] 1254 Backend-Tests grün
- [x] 182 Frontend-Tests grün
- [ ] E2E: Registrierung → Pending → Admin-Freischaltung → App-Zugriff

🤖 Generated with [Claude Code](https://claude.com/claude-code)