### PR TITLE
fix: fehlende user_id nach Auth-Umstellung (#652)

### DIFF
--- a/backend/app/services/ai_log_service.py
+++ b/backend/app/services/ai_log_service.py
@@ -23,6 +23,7 @@ class AICallData:
     duration_ms: int | None = None
     workout_id: int | None = None
     context_label: str | None = None
+    user_id: int | None = None
 
 
 async def log_ai_call(db: AsyncSession, data: AICallData) -> None:
@@ -42,6 +43,7 @@ async def log_ai_call(db: AsyncSession, data: AICallData) -> None:
             duration_ms=data.duration_ms,
             workout_id=data.workout_id,
             context_label=data.context_label,
+            user_id=data.user_id,
         )
     )
     await db.commit()

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -163,7 +163,7 @@ async def prepare_stream_with_tools(
     api_messages = [{"role": m.role, "content": m.content} for m in history]
 
     api_key = await resolve_claude_api_key(db, user_id)
-    tool_handler = partial(dispatch_tool, db=db)
+    tool_handler = partial(dispatch_tool, db=db, user_id=user_id)
     stream, provider_name = await ai_service.stream_chat_with_tools(
         api_messages, system_prompt, CHAT_TOOLS, tool_handler, api_key
     )

--- a/backend/app/services/chat_tool_handlers.py
+++ b/backend/app/services/chat_tool_handlers.py
@@ -43,7 +43,9 @@ PERIOD_MAP = {
 }
 
 
-async def dispatch_tool(name: str, args: dict, db: AsyncSession) -> dict:
+async def dispatch_tool(
+    name: str, args: dict, db: AsyncSession, *, user_id: int | None = None
+) -> dict:
     """Ruft den passenden Tool-Handler auf."""
     handlers = {
         "get_session_details": handle_get_session_details,
@@ -65,13 +67,13 @@ async def dispatch_tool(name: str, args: dict, db: AsyncSession) -> dict:
     if not handler:
         return {"error": f"Unbekanntes Tool: {name}"}
     try:
-        return await handler(args, db)
+        return await handler(args, db, user_id=user_id)  # type: ignore[operator]
     except Exception as e:
         logger.exception("Tool-Handler %s fehlgeschlagen", name)
         return {"error": f"Fehler bei {name}: {str(e)}"}
 
 
-async def handle_get_session_details(args: dict, db: AsyncSession) -> dict:
+async def handle_get_session_details(args: dict, db: AsyncSession, **_kw: object) -> dict:
     """Laedt vollstaendige Session-Details."""
     session_id = args["session_id"]
     result = await db.execute(select(WorkoutModel).where(WorkoutModel.id == session_id))
@@ -122,7 +124,7 @@ async def handle_get_session_details(args: dict, db: AsyncSession) -> dict:
     return data
 
 
-async def handle_search_sessions(args: dict, db: AsyncSession) -> dict:
+async def handle_search_sessions(args: dict, db: AsyncSession, **_kw: object) -> dict:
     """Sucht Sessions mit Filtern."""
     query = select(WorkoutModel)
 
@@ -170,7 +172,7 @@ async def handle_search_sessions(args: dict, db: AsyncSession) -> dict:
     return {"sessions": sessions, "count": len(sessions)}
 
 
-async def handle_get_training_stats(args: dict, db: AsyncSession) -> dict:
+async def handle_get_training_stats(args: dict, db: AsyncSession, **_kw: object) -> dict:
     """Aggregierte Trainingsstatistiken + Athletenprofil."""
     today = date.today()
     delta = PERIOD_MAP.get(args["period"], timedelta(weeks=4))
@@ -201,7 +203,7 @@ async def handle_get_training_stats(args: dict, db: AsyncSession) -> dict:
     return result
 
 
-async def handle_get_plan_details(args: dict, db: AsyncSession) -> dict:
+async def handle_get_plan_details(args: dict, db: AsyncSession, **_kw: object) -> dict:
     """Laedt aktiven Trainingsplan mit Phasen und Wochenstruktur."""
     today = date.today()
     plan_result = await db.execute(
@@ -264,7 +266,7 @@ async def handle_get_plan_details(args: dict, db: AsyncSession) -> dict:
     }
 
 
-async def handle_get_plan_compliance(args: dict, db: AsyncSession) -> dict:
+async def handle_get_plan_compliance(args: dict, db: AsyncSession, **_kw: object) -> dict:
     """Soll/Ist-Vergleich fuer eine Woche."""
     today = date.today()
     week_offset = args.get("week_offset", 0)
@@ -325,7 +327,7 @@ async def handle_get_plan_compliance(args: dict, db: AsyncSession) -> dict:
     }
 
 
-async def handle_get_personal_records(_args: dict, db: AsyncSession) -> dict:
+async def handle_get_personal_records(_args: dict, db: AsyncSession, **_kw: object) -> dict:
     """Persoenliche Bestleistungen."""
     # Schnellste Pace (nur Laeufe mit Pace-Wert)
     pace_result = await db.execute(
@@ -390,7 +392,7 @@ async def handle_get_personal_records(_args: dict, db: AsyncSession) -> dict:
     }
 
 
-async def handle_get_exercises(args: dict, db: AsyncSession) -> dict:
+async def handle_get_exercises(args: dict, db: AsyncSession, **_kw: object) -> dict:
     """Durchsucht die Uebungsdatenbank."""
     query = select(ExerciseModel)
 
@@ -426,7 +428,7 @@ async def handle_get_exercises(args: dict, db: AsyncSession) -> dict:
     return {"exercises": exercises, "count": len(exercises)}
 
 
-async def handle_get_ai_recommendations(args: dict, db: AsyncSession) -> dict:
+async def handle_get_ai_recommendations(args: dict, db: AsyncSession, **_kw: object) -> dict:
     """Laedt KI-Empfehlungen."""
     query = select(AIRecommendationModel)
 
@@ -460,7 +462,7 @@ async def handle_get_ai_recommendations(args: dict, db: AsyncSession) -> dict:
     return {"recommendations": recs, "count": len(recs)}
 
 
-async def handle_get_weekly_review(args: dict, db: AsyncSession) -> dict:
+async def handle_get_weekly_review(args: dict, db: AsyncSession, **_kw: object) -> dict:
     """Laedt den Wochenrueckblick."""
     today = date.today()
     week_offset = args.get("week_offset", -1)
@@ -487,7 +489,7 @@ async def handle_get_weekly_review(args: dict, db: AsyncSession) -> dict:
     }
 
 
-async def handle_search_conversations(args: dict, db: AsyncSession) -> dict:
+async def handle_search_conversations(args: dict, db: AsyncSession, **_kw: object) -> dict:
     """Durchsucht fruehere Chat-Konversationen."""
     query_text = args["query"]
     limit = min(args.get("limit", 5), 20)
@@ -513,7 +515,7 @@ async def handle_search_conversations(args: dict, db: AsyncSession) -> dict:
     return {"matches": matches, "count": len(matches)}
 
 
-async def handle_get_plan_change_log(args: dict, db: AsyncSession) -> dict:
+async def handle_get_plan_change_log(args: dict, db: AsyncSession, **_kw: object) -> dict:
     """Laedt Planaenderungshistorie."""
     period = args.get("period", "4w")
     delta = PERIOD_MAP.get(period, timedelta(weeks=4))
@@ -682,7 +684,7 @@ async def _load_week_planned_sessions(
     return sessions
 
 
-async def handle_propose_plan_change(args: dict, db: AsyncSession) -> dict:
+async def handle_propose_plan_change(args: dict, db: AsyncSession, **_kw: object) -> dict:
     """Formatiert einen Plan-Vorschlag als strukturierten Block.
 
     Ermittelt die betroffene Woche aus dem Datum und lädt den aktuellen
@@ -729,7 +731,9 @@ async def handle_propose_plan_change(args: dict, db: AsyncSession) -> dict:
     }
 
 
-async def handle_generate_training_plan(args: dict, db: AsyncSession) -> dict:  # noqa: C901, PLR0912, PLR0915
+async def handle_generate_training_plan(  # noqa: C901, PLR0912, PLR0915
+    args: dict, db: AsyncSession, *, user_id: int | None = None, **_kw: object
+) -> dict:
     """Erstellt einen echten Trainingsplan in der Datenbank.
 
     Die KI liefert phase_templates mit der Trainingsstruktur pro Phase.
@@ -824,7 +828,7 @@ async def handle_generate_training_plan(args: dict, db: AsyncSession) -> dict:  
         weeks = max(4, (race_date - start_date).days // 7 + 1)
 
     end_date = start_date + timedelta(weeks=weeks) - timedelta(days=1)
-    goal_id = await _create_race_goal(db, goal_text, race_date)
+    goal_id = await _create_race_goal(db, goal_text, race_date, user_id=user_id)
 
     rest_days = _extract_rest_days(ki_phase_templates)
     plan = await _create_plan_model(
@@ -836,6 +840,7 @@ async def handle_generate_training_plan(args: dict, db: AsyncSession) -> dict:  
         race_date,
         rest_days,
         today,
+        user_id=user_id,
     )
     phases_created = await _create_plan_phases(
         db,
@@ -853,6 +858,7 @@ async def handle_generate_training_plan(args: dict, db: AsyncSession) -> dict:  
             plan.id,
             rest_days,
             fitness_profile=fitness_profile,
+            user_id=user_id,
         )
     except Exception:
         logger.exception("Wochenpläne-Generierung fehlgeschlagen für Plan %d", plan.id)
@@ -1035,6 +1041,8 @@ async def _create_race_goal(
     db: AsyncSession,
     goal_text: str,
     race_date: date | None,
+    *,
+    user_id: int | None = None,
 ) -> int | None:
     """Erstellt ein Wettkampfziel wenn ein Datum vorhanden ist."""
     if not race_date:
@@ -1045,13 +1053,14 @@ async def _create_race_goal(
         distance_km=_parse_goal_distance(goal_text),
         target_time_seconds=_parse_goal_time(goal_text),
         is_active=True,
+        user_id=user_id,
     )
     db.add(goal_model)
     await db.flush()
     return goal_model.id
 
 
-async def _create_plan_model(
+async def _create_plan_model(  # noqa: PLR0913 — user_id added for multi-user
     db: AsyncSession,
     goal_text: str,
     goal_id: int | None,
@@ -1060,6 +1069,8 @@ async def _create_plan_model(
     race_date: date | None,
     rest_days: list[int],
     today: date,
+    *,
+    user_id: int | None = None,
 ) -> TrainingPlanModel:
     """Erstellt das TrainingPlan-Modell in der DB.
 
@@ -1094,6 +1105,7 @@ async def _create_plan_model(
         target_event_date=race_date,
         weekly_structure_json=json.dumps({"rest_days": rest_days}),
         status=status,
+        user_id=user_id,
     )
     db.add(plan)
     await db.flush()
@@ -1401,6 +1413,8 @@ async def _generate_and_save_weekly_plans(  # noqa: PLR0912, PLR0915
     plan_id: int,
     rest_days: list[int],
     fitness_profile: object | None = None,
+    *,
+    user_id: int | None = None,
 ) -> int:
     """Generiert Wochenpläne und speichert sie in der DB.
 
@@ -1519,6 +1533,7 @@ async def _generate_and_save_weekly_plans(  # noqa: PLR0912, PLR0915
                 day_of_week=entry.day_of_week,
                 is_rest_day=entry.is_rest_day,
                 notes=entry.notes,
+                user_id=user_id,
             )
             db.add(day)
             await db.flush()
@@ -1536,6 +1551,7 @@ async def _generate_and_save_weekly_plans(  # noqa: PLR0912, PLR0915
                     ),
                     exercises_json=exercises_json,
                     notes=sess.notes,
+                    user_id=user_id,
                 )
                 db.add(ps)
         weeks_generated += 1
@@ -1703,7 +1719,7 @@ def _parse_goal_time(goal_text: str) -> int:
     return 7200
 
 
-async def handle_search_training_knowledge(args: dict, _db: AsyncSession) -> dict:
+async def handle_search_training_knowledge(args: dict, _db: AsyncSession, **_kw: object) -> dict:
     """Durchsucht die Trainingswissen-Datenbank."""
     from app.services.training_knowledge import search_knowledge
 

--- a/backend/app/services/recommendation_to_plan_service.py
+++ b/backend/app/services/recommendation_to_plan_service.py
@@ -51,14 +51,14 @@ async def apply_recommendations(
     target_week = review_week_start + timedelta(days=7)
 
     # Bestehenden Plan mit vollen Details laden
-    existing_plan = await _load_full_plan(target_week, db)
+    existing_plan = await _load_full_plan(target_week, db, user_id=user_id)
 
     # plan_id für Sync extrahieren
     plan_id = _extract_plan_id(existing_plan)
 
     # Kontext laden
     templates = await _load_strength_templates(db)
-    race_goal = await _load_race_goal(db)
+    race_goal = await _load_race_goal(db, user_id=user_id)
 
     # Prompt bauen und KI aufrufen
     system_prompt = _build_system_prompt(race_goal, target_week)
@@ -76,7 +76,7 @@ async def apply_recommendations(
 
     # Bestehende Einträge löschen und neue persistieren
     if ai_days:
-        await _replace_plan(target_week, existing_plan, ai_days, db)
+        await _replace_plan(target_week, existing_plan, ai_days, db, user_id=user_id)
 
     # Sync zurück zum Trainingsplan + Changelog
     if ai_days and plan_id:
@@ -128,13 +128,14 @@ def _extract_plan_id(existing_plan: list[dict]) -> int | None:
 # ---------------------------------------------------------------------------
 
 
-async def _load_full_plan(week_start: date, db: AsyncSession) -> list[dict]:
+async def _load_full_plan(
+    week_start: date, db: AsyncSession, *, user_id: int | None = None
+) -> list[dict]:
     """Lädt den bestehenden Plan mit vollen Session-Details für den KI-Prompt."""
-    day_result = await db.execute(
-        select(WeeklyPlanDayModel)
-        .where(WeeklyPlanDayModel.week_start == week_start)
-        .order_by(WeeklyPlanDayModel.day_of_week)
-    )
+    q = select(WeeklyPlanDayModel).where(WeeklyPlanDayModel.week_start == week_start)
+    if user_id is not None:
+        q = q.where(WeeklyPlanDayModel.user_id == user_id)
+    day_result = await db.execute(q.order_by(WeeklyPlanDayModel.day_of_week))
     days = day_result.scalars().all()
     if not days:
         return []
@@ -178,11 +179,12 @@ async def _load_strength_templates(db: AsyncSession) -> list[dict]:
     return [{"id": row.id, "name": str(row.name)} for row in result.all()]
 
 
-async def _load_race_goal(db: AsyncSession) -> dict | None:
+async def _load_race_goal(db: AsyncSession, *, user_id: int | None = None) -> dict | None:
     """Lädt das aktive Wettkampfziel."""
-    result = await db.execute(
-        select(RaceGoalModel).where(RaceGoalModel.is_active.is_(True)).limit(1)
-    )
+    q = select(RaceGoalModel).where(RaceGoalModel.is_active.is_(True))
+    if user_id is not None:
+        q = q.where(RaceGoalModel.user_id == user_id)
+    result = await db.execute(q.limit(1))
     goal = result.scalar_one_or_none()
     if not goal:
         return None
@@ -524,12 +526,15 @@ async def _replace_plan(
     existing_plan: list[dict],
     ai_days: list[dict],
     db: AsyncSession,
+    *,
+    user_id: int | None = None,
 ) -> None:
     """Löscht bestehende Einträge und erstellt den angepassten Plan."""
     # Bestehende Tage + Sessions löschen
-    day_result = await db.execute(
-        select(WeeklyPlanDayModel).where(WeeklyPlanDayModel.week_start == target_week)
-    )
+    q = select(WeeklyPlanDayModel).where(WeeklyPlanDayModel.week_start == target_week)
+    if user_id is not None:
+        q = q.where(WeeklyPlanDayModel.user_id == user_id)
+    day_result = await db.execute(q)
     old_days = day_result.scalars().all()
 
     if old_days:
@@ -548,7 +553,7 @@ async def _replace_plan(
 
     # Neue Tage + Sessions erstellen
     for ai_day in ai_days:
-        await _create_plan_day(target_week, ai_day, plan_id, db)
+        await _create_plan_day(target_week, ai_day, plan_id, db, user_id=user_id)
 
 
 async def _create_plan_day(
@@ -556,6 +561,8 @@ async def _create_plan_day(
     ai_day: dict,
     plan_id: int | None,
     db: AsyncSession,
+    *,
+    user_id: int | None = None,
 ) -> None:
     """Erstellt einen einzelnen Plan-Tag mit Session in der DB."""
     is_rest = ai_day.get("is_rest_day", False)
@@ -567,6 +574,7 @@ async def _create_plan_day(
         notes=ai_day.get("notes"),
         plan_id=plan_id,
         edited=True,
+        user_id=user_id,
     )
     db.add(db_day)
     await db.flush()
@@ -585,6 +593,7 @@ async def _create_plan_day(
         template_id=ai_day.get("template_id"),
         run_details_json=run_details_str,
         notes=ai_day.get("notes"),
+        user_id=user_id,
     )
     db.add(db_session)
 


### PR DESCRIPTION
## Summary
- Fehlende `user_id` in KI/Chat-Services und Recommendation-Service nach der Multi-User-Migration behoben
- **Root Cause:** Bei `apply_recommendations` wurden `WeeklyPlanDayModel` und `PlannedSessionModel` ohne `user_id` erstellt → beim Laden mit `WHERE user_id=X` kamen 0 Ergebnisse → Wochenplan erschien leer
- Gleiches Problem im Chat-Tool-Handler: `RaceGoalModel`, `TrainingPlanModel` und Weekly-Plan-Models ohne `user_id`

### Geänderte Dateien (4):
- **`recommendation_to_plan_service.py`** — `user_id` durch gesamte Kette + Queries filtern
- **`chat_tool_handlers.py`** — `dispatch_tool` + alle Model-Erstellungen mit `user_id`
- **`chat_service.py`** — `user_id` an `dispatch_tool` via `partial` durchgereicht
- **`ai_log_service.py`** — `AICallData.user_id` Feld + Model-Erstellung

## Test plan
- [x] Ruff check: 0 Fehler
- [x] Ruff format: alle Dateien formatiert
- [x] Mypy: 0 Fehler (6 Dateien geprüft)
- [x] Pytest: 1254 Tests bestanden
- [ ] Manuell: Wochenreview → Empfehlungen anwenden → nächste Woche hat Einträge
- [ ] Manuell: KI-Chat → Trainingsplan generieren → Plan wird mit user_id erstellt

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)