### PR TITLE
fix: E2E responsive Test — Home → Heute (#682)

### DIFF
--- a/e2e/smoke/responsive.spec.ts
+++ b/e2e/smoke/responsive.spec.ts
@@ -9,12 +9,12 @@ test.describe("Responsive Layout", () => {
 
     // BottomNav enthält die 5 Navigations-Links
     const bottomNav = page.locator("nav").filter({
-      has: page.getByRole("link", { name: "Home" }),
+      has: page.getByRole("link", { name: "Heute" }),
     });
     await expect(bottomNav).toBeVisible();
 
     // Alle 5 Nav-Items sichtbar
-    await expect(page.getByRole("link", { name: "Home" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Heute" })).toBeVisible();
     await expect(page.getByRole("link", { name: "Sessions" })).toBeVisible();
     await expect(page.getByRole("link", { name: "Plan" })).toBeVisible();
   });
@@ -62,7 +62,7 @@ test.describe("Responsive Layout", () => {
 
     // BottomNav hat class "lg:hidden" — auf Desktop nicht sichtbar
     const bottomNav = page.locator("nav").filter({
-      has: page.getByRole("link", { name: "Home" }),
+      has: page.getByRole("link", { name: "Heute" }),
     });
     await expect(bottomNav).not.toBeVisible();
   });


### PR DESCRIPTION
## Problem

`responsive.spec.ts` sucht nach BottomNav-Link `"Home"`, aber BottomNav wurde in #680 auf `"Heute"` umbenannt. Dieser Test wurde in den bisherigen Fix-PRs nicht aktualisiert.

## Änderung

3× `{ name: "Home" }` → `{ name: "Heute" }` in `e2e/smoke/responsive.spec.ts`

## Test plan
- [ ] E2E Smoke Tests komplett grün

Fixes #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)