### PR TITLE
fix: KI-Chat nutzt User-gewählten Provider statt hardcoded Claude

### DIFF
--- a/backend/app/api/v1/ai.py
+++ b/backend/app/api/v1/ai.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.api_key_resolver import resolve_claude_api_key
+from app.core.api_key_resolver import resolve_ai_config
 from app.core.dependencies import get_current_active_user
 from app.infrastructure.ai.ai_service import AIProviderFactory, ai_service
 from app.infrastructure.database.models import (
@@ -62,13 +62,19 @@ class ApplyPlanChangeRequest(BaseModel):
 
 @router.get("/ai/providers")
 async def get_providers(
-    current_user: UserModel = Depends(get_current_active_user),  # noqa: ARG001
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_active_user),
 ):
-    """Gibt verfügbare AI Provider und deren Status zurück."""
+    """Gibt verfügbare AI Provider und User-spezifischen Status zurück."""
+    api_key, provider_name = await resolve_ai_config(db, current_user.id)
+    provider_available = bool(api_key)
     return {
-        "primary": ai_service.get_active_provider(),
+        "primary": provider_name if provider_available else None,
+        "preferred": provider_name,
         "available": AIProviderFactory.get_available_providers(),
-        "status": ai_service.get_provider_status(),
+        "status": {
+            provider_name: {"available": provider_available, "is_primary": True},
+        },
     }
 
 
@@ -80,12 +86,14 @@ async def chat(
 ):
     """Chat with AI trainer (User-Key → .env Fallback)."""
     try:
-        claude_key = await resolve_claude_api_key(db, current_user.id)
-        response = await ai_service.chat(request.message, request.context, api_key=claude_key)
+        api_key, provider_name = await resolve_ai_config(db, current_user.id)
+        response = await ai_service.chat(
+            request.message, request.context, api_key=api_key, provider_name=provider_name
+        )
         return {
             "success": True,
             "message": response,
-            "provider": ai_service.get_active_provider(),
+            "provider": provider_name,
         }
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"AI chat failed: {str(e)}") from e

--- a/backend/app/api/v1/exercise_library.py
+++ b/backend/app/api/v1/exercise_library.py
@@ -834,7 +834,7 @@ async def delete_exercise(
 async def enrich_all_exercises(
     force: bool = False,
     db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_active_user),  # noqa: ARG001 — ensures auth
+    current_user: UserModel = Depends(get_current_active_user),
 ) -> dict:
     """Reichert alle unangereicherten Übungen per KI an.
 
@@ -844,7 +844,7 @@ async def enrich_all_exercises(
     from app.core.api_key_resolver import resolve_claude_api_key
     from app.services.exercise_ai_enrichment import generate_exercise_enrichment
 
-    api_key = await resolve_claude_api_key(db)
+    api_key = await resolve_claude_api_key(db, current_user.id)
 
     if force:
         result = await db.execute(select(ExerciseModel).where(ExerciseModel.is_hidden.is_not(True)))

--- a/backend/app/api/v1/workouts.py
+++ b/backend/app/api/v1/workouts.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.api_key_resolver import resolve_claude_api_key
+from app.core.api_key_resolver import resolve_ai_config
 from app.core.dependencies import get_current_active_user
 from app.infrastructure.ai.ai_service import ai_service
 from app.infrastructure.database.models import UserModel, WorkoutModel
@@ -48,8 +48,10 @@ async def upload_workout(
 
         # Analyze with AI (User-Key → .env Fallback)
         try:
-            claude_key = await resolve_claude_api_key(db, current_user.id)
-            ai_analysis = await ai_service.analyze_workout(workout_data, api_key=claude_key)
+            api_key, provider_name = await resolve_ai_config(db, current_user.id)
+            ai_analysis = await ai_service.analyze_workout(
+                workout_data, api_key=api_key, provider_name=provider_name
+            )
         except Exception as e:
             ai_analysis = f"AI analysis failed: {str(e)}"
 

--- a/backend/app/core/api_key_resolver.py
+++ b/backend/app/core/api_key_resolver.py
@@ -28,6 +28,22 @@ async def resolve_preferred_provider(db: AsyncSession, user_id: int | None = Non
     return settings.ai_primary_provider
 
 
+async def resolve_ai_config(db: AsyncSession, user_id: int | None = None) -> tuple[str, str]:
+    """Gibt (api_key, provider_name) basierend auf User-Präferenz zurück.
+
+    Prüft welchen Provider der User gewählt hat und löst den
+    passenden API Key auf. Fallback auf System-Defaults.
+    """
+    provider = await resolve_preferred_provider(db, user_id)
+
+    if provider == "openai":
+        key = await resolve_openai_api_key(db, user_id)
+    else:
+        key = await resolve_claude_api_key(db, user_id)
+
+    return key, provider
+
+
 async def _get_athlete(db: AsyncSession, user_id: int | None) -> AthleteModel | None:
     """Athlete für User laden."""
     query = select(AthleteModel)

--- a/backend/app/infrastructure/ai/ai_service.py
+++ b/backend/app/infrastructure/ai/ai_service.py
@@ -2,6 +2,7 @@
 AI Service Factory and Manager
 
 Handles AI provider initialization, selection, and fallback logic.
+Providers können pro Request gewählt werden (User-Präferenz).
 """
 
 from collections.abc import AsyncIterator
@@ -11,6 +12,7 @@ from app.core.config import settings
 from app.domain.interfaces.ai_service import AIProvider
 from app.infrastructure.ai.providers.claude_provider import ClaudeProvider
 from app.infrastructure.ai.providers.ollama_provider import OllamaProvider
+from app.infrastructure.ai.providers.openai_provider import OpenAIProvider
 
 
 class AIProviderFactory:
@@ -19,6 +21,7 @@ class AIProviderFactory:
     _providers = {
         "claude": ClaudeProvider,
         "ollama": OllamaProvider,
+        "openai": OpenAIProvider,
     }
 
     @classmethod
@@ -27,8 +30,7 @@ class AIProviderFactory:
         provider_class = cls._providers.get(provider_name.lower())
         if not provider_class:
             raise ValueError(f"Unknown AI provider: {provider_name}")
-
-        return provider_class()
+        return provider_class()  # type: ignore[abstract]
 
     @classmethod
     def get_available_providers(cls) -> list[str]:
@@ -37,61 +39,65 @@ class AIProviderFactory:
 
 
 class AIService:
-    """
-    Main AI Service with provider management and fallback support
+    """Main AI Service mit Provider-Cache und dynamischer Auswahl pro Request."""
 
-    Example:
-        ai_service = AIService()
-        analysis = await ai_service.analyze_workout(workout_data)
-    """
-
-    def __init__(self):
+    def __init__(self) -> None:
+        self._provider_cache: dict[str, AIProvider] = {}
         self.primary_provider: Optional[AIProvider] = None
         self.fallback_providers: list[AIProvider] = []
         self._initialize_providers()
 
-    def _initialize_providers(self):
-        """Initialize AI providers based on config"""
-        # Primary provider
+    def _initialize_providers(self) -> None:
+        """Initialisiert Default-Provider aus Config (für Fallback-Chain)."""
         try:
-            self.primary_provider = AIProviderFactory.create(settings.ai_primary_provider)
+            self.primary_provider = self._get_or_create(settings.ai_primary_provider)
             print(f"✅ Primary AI provider: {self.primary_provider.name}")
         except Exception as e:
             print(f"⚠️  Failed to initialize primary provider: {e}")
 
-        # Fallback providers
         for fallback_name in settings.ai_fallback_providers:
             try:
-                provider = AIProviderFactory.create(fallback_name)
+                provider = self._get_or_create(fallback_name)
                 if provider.is_available():
                     self.fallback_providers.append(provider)
                     print(f"✅ Fallback provider: {provider.name}")
             except Exception as e:
                 print(f"⚠️  Failed to initialize fallback {fallback_name}: {e}")
 
-    async def analyze_workout(self, workout_data: dict, api_key: str | None = None) -> str:
-        """Analyze workout with automatic fallback.
+    def _get_or_create(self, provider_name: str) -> AIProvider:
+        """Provider aus Cache holen oder neu erstellen."""
+        name = provider_name.lower()
+        if name not in self._provider_cache:
+            self._provider_cache[name] = AIProviderFactory.create(name)
+        return self._provider_cache[name]
 
-        Args:
-            workout_data: Dictionary with workout metrics
-            api_key: Optionaler User-API-Key (überschreibt .env)
-
-        Returns:
-            AI analysis text
-
-        Raises:
-            Exception: If all providers fail
-        """
-        # Try primary provider
-        if self.primary_provider and self.primary_provider.is_available(api_key):
+    def _select_provider(self, provider_name: str | None) -> AIProvider | None:
+        """Wählt Provider basierend auf Name oder nimmt Primary."""
+        if provider_name:
             try:
-                result = await self.primary_provider.analyze_workout(workout_data, api_key)
-                return f"[{self.primary_provider.name}] {result}"
+                return self._get_or_create(provider_name)
+            except ValueError:
+                pass
+        return self.primary_provider
+
+    async def analyze_workout(
+        self,
+        workout_data: dict,
+        api_key: str | None = None,
+        provider_name: str | None = None,
+    ) -> str:
+        """Analyze workout mit gewähltem Provider + Fallback."""
+        primary = self._select_provider(provider_name)
+        if primary and primary.is_available(api_key):
+            try:
+                result = await primary.analyze_workout(workout_data, api_key)
+                return f"[{primary.name}] {result}"
             except Exception as e:
                 print(f"Primary provider failed: {e}")
 
-        # Try fallback providers
         for provider in self.fallback_providers:
+            if provider is primary:
+                continue
             if provider.is_available():
                 try:
                     result = await provider.analyze_workout(workout_data)
@@ -102,26 +108,24 @@ class AIService:
 
         raise Exception("All AI providers failed")
 
-    async def chat(self, message: str, context: dict, api_key: str | None = None) -> str:
-        """Chat with AI with automatic fallback.
-
-        Args:
-            message: User message
-            context: Conversation context
-            api_key: Optionaler User-API-Key (überschreibt .env)
-
-        Returns:
-            AI response text
-        """
-        # Try primary provider
-        if self.primary_provider and self.primary_provider.is_available(api_key):
+    async def chat(
+        self,
+        message: str,
+        context: dict,
+        api_key: str | None = None,
+        provider_name: str | None = None,
+    ) -> str:
+        """Chat mit gewähltem Provider + Fallback."""
+        primary = self._select_provider(provider_name)
+        if primary and primary.is_available(api_key):
             try:
-                return await self.primary_provider.chat(message, context, api_key)
+                return await primary.chat(message, context, api_key)
             except Exception as e:
                 print(f"Primary provider failed: {e}")
 
-        # Try fallback providers
         for provider in self.fallback_providers:
+            if provider is primary:
+                continue
             if provider.is_available():
                 try:
                     return await provider.chat(message, context)
@@ -136,22 +140,20 @@ class AIService:
         messages: list[dict],
         system_prompt: str,
         api_key: str | None = None,
+        provider_name: str | None = None,
     ) -> tuple[str, str]:
-        """Multi-Turn Chat mit Konversationshistorie.
-
-        Returns:
-            Tuple von (response_text, provider_name).
-        """
-        if self.primary_provider and self.primary_provider.is_available(api_key):
+        """Multi-Turn Chat mit gewähltem Provider."""
+        primary = self._select_provider(provider_name)
+        if primary and primary.is_available(api_key):
             try:
-                result = await self.primary_provider.chat_multi_turn(
-                    messages, system_prompt, api_key
-                )
-                return result, self.primary_provider.name
+                result = await primary.chat_multi_turn(messages, system_prompt, api_key)
+                return result, primary.name
             except Exception as e:
                 print(f"Primary provider failed: {e}")
 
         for provider in self.fallback_providers:
+            if provider is primary:
+                continue
             if provider.is_available():
                 try:
                     result = await provider.chat_multi_turn(messages, system_prompt)
@@ -167,19 +169,19 @@ class AIService:
         messages: list[dict],
         system_prompt: str,
         api_key: str | None = None,
+        provider_name: str | None = None,
     ) -> tuple[AsyncIterator[str], str]:
-        """Streamt Multi-Turn Chat Token fuer Token.
-
-        Returns:
-            Tuple von (async_iterator, provider_name).
-        """
-        if self.primary_provider and self.primary_provider.is_available(api_key):
+        """Streamt Multi-Turn Chat Token fuer Token."""
+        primary = self._select_provider(provider_name)
+        if primary and primary.is_available(api_key):
             return (
-                self.primary_provider.stream_chat_multi_turn(messages, system_prompt, api_key),
-                self.primary_provider.name,
+                primary.stream_chat_multi_turn(messages, system_prompt, api_key),
+                primary.name,
             )
 
         for provider in self.fallback_providers:
+            if provider is primary:
+                continue
             if provider.is_available():
                 return (
                     provider.stream_chat_multi_turn(messages, system_prompt),
@@ -195,30 +197,28 @@ class AIService:
         tools: list[dict],
         tool_handler: Any,
         api_key: str | None = None,
+        provider_name: str | None = None,
     ) -> tuple[AsyncIterator[dict], str]:
-        """Streamt Chat mit Tool Use. Nur Claude unterstuetzt Tools.
-
-        Returns:
-            Tuple von (async_iterator mit dicts, provider_name).
-        """
-        if self.primary_provider and isinstance(self.primary_provider, ClaudeProvider):
+        """Streamt Chat mit Tool Use. Nur Claude unterstützt Tools nativ."""
+        primary = self._select_provider(provider_name)
+        if isinstance(primary, ClaudeProvider) and primary.is_available(api_key):
             return (
-                self.primary_provider.stream_chat_with_tools(
+                primary.stream_chat_with_tools(
                     messages, system_prompt, tools, tool_handler, api_key
                 ),
-                self.primary_provider.name,
+                primary.name,
             )
 
-        # Fallback: Ohne Tools streamen (Ollama etc.)
-        if self.primary_provider and self.primary_provider.is_available(api_key):
+        # Fallback: Ohne Tools streamen (OpenAI, Ollama etc.)
+        if primary and primary.is_available(api_key):
 
             async def _wrap_stream() -> AsyncIterator[dict]:
-                async for text in self.primary_provider.stream_chat_multi_turn(  # type: ignore[union-attr]
+                async for text in primary.stream_chat_multi_turn(  # type: ignore[union-attr]
                     messages, system_prompt, api_key
                 ):
                     yield {"type": "token", "content": text}
 
-            return _wrap_stream(), self.primary_provider.name
+            return _wrap_stream(), primary.name
 
         raise Exception("No AI provider available for tool-use streaming")
 
@@ -235,7 +235,7 @@ class AIService:
 
     def get_provider_status(self) -> dict:
         """Get status of all configured providers"""
-        status = {}
+        status: dict = {}
 
         if self.primary_provider:
             status[self.primary_provider.name] = {

--- a/backend/app/infrastructure/ai/providers/openai_provider.py
+++ b/backend/app/infrastructure/ai/providers/openai_provider.py
@@ -1,0 +1,146 @@
+"""
+OpenAI AI Provider
+
+High-quality AI analysis using OpenAI's GPT models.
+"""
+
+import logging
+from collections.abc import AsyncIterator
+
+from openai import AsyncOpenAI, OpenAI
+
+from app.core.config import settings
+from app.domain.interfaces.ai_service import AIProvider
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAIProvider(AIProvider):
+    """OpenAI (ChatGPT) AI Provider"""
+
+    def __init__(self) -> None:
+        self.default_api_key = settings.openai_api_key
+        self.model = settings.openai_model
+
+    def _get_client(self, api_key: str | None = None) -> OpenAI:
+        """Client zurückgeben, optional mit anderem API Key."""
+        key = api_key or self.default_api_key
+        return OpenAI(api_key=key) if key else OpenAI(api_key="none")
+
+    def _get_async_client(self, api_key: str | None = None) -> AsyncOpenAI:
+        """Async Client zurückgeben, optional mit anderem API Key."""
+        key = api_key or self.default_api_key
+        return AsyncOpenAI(api_key=key) if key else AsyncOpenAI(api_key="none")
+
+    async def analyze_workout(self, workout_data: dict, api_key: str | None = None) -> str:
+        """Analyze workout using OpenAI"""
+        prompt = self._build_workout_analysis_prompt(workout_data)
+        client = self._get_async_client(api_key)
+
+        try:
+            response = await client.chat.completions.create(
+                model=self.model,
+                max_tokens=1000,
+                temperature=0.3,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            return response.choices[0].message.content or ""
+        except Exception as e:
+            raise Exception(f"OpenAI API error: {str(e)}") from e
+
+    async def chat(self, message: str, context: dict, api_key: str | None = None) -> str:
+        """Chat with OpenAI"""
+        system_prompt = context.get("system_prompt") or self._build_system_prompt(context)
+        client = self._get_async_client(api_key)
+
+        try:
+            response = await client.chat.completions.create(
+                model=self.model,
+                max_tokens=2000,
+                temperature=0.3,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": message},
+                ],
+            )
+            return response.choices[0].message.content or ""
+        except Exception as e:
+            raise Exception(f"OpenAI API error: {str(e)}") from e
+
+    async def chat_multi_turn(
+        self,
+        messages: list[dict],
+        system_prompt: str,
+        api_key: str | None = None,
+    ) -> str:
+        """Multi-Turn Chat mit Konversationshistorie."""
+        client = self._get_async_client(api_key)
+        api_messages: list[dict] = [
+            {"role": "system", "content": system_prompt},
+            *[{"role": m["role"], "content": m["content"]} for m in messages],
+        ]
+
+        try:
+            response = await client.chat.completions.create(
+                model=self.model,
+                max_tokens=2000,
+                temperature=0.3,
+                messages=api_messages,  # type: ignore[arg-type]
+            )
+            return response.choices[0].message.content or ""
+        except Exception as e:
+            raise Exception(f"OpenAI API error: {str(e)}") from e
+
+    async def stream_chat_multi_turn(
+        self,
+        messages: list[dict],
+        system_prompt: str,
+        api_key: str | None = None,
+    ) -> AsyncIterator[str]:
+        """Streamt die KI-Antwort Token fuer Token."""
+        client = self._get_async_client(api_key)
+        api_messages: list[dict] = [
+            {"role": "system", "content": system_prompt},
+            *[{"role": m["role"], "content": m["content"]} for m in messages],
+        ]
+
+        stream = await client.chat.completions.create(
+            model=self.model,
+            max_tokens=2000,
+            temperature=0.3,
+            messages=api_messages,  # type: ignore[arg-type]
+            stream=True,
+        )
+        async for chunk in stream:  # type: ignore[union-attr]
+            delta = chunk.choices[0].delta.content
+            if delta:
+                yield delta
+
+    def is_available(self, api_key: str | None = None) -> bool:
+        """Prüft ob ein API Key vorhanden ist (kein teurer Test-Call)."""
+        key = api_key or self.default_api_key
+        return bool(key)
+
+    @property
+    def name(self) -> str:
+        return f"OpenAI ({self.model})"
+
+    def _build_workout_analysis_prompt(self, workout_data: dict) -> str:
+        """Build prompt for workout analysis"""
+        return f"""Analysiere dieses Lauftraining für die Halbmarathon-Vorbereitung:
+
+Typ: {workout_data.get("workout_type", "unknown")}
+Dauer: {workout_data.get("duration_sec", 0) // 60} Minuten
+Distanz: {workout_data.get("distance_km", 0):.2f} km
+Pace: {workout_data.get("pace", "N/A")}
+Herzfrequenz Ø: {workout_data.get("hr_avg", "N/A")} bpm
+Herzfrequenz Max: {workout_data.get("hr_max", "N/A")} bpm
+
+Bewerte das Training kurz und prägnant in 3-4 Sätzen."""
+
+    def _build_system_prompt(self, _context: dict) -> str:
+        """Build system prompt for chat"""
+        return """Du bist ein erfahrener Lauftrainer für Halbmarathon-Vorbereitung.
+Analysiere Trainingseinheiten wissenschaftlich fundiert, gib konkrete Empfehlungen,
+achte auf Übertraining-Signale und priorisiere Gesundheit vor Performance.
+Antworte prägnant, freundlich und kompetent."""

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -15,7 +15,7 @@ from functools import partial
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.api_key_resolver import resolve_claude_api_key
+from app.core.api_key_resolver import resolve_ai_config
 from app.infrastructure.ai.ai_service import ai_service
 from app.infrastructure.database.models import ChatConversationModel, ChatMessageModel
 from app.models.chat import (
@@ -81,10 +81,10 @@ async def send_message(
     api_messages = [{"role": m.role, "content": m.content} for m in history]
 
     # 6. AI-Anfrage
-    api_key = await resolve_claude_api_key(db, user_id)
+    api_key, preferred_provider = await resolve_ai_config(db, user_id)
     start = time.monotonic()
     response_text, provider_name = await ai_service.chat_multi_turn(
-        api_messages, system_prompt, api_key
+        api_messages, system_prompt, api_key, provider_name=preferred_provider
     )
     duration_ms = int((time.monotonic() - start) * 1000)
 
@@ -162,10 +162,15 @@ async def prepare_stream_with_tools(
     system_prompt = await build_chat_system_prompt()
     api_messages = [{"role": m.role, "content": m.content} for m in history]
 
-    api_key = await resolve_claude_api_key(db, user_id)
+    api_key, preferred_provider = await resolve_ai_config(db, user_id)
     tool_handler = partial(dispatch_tool, db=db, user_id=user_id)
     stream, provider_name = await ai_service.stream_chat_with_tools(
-        api_messages, system_prompt, CHAT_TOOLS, tool_handler, api_key
+        api_messages,
+        system_prompt,
+        CHAT_TOOLS,
+        tool_handler,
+        api_key,
+        provider_name=preferred_provider,
     )
 
     ctx = StreamContext(

--- a/backend/app/services/recommendation_service.py
+++ b/backend/app/services/recommendation_service.py
@@ -14,7 +14,7 @@ from datetime import date, datetime, timedelta
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.api_key_resolver import resolve_claude_api_key
+from app.core.api_key_resolver import resolve_ai_config
 from app.infrastructure.ai.ai_service import ai_service
 from app.infrastructure.database.models import (
     AIRecommendationModel,
@@ -82,12 +82,14 @@ async def generate_recommendations(
     # Prompt bauen und AI aufrufen
     prompt = _build_recommendation_prompt(context)
     system_prompt = _build_system_prompt(context)
-    api_key = await resolve_claude_api_key(db, user_id)
+    api_key, provider_name = await resolve_ai_config(db, user_id)
 
     t0 = time.monotonic()
-    raw = await ai_service.chat(prompt, {"system_prompt": system_prompt}, api_key)
+    raw = await ai_service.chat(
+        prompt, {"system_prompt": system_prompt}, api_key, provider_name=provider_name
+    )
     duration_ms = int((time.monotonic() - t0) * 1000)
-    provider = ai_service.get_active_provider() or "unknown"
+    provider = provider_name
 
     # Parsen
     parsed = _parse_recommendations_json(raw)

--- a/backend/app/services/recommendation_to_plan_service.py
+++ b/backend/app/services/recommendation_to_plan_service.py
@@ -15,7 +15,7 @@ from datetime import date, datetime, timedelta
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.api_key_resolver import resolve_claude_api_key
+from app.core.api_key_resolver import resolve_ai_config
 from app.infrastructure.ai.ai_service import ai_service
 from app.infrastructure.database.models import (
     PlanChangeLogModel,
@@ -63,12 +63,14 @@ async def apply_recommendations(
     # Prompt bauen und KI aufrufen
     system_prompt = _build_system_prompt(race_goal, target_week)
     user_prompt = _build_user_prompt(recommendations, existing_plan, templates)
-    api_key = await resolve_claude_api_key(db, user_id)
+    api_key, provider_name = await resolve_ai_config(db, user_id)
 
     t0 = time.monotonic()
-    raw = await ai_service.chat(user_prompt, {"system_prompt": system_prompt}, api_key)
+    raw = await ai_service.chat(
+        user_prompt, {"system_prompt": system_prompt}, api_key, provider_name=provider_name
+    )
     duration_ms = int((time.monotonic() - t0) * 1000)
-    provider = ai_service.get_active_provider() or "unknown"
+    provider = provider_name
 
     # KI-Antwort parsen → vollständiger 7-Tage-Plan
     ai_days = _parse_plan(raw)

--- a/backend/app/services/session_analysis_service.py
+++ b/backend/app/services/session_analysis_service.py
@@ -15,7 +15,7 @@ from datetime import datetime, timedelta
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.api_key_resolver import resolve_claude_api_key
+from app.core.api_key_resolver import resolve_ai_config
 from app.infrastructure.ai.ai_service import ai_service
 from app.infrastructure.database.models import (
     AthleteModel,
@@ -57,12 +57,14 @@ async def analyze_session(
     context = await _load_analysis_context(workout, db)
     prompt = _build_analysis_prompt(workout, context)
     system_prompt = _build_system_prompt(context)
-    api_key = await resolve_claude_api_key(db, user_id)
+    api_key, provider_name = await resolve_ai_config(db, user_id)
 
     t0 = time.monotonic()
-    raw = await ai_service.chat(prompt, {"system_prompt": system_prompt}, api_key)
+    raw = await ai_service.chat(
+        prompt, {"system_prompt": system_prompt}, api_key, provider_name=provider_name
+    )
     duration_ms = int((time.monotonic() - t0) * 1000)
-    provider = ai_service.get_active_provider() or "unknown"
+    provider = provider_name
 
     # Parsen + Cache speichern + Log schreiben
     analysis = _parse_analysis_json(raw, session_id, provider)
@@ -753,12 +755,14 @@ async def analyze_race_session(
     context = await _load_analysis_context(workout, db)
     prompt = _build_race_prompt(workout, context, race_report)
     system_prompt = _build_system_prompt(context)
-    api_key = await resolve_claude_api_key(db, user_id)
+    api_key, provider_name = await resolve_ai_config(db, user_id)
 
     t0 = time.monotonic()
-    raw = await ai_service.chat(prompt, {"system_prompt": system_prompt}, api_key)
+    raw = await ai_service.chat(
+        prompt, {"system_prompt": system_prompt}, api_key, provider_name=provider_name
+    )
     duration_ms = int((time.monotonic() - t0) * 1000)
-    provider = ai_service.get_active_provider() or "unknown"
+    provider = provider_name
 
     analysis = _parse_race_analysis_json(raw, session_id, provider)
     await log_ai_call(

--- a/backend/app/services/weekly_review_service.py
+++ b/backend/app/services/weekly_review_service.py
@@ -14,7 +14,7 @@ from datetime import date, datetime, timedelta
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.api_key_resolver import resolve_claude_api_key
+from app.core.api_key_resolver import resolve_ai_config
 from app.infrastructure.ai.ai_service import ai_service
 from app.infrastructure.database.models import (
     RaceGoalModel,
@@ -71,12 +71,14 @@ async def generate_weekly_review(
     # Prompt bauen und AI aufrufen
     prompt = _build_review_prompt(context)
     system_prompt = _build_system_prompt(context)
-    api_key = await resolve_claude_api_key(db, user_id)
+    api_key, provider_name = await resolve_ai_config(db, user_id)
 
     t0 = time.monotonic()
-    raw = await ai_service.chat(prompt, {"system_prompt": system_prompt}, api_key)
+    raw = await ai_service.chat(
+        prompt, {"system_prompt": system_prompt}, api_key, provider_name=provider_name
+    )
     duration_ms = int((time.monotonic() - t0) * 1000)
-    provider = ai_service.get_active_provider() or "unknown"
+    provider = provider_name
 
     # Parsen
     parsed = _parse_review_json(raw, context)


### PR DESCRIPTION
## Summary

- Alle AI-Services riefen **hardcodiert** `resolve_claude_api_key()` auf → wenn User OpenAI gewählt hatte, wurde trotzdem Claude-Key gesucht → Fehler
- **Neue** `resolve_ai_config(db, user_id)` → gibt `(api_key, provider_name)` basierend auf User-Präferenz zurück
- **Neuer** OpenAIProvider (GPT Chat-Completion + Streaming)
- `AIService` akzeptiert `provider_name` Parameter für dynamische Auswahl pro Request

## Services umgestellt (5)

- chat_service (send_message + stream)
- session_analysis_service (analyze_session + analyze_race)
- recommendation_service
- weekly_review_service
- recommendation_to_plan_service

## Test plan

- [ ] Chat mit Claude funktioniert (User hat Claude-Key + preferred_provider='claude')
- [ ] Chat mit OpenAI funktioniert (User hat OpenAI-Key + preferred_provider='openai')
- [ ] `/ai/providers` zeigt User-spezifischen Status

Closes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)