### PR TITLE
fix: TodayPage <main> → <div> (#682) [v3]

### DIFF
--- a/frontend/src/pages/TodayPage.tsx
+++ b/frontend/src/pages/TodayPage.tsx
@@ -33,7 +33,7 @@ export function TodayPage() {
   }
 
   return (
-    <main className="p-4 pt-6 md:p-6 md:pt-8 max-w-5xl mx-auto space-y-4 pb-24">
+    <div className="p-4 pt-6 md:p-6 md:pt-8 max-w-5xl mx-auto space-y-4 pb-24">
       {/* Begrüßung */}
       <header className="pb-2">
         <h1 className="text-2xl font-bold text-[var(--color-text-base)]">{data.greeting}</h1>
@@ -54,7 +54,7 @@ export function TodayPage() {
 
       {/* Insights */}
       {data.insights.length > 0 && <InsightCards insights={data.insights} />}
-    </main>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Problem

AppLayout.tsx rendert `<main>` als Wrapper. TodayPage rendert ein zweites `<main>` → Playwright strict mode violation (`locator('main') resolved to 2 elements`).

**PR #683 und #684 hatten denselben Fix, aber der Squash-Merge hat jeweils den alten Feature-Branch statt des Fix-Branches gemergt** (weil `gh pr create` ohne `--head` aus dem Worktree lief).

## Änderung

`TodayPage.tsx`: `<main>` → `<div>` (Zeile 36/57)

## Test plan
- [ ] E2E Smoke Tests grün nach Merge
- [ ] Kein `strict mode violation` mehr

Fixes #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)