### PR TITLE
fix: Wochenplan-Save crasht bei langen notes (#664)

### DIFF
--- a/backend/app/models/training_plan.py
+++ b/backend/app/models/training_plan.py
@@ -34,7 +34,7 @@ class PhaseWeeklyTemplateSessionEntry(BaseModel):
     run_type: Optional[str] = Field(default=None, pattern=SESSION_TYPE_REGEX)
     template_id: Optional[int] = None
     template_name: Optional[str] = None
-    notes: Optional[str] = Field(default=None, max_length=200)
+    notes: Optional[str] = Field(default=None, max_length=2000)
     run_details: Optional[RunDetails] = None
     exercises: Optional[list[TemplateExercise]] = None
 
@@ -45,7 +45,7 @@ class PhaseWeeklyTemplateDayEntry(BaseModel):
     day_of_week: int = Field(..., ge=0, le=6, description="0=Mon, 6=Sun")
     sessions: list[PhaseWeeklyTemplateSessionEntry] = Field(default_factory=list)
     is_rest_day: bool = False
-    notes: Optional[str] = Field(default=None, max_length=200)
+    notes: Optional[str] = Field(default=None, max_length=2000)
 
     # Legacy flat fields (backwards-compat for old JSON, excluded from serialization)
     training_type: Optional[str] = Field(default=None, pattern="^(strength|running)$", exclude=True)


### PR DESCRIPTION
## Problem
Beim Speichern des Wochenplans nach manueller Umsortierung + Hinzufügen eines Ruhetags (Sonntag) trat ein 500er auf:

\`\`\`
ValidationError: 1 validation error for PhaseWeeklyTemplateDayEntry
notes
  String should have at most 200 characters
  [type=string_too_long, input_value='Neuer Easy-Lauf am Sonnt...cher Anstrengung sinkt.']
\`\`\`

## Root Cause
- DB-Spalte \`weekly_plan_days.notes\` ist \`Text\` (unlimited)
- Pydantic-Schema \`PhaseWeeklyTemplateDayEntry.notes\` und \`PhaseWeeklyTemplateSessionEntry.notes\` hatten aber \`max_length=200\`
- Beim Auto-Sync (\`_auto_sync_week_to_plan\` → \`_build_phase_template_from_days\`) wird \`db_day.notes\` 1:1 in das Schema gepackt
- KI-generierte Begründungen (Claude/GPT) sind oft > 200 Zeichen → Crash

## Fix
\`max_length\` auf 2000 erhöht (konsistent mit \`TrainingPlan.description\` und \`TrainingPhase.notes\`).

## Test plan
- [ ] Deploy abwarten
- [ ] Wochenplan umsortieren + Ruhetag Sonntag → Save erfolgreich
- [ ] Training Plan zeigt den auto-synced Override korrekt an

Closes #664

🤖 Generated with [Claude Code](https://claude.com/claude-code)