### PR TITLE
fix: streamChatMessage fehlt Authorization-Header

### DIFF
--- a/frontend/src/api/chat.ts
+++ b/frontend/src/api/chat.ts
@@ -66,9 +66,14 @@ export async function streamChatMessage(
   signal?: AbortSignal,
 ): Promise<void> {
   const baseUrl = apiClient.defaults.baseURL ?? '';
+  const authHeader = apiClient.defaults.headers.common['Authorization'];
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (typeof authHeader === 'string') {
+    headers['Authorization'] = authHeader;
+  }
   const response = await fetch(`${baseUrl}/api/v1/ai/conversations/messages/stream`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers,
     body: JSON.stringify(params),
     signal,
   });


### PR DESCRIPTION
## Summary

- `streamChatMessage` nutzt `fetch()` direkt statt `apiClient` und setzt **keinen Authorization-Header**
- Deshalb gibt der Stream-Endpoint `/ai/conversations/messages/stream` seit Auth-Einführung 401 zurück
- Frontend zeigt: **"Nachricht konnte nicht gesendet werden"**
- Fix: Auth-Header aus `apiClient.defaults.headers.common` in die fetch()-Headers kopieren

Closes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)