### PR TITLE
fix: E2E auth-setup ESM-Fix + BASE_URL nordliggrad.com

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,7 +379,7 @@ jobs:
         id: e2e
         working-directory: e2e
         env:
-          BASE_URL: http://training.89.167.78.223.sslip.io
+          BASE_URL: https://training.nordliggrad.com
         run: npx playwright test
 
       - name: Upload Test Report

--- a/e2e/auth-setup.ts
+++ b/e2e/auth-setup.ts
@@ -5,8 +5,9 @@
 import { chromium } from "@playwright/test";
 import path from "path";
 
-export const AUTH_STATE_PATH = path.join(
-  import.meta.dirname,
+export const AUTH_STATE_PATH = path.resolve(
+  process.cwd(),
+  "e2e",
   ".auth-state.json",
 );
 


### PR DESCRIPTION
import.meta.dirname → path.resolve(process.cwd()) für Node-Kompatibilität. BASE_URL auf HTTPS nordliggrad.com.