### PR TITLE
fix: Endloser Spinner bei abgelaufenem Token

### DIFF
--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -79,6 +79,7 @@ async function loadUserAndSetState(set: (state: Partial<AuthState>) => void) {
 function clearAuthState(set: (state: Partial<AuthState>) => void) {
   set({
     isAuthenticated: false,
+    isLoading: false,
     user: null,
     accessToken: null,
     refreshToken: null,


### PR DESCRIPTION
clearAuthState fehlte isLoading=false. Wenn Token-Refresh fehlschlug, blieb isLoading=true → endloser Spinner.