### PR TITLE
fix: TRIMP Backfill bei App-Startup (#687)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,7 +25,39 @@ logger = logging.getLogger(__name__)
 async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     """Application lifespan: startup and shutdown events."""
     await init_db()
+    await _backfill_trimp_scores()
     yield
+
+
+async def _backfill_trimp_scores() -> None:
+    """Berechne TRIMP für Sessions ohne Score (nach Migration / neuen Algorithmen)."""
+    from sqlalchemy import select
+
+    from app.infrastructure.database.models import WorkoutModel
+    from app.infrastructure.database.session import async_session_maker
+    from app.services.fitness_score import calculate_trimp
+
+    async with async_session_maker() as db:
+        result = await db.execute(select(WorkoutModel).where(WorkoutModel.trimp_score.is_(None)))
+        sessions = list(result.scalars().all())
+        if not sessions:
+            return
+
+        count = 0
+        for session in sessions:
+            trimp = calculate_trimp(session)
+            if trimp > 0:
+                session.trimp_score = trimp
+                count += 1
+
+        if count > 0:
+            await db.commit()
+
+        import logging
+
+        logging.getLogger("uvicorn").info(
+            "TRIMP Backfill: %d/%d Sessions berechnet", count, len(sessions)
+        )
 
 
 app = FastAPI(


### PR DESCRIPTION
## Problem

22/23 Sessions in Produktion hatten `trimp_score = NULL` (vor dem TRIMP-Feature angelegt). Das ergab CTL=2.52 und Score=10 statt dem korrekten Score=59.

Nach manuellem `POST /fitness/recalculate` war der Score sofort korrekt.

## Lösung

TRIMP-Backfill im `lifespan` Startup: Alle Sessions ohne `trimp_score` werden automatisch nachberechnet. Passiert einmalig beim Container-Start, bevor Requests bedient werden.

## Test plan
- [ ] CI grün
- [ ] Nach Deploy: Score zeigt sinnvolle Werte (nicht 10)

Fixes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)