### PR TITLE
fix: Aktiver Plan crasht beim Laden + Undo-Snapshot falsch (#652)

### DIFF
--- a/backend/app/api/v1/health.py
+++ b/backend/app/api/v1/health.py
@@ -30,11 +30,17 @@ async def debug_user_data():
     results: dict = {}
     try:
         async with engine.connect() as conn:
+            rows = (
+                await conn.execute(text("SELECT id, email, role FROM users ORDER BY id"))
+            ).fetchall()
+            results["users"] = [{"id": r[0], "email": r[1], "role": r[2]} for r in rows]
+
             for table in [
-                "users",
                 "training_plans",
+                "training_phases",
                 "weekly_plan_days",
                 "planned_sessions",
+                "plan_changelog",
                 "race_goals",
                 "workouts",
                 "chat_conversations",
@@ -42,7 +48,8 @@ async def debug_user_data():
                 rows = (
                     await conn.execute(
                         text(
-                            f"SELECT user_id, COUNT(*) FROM {table} GROUP BY user_id ORDER BY user_id"
+                            f"SELECT user_id, COUNT(*) FROM {table}"  # noqa: S608
+                            " GROUP BY user_id ORDER BY user_id"
                         )
                     )
                 ).fetchall()

--- a/backend/app/api/v1/training_plans.py
+++ b/backend/app/api/v1/training_plans.py
@@ -83,26 +83,30 @@ def _phase_to_response(
     focus: Optional[PhaseFocus] = None
     raw_focus = _parse_json(str(phase.focus_json) if phase.focus_json else None)
     if raw_focus:
-        focus = PhaseFocus(**raw_focus)
+        with contextlib.suppress(ValidationError):
+            focus = PhaseFocus(**raw_focus)
 
     target_metrics: Optional[PhaseTargetMetrics] = None
     raw_metrics = _parse_json(str(phase.target_metrics_json) if phase.target_metrics_json else None)
     if raw_metrics:
-        target_metrics = PhaseTargetMetrics(**raw_metrics)
+        with contextlib.suppress(ValidationError):
+            target_metrics = PhaseTargetMetrics(**raw_metrics)
 
     weekly_template: Optional[PhaseWeeklyTemplate] = None
     raw_template = _parse_json(
         str(phase.weekly_template_json) if phase.weekly_template_json else None
     )
     if raw_template:
-        weekly_template = PhaseWeeklyTemplate(**raw_template)
+        with contextlib.suppress(ValidationError):
+            weekly_template = PhaseWeeklyTemplate(**raw_template)
 
     weekly_templates: Optional[PhaseWeeklyTemplates] = None
     raw_templates = _parse_json(
         str(phase.weekly_templates_json) if phase.weekly_templates_json else None
     )
     if raw_templates:
-        weekly_templates = PhaseWeeklyTemplates(**raw_templates)
+        with contextlib.suppress(ValidationError):
+            weekly_templates = PhaseWeeklyTemplates(**raw_templates)
 
     return TrainingPhaseResponse(
         id=phase.id,

--- a/backend/app/models/training_plan.py
+++ b/backend/app/models/training_plan.py
@@ -72,7 +72,7 @@ class PhaseWeeklyTemplateDayEntry(BaseModel):
 class PhaseWeeklyTemplate(BaseModel):
     """7-day weekly template for a training phase."""
 
-    days: list[PhaseWeeklyTemplateDayEntry] = Field(..., min_length=7, max_length=7)
+    days: list[PhaseWeeklyTemplateDayEntry] = Field(..., min_length=1, max_length=7)
 
 
 class PhaseWeeklyTemplates(BaseModel):

--- a/backend/app/services/recommendation_to_plan_service.py
+++ b/backend/app/services/recommendation_to_plan_service.py
@@ -761,10 +761,36 @@ def _log_recommendation_change(
     )
     reason = "; ".join(recommendations[:10])
 
-    # Build undo snapshot from old_plan (dict-based format from _load_full_plan)
+    # Build undo snapshot from old_plan (dict-based format from _load_full_plan).
+    # Undo erwartet sessions mit run_details_json (String), nicht run_details (Dict).
+    undo_days = []
+    for day in old_plan:
+        undo_day = {
+            "day_of_week": day["day_of_week"],
+            "is_rest_day": day.get("is_rest_day", False),
+            "notes": day.get("notes"),
+            "plan_id": day.get("plan_id"),
+            "edited": day.get("edited", False),
+            "sessions": [],
+        }
+        for sess in day.get("sessions", []):
+            rd = sess.get("run_details")
+            undo_day["sessions"].append(
+                {
+                    "training_type": sess.get("training_type", ""),
+                    "template_id": sess.get("template_id"),
+                    "run_details_json": json.dumps(rd) if rd else None,
+                    "exercises_json": sess.get("exercises_json"),
+                    "notes": sess.get("notes"),
+                    "position": sess.get("position", 0),
+                    "status": sess.get("status", "active"),
+                }
+            )
+        undo_days.append(undo_day)
+
     snapshot_before: dict = {
         "week_start": str(target_week),
-        "days": old_plan,
+        "days": undo_days,
         "phase_id": phase_snapshot.get("phase_id") if phase_snapshot else None,
         "phase_weekly_templates_json": (
             phase_snapshot.get("phase_weekly_templates_json") if phase_snapshot else None


### PR DESCRIPTION
## Summary
- **Aktiver Plan crasht:** `_phase_to_response` warf Pydantic ValidationError wenn weekly_templates ungültige/unvollständige Daten hatten → 500 statt Antwort. Jetzt werden ValidationErrors abgefangen und das Feld bleibt `null`.
- **PhaseWeeklyTemplate:** `min_length=7` → `min_length=1` — KI-generierte Templates können weniger als 7 Tage haben
- **Undo-Snapshot:** `_log_recommendation_change` schrieb `run_details` als Dict, aber Undo erwartet `run_details_json` als JSON-String — Format korrigiert
- **Debug-Endpoint:** users-Tabelle hat kein user_id, wird jetzt separat abgefragt

## Test plan
- [x] Ruff: 0 Fehler
- [x] Mypy: 0 Fehler
- [x] Pytest: 1254 Tests bestanden
- [ ] Manuell: Aktiver Plan lässt sich öffnen
- [ ] Manuell: KI-Empfehlungen rückgängig machen funktioniert

Fixes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)