### PR TITLE
fix: Deploy-Verify curl mit --retry und --connect-timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,7 @@ jobs:
               FAILED=true
             else
               for asset in $JS_ASSETS; do
-                HTTP_CODE=$(curl -sk -o /dev/null -w "%{http_code}" "$PROD_URL$asset" --max-time 10 2>/dev/null || echo "000")
+                HTTP_CODE=$(curl -sk -o /dev/null -w "%{http_code}" "$PROD_URL$asset" --connect-timeout 5 --max-time 15 --retry 2 --retry-delay 3 2>/dev/null || echo "000")
                 if [ "$HTTP_CODE" = "200" ]; then
                   echo "  ✓ $asset"
                 else


### PR DESCRIPTION
## Summary

- curl-Aufrufe für JS-Bundle-Check im Deploy-Verify-Step hatten keinen `--connect-timeout` und keine `--retry`-Logik
- Ein transienter SSL-Fehler (exit code 35) brach das ganze Script sofort ab, statt zur nächsten Retry-Iteration zu gehen
- Fix: `--connect-timeout 5 --max-time 15 --retry 2 --retry-delay 3`

## Test plan

- [ ] Deploy-Verify-Step überlebt transiente SSL-Fehler
- [ ] E2E Smoke Tests laufen nach erfolgreichem Deploy

Relates to #651

🤖 Generated with [Claude Code](https://claude.com/claude-code)