### PR TITLE
fix: bcrypt direkt statt passlib (Registrierung 500)

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -4,22 +4,22 @@ import hashlib
 import secrets
 from datetime import datetime, timedelta
 
+import bcrypt as _bcrypt  # type: ignore[import-untyped]
 from jose import JWTError, jwt  # type: ignore[import-untyped]
-from passlib.context import CryptContext  # type: ignore[import-untyped]
 
 from app.core.config import settings
 
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-
 
 def hash_password(password: str) -> str:
-    """Hasht ein Passwort mit bcrypt."""
-    return pwd_context.hash(password)
+    """Hasht ein Passwort mit bcrypt (direkt, ohne passlib)."""
+    return _bcrypt.hashpw(password.encode("utf-8"), _bcrypt.gensalt()).decode("utf-8")
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     """Verifiziert ein Passwort gegen einen bcrypt-Hash."""
-    return pwd_context.verify(plain_password, hashed_password)  # type: ignore[no-any-return]
+    return _bcrypt.checkpw(  # type: ignore[no-any-return]
+        plain_password.encode("utf-8"), hashed_password.encode("utf-8")
+    )
 
 
 def create_access_token(user_id: int) -> str:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     
     # Security
     "python-jose[cryptography]>=3.3.0",
-    "passlib[bcrypt]>=1.7.4",
+    "bcrypt>=4.0.0",
     "python-dotenv>=1.0.0",
     
     # Utilities
@@ -78,7 +78,6 @@ dev = [
     
     # Type stubs
     "types-python-dateutil>=2.8.19",
-    "types-passlib>=1.7.7",
     "types-PyYAML>=6.0",
     "pandas-stubs>=2.0.0",
     


### PR DESCRIPTION
passlib ist inkompatibel mit bcrypt>=4.1 → 72-Byte-Fehler bei jedem Passwort. Fix: bcrypt direkt nutzen.