### PR TITLE
fix: E2E auth-state Pfad-Fix (doppelter e2e/)

### DIFF
--- a/e2e/auth-setup.ts
+++ b/e2e/auth-setup.ts
@@ -5,9 +5,10 @@
 import { chromium } from "@playwright/test";
 import path from "path";
 
+// __dirname-Equivalent: Pfad relativ zu dieser Datei, nicht zu cwd
+// (cwd kann "e2e/" sein wenn working-directory gesetzt ist)
 export const AUTH_STATE_PATH = path.resolve(
-  process.cwd(),
-  "e2e",
+  path.dirname(new URL(import.meta.url).pathname),
   ".auth-state.json",
 );
 


### PR DESCRIPTION
process.cwd() war im CI schon 'e2e/' → path.resolve('e2e', '.auth-state.json') wurde zu 'e2e/e2e/'. Fix: Pfad relativ zu import.meta.url.