### PR TITLE
docs: Brand & Style Guide — minsaga (#700)

### DIFF
--- a/docs/BRAND_STYLE_GUIDE.md
+++ b/docs/BRAND_STYLE_GUIDE.md
@@ -1,0 +1,577 @@
+# Brand & Style Guide — minsaga
+
+> **Status:** Entwurf — wird schrittweise ergänzt
+> **Letzte Aktualisierung:** 2026-04-12
+
+---
+
+## 1. Name & Identität
+
+### App-Name
+
+**minsaga**
+
+Immer lowercase. Nie „MinSaga", nie „MINSAGA".
+
+Bisheriger Name: *Training Analyzer*
+
+### Herkunft des Namens
+
+**min** — nordisch/skandinavisch für „mein" — radikal persönlich.
+**saga** — eine Geschichte, eine Reise mit Anfang, Herausforderung und Fortschritt.
+
+Zusammen: **Meine Geschichte. Meine Reise.**
+
+### Für wen?
+
+Minsaga ist für den ambitionierten Läufer. Nicht den Gelegenheitsjogger, nicht den
+Profi — sondern den Menschen der sich Ziele setzt und sie ernsthaft verfolgt.
+Der einen Halbmarathon unter zwei Stunden laufen will. Der seinen ersten Marathon
+finisht. Der sich verbessern, verstehen und wachsen will.
+
+### Philosophie / Vision
+
+Von einem Daten-Verwaltungstool zu einem **persönlichen Trainingsbegleiter**, der
+proaktiv Erkenntnisse liefert und aus der Perspektive des Nutzers denkt — nicht
+aus der Datenbank.
+
+Minsaga begleitet den Läufer beim Erreichen seiner gesteckten Ziele. Training ist
+keine Abfolge von Einheiten — es ist eine Geschichte. Jeder Lauf, jeder harte Tag
+und jeder Durchbruch sind Kapitel dieser Saga.
+
+### Tagline / Claim
+
+> *„Jede Saga beginnt mit einem ersten Schritt."*
+
+Verwendet in leeren Zuständen, Onboarding, und als motivierendes Element wenn der
+Nutzer noch keine Daten hat.
+
+---
+
+## 2. Designprinzipien
+
+### Designsprache
+
+**Die Metapher: Berghütte & Nordlicht**
+
+minsaga fühlt sich an wie eine Berghütte nach einem langen Trail. Draußen war es
+kalt, anspruchsvoll, schön — drinnen ist es warm. Du kannst durchatmen. Jemand
+weiß was du geleistet hast.
+
+Und durch das Fenster leuchtet das Nordlicht — weit, lebendig, kraftvoll. Es ist
+die Energie die einen weitertreibt. Sky → Cyan → Indigo: dieser Gradient ist nicht
+nur Logo, er ist Markenpersönlichkeit. Er erscheint überall dort wo Aktion,
+Fortschritt und Vorwärtsbewegung sind.
+
+Diese Spannung — warme Stille als Basis, Nordlicht-Energie als Antrieb — ist die
+visuelle DNA von minsaga.
+
+**Vier visuelle Haltungen:**
+
+**1. Warm & still** — der Alltag der App. Warme Hintergründe (stone als Page,
+weiß als Card), ruhige Typografie, viel Luft. Der Läufer soll sich empfangen
+fühlen, nicht überwältigt.
+
+**2. Nordlicht-Energie** — der Gradient ist Markenpräsenz. Er erscheint auf
+primären Buttons, Progress-Elementen, aktiven Tab-Indikatoren und Highlights.
+Überall wo der Läufer voranschreitet, ist das Nordlicht sichtbar.
+
+**3. Feier** — wenn etwas wirklich Bedeutsames passiert, geht die App ganz aus
+sich heraus. Der Gradient flutet langsam den Screen, dann die Badge-Transformation,
+dann eine große Fraunces-Überschrift mit viel Raum drum herum. Still, warm,
+verdient. Kein Spektakel — ein echter Moment.
+
+**4. Nüchtern bei Daten, warm bei Kontext** — Metriken und Zahlen sind klar und
+präzise (DM Sans, ohne Schnörkel). Sobald eine Zahl eingeordnet wird, wechselt
+der Ton: Coach-Sprache, Fraunces für emotionale Momente, Nordlicht-Farbe für
+Fortschritt. Die App weiß wann sie Daten zeigt und wann sie spricht.
+
+**Coach, nicht Werkzeug** — Daten erscheinen immer mit Kontext. Nicht „CTL: 82"
+sondern „Du bist in voller Form." Der Läufer sieht nicht nur Zahlen — er versteht
+was sie bedeuten und was als nächstes kommt.
+
+**Was minsaga nicht ist:**
+- Kein Garmin — keine Datenwand ohne emotionalen Kontext
+- Kein Strava — kein sozialer Vergleich, keine externen Rankings. Nur Vergleich
+  mit dir selbst
+- Keine generische weiße Fitness-App
+
+---
+
+### Die fünf Säulen
+
+| Säule | Prinzip | Für minsaga |
+|---|---|---|
+| **Funktionalismus** | Jedes Element rechtfertigt seine Existenz | Keine dekorativen UI-Elemente — Daten sprechen für sich |
+| **Lagom** | Genau das richtige Maß | Nicht überladen, nicht karg — progressive Disclosure |
+| **Hygge** | Warm und einladend | Die App fühlt sich wie ein Begleiter an, nicht wie ein Werkzeug |
+| **Demokratisk** | Für alle | WCAG 2.1 AA, Touch, Tastatur, jedes Gerät |
+| **Tidloeshet** | Zeitlos | Kein Trend-Chasing — in 5 Jahren noch gut |
+
+### Die Nordlig-Heuristik
+
+Bei jeder Designentscheidung diese fünf Fragen beantworten:
+
+1. **Ist es nötig?** — Kann ich es entfernen ohne Funktion zu verlieren?
+2. **Ist es ausgewogen?** — Stimmen Proportionen, Spacing, Farbverteilung?
+3. **Ist es einladend?** — Warm, zugänglich, genug Luft zum Atmen?
+4. **Ist es für alle?** — Touch, Tastatur, Screenreader, jedes Gerät?
+5. **Wird es bestehen?** — Zeitlos oder Trend? Sieht es in 5 Jahren noch gut aus?
+
+Wenn eine Frage mit *Nein* beantwortet wird, ist das Design nicht fertig.
+
+### Informationsdichte
+
+- **Progressive Disclosure** — nicht alles auf einmal. Erst das Wichtigste, Details auf Abruf.
+- **Max. 4–6 Metriken** auf einen Blick im Dashboard
+- **Skeleton Screens** statt Spinner für Ladezustände
+- **Empty States** immer gestaltet und erzählerisch — nie technisch leer
+
+---
+
+## 3. Logo
+
+### Finales Konzept: Berg & Trail
+
+Das Logo zeigt zwei Berggipfel die gemeinsam ein **M** formen, mit einem
+geschwungenen Trail/Weg der ein **S** bildet — die Initialen **MS** für **minsaga**.
+
+Der Farbverlauf ist vom Nordlicht inspiriert und nutzt die drei Brand Colors:
+Sky Blue → Cyan → Indigo/Violet.
+
+### Bedeutung der visuellen Elemente
+
+| Element | Form | Bedeutung |
+|---|---|---|
+| Zwei Berggipfel | **M** | „M" — Min, der Läufer, das Ziel |
+| Geschwungener Trail | **S** | „S" — Saga, der Weg dorthin |
+| Nordlicht-Gradient | 3 Brand Colors | Weite, Natur, nordische Seele der Marke |
+
+### Wortmarke
+
+„minsaga" in einem gerundeten Sans-Serif, tiefes Navy. Einheitliches Gewicht
+(Medium/Semibold) — kein Bold/Regular-Split im Wortbild.
+
+### Logo Lockup (Horizontal)
+
+```
+[Icon]  minsaga
+```
+
+### App Icon
+
+Logo-Icon auf hellem Hintergrund. Kein dunkler Hintergrund für das Standard-Icon.
+
+### Größen
+
+| Größe | Verwendung |
+|---|---|
+| 125 × 125 | Store / Marketing |
+| 60 × 60 | Standard App Icon |
+| 44 × 44 | Header (In-App) |
+| 32 × 32 | Favicon |
+
+### Logo-Regeln
+
+- Nicht verzerren, nicht auf unruhigem Hintergrund
+- Mindestgröße: <!-- TODO -->
+- Schutzzone: <!-- TODO -->
+- Dateipfade: `minsaga-logo-final.png` (Worktree Root) — SVG ausstehend
+
+### Verworfene Konzepte
+
+| Konzept | Grund |
+|---|---|
+| Nordlicht-Bogen | Zu abstrakt, keine Buchstaben-Lesbarkeit |
+| Kontinuierliche Pulslinie | Zu nah an Fitness-Tracker-Klischee |
+| M-Letterform (geometrisch) | Zu generisch |
+| Medaille, Tropfen, Laufende Figur | Zu illustrativ, zu wenig eigenständig |
+
+---
+
+## 4. Farbsystem
+
+### Brand Colors
+
+Im Logo sichtbar als Nordlicht-Gradient (sky → cyan → indigo):
+
+| Token | Palette | Hex (500) | Rolle im Gradient |
+|---|---|---|---|
+| brand-1 | sky | `#0ea5e9` | Links / oben |
+| brand-2 | indigo | `#6366f1` | Rechts / unten |
+| brand-3 | cyan | `#06b6d4` | Mitte |
+
+### Funktionsfarben
+
+| Token | Palette | Hex (500) | Rolle |
+|---|---|---|---|
+| accent-1 | emerald | `#10b981` | Success |
+| accent-2 | amber | `#f59e0b` | Warning |
+| accent-3 | rose | `#f43f5e` | Error |
+| accent-4 | fuchsia | `#d946ef` | AI / Coach |
+| accent-5 | slate | `#64748b` | Info |
+
+**Fuchsia für den AI Coach:** Klar getrennt von allen anderen Systemfarben.
+Signalisiert sofort: das ist KI-generierter Inhalt.
+
+### Neutral Colors
+
+| Token | Palette | Hauptverwendung |
+|---|---|---|
+| neutral-1 | slate | Text, Borders, Icons |
+| neutral-2 | stone | Hintergrundflächen, Surfaces — alternativ weiß |
+
+Klare Hintergrund-Hierarchie:
+
+| Ebene | Farbe | Begründung |
+|---|---|---|
+| Page / App-Hintergrund | stone | Warmer Grundton, nie kalt oder steril |
+| Cards | weiß | Hebt sich sauber vom stone-Hintergrund ab |
+| Modals / Overlays | weiß | Maximale Klarheit im Fokus-Zustand |
+
+### Nicht in der Palette
+
+- ~~teal~~ — kein Bestandteil (ausstehend: aus Figma entfernen)
+- ~~red~~ — ersetzt durch rose (ausstehend: in Figma umbiegen)
+
+### Farbverwendung
+
+**70-20-10 Regel:**
+
+| Anteil | Farbe | Beispiel |
+|---|---|---|
+| 70 % | Neutral (stone/slate/weiß) | Hintergründe, Flächen, Text |
+| 20 % | Primär (brand-1/sky) | Aktionen, Links, Highlights |
+| 10 % | Akzent (Funktionsfarben) | Status, Badges, AI-Elemente |
+
+**Kontrast (WCAG):**
+- Body-Text: mind. 4,5:1 (WCAG AA) — Ziel 7:1 (AAA)
+- Große Texte / Icons: mind. 3:1
+
+**Warme Untertöne:**
+- Page-Hintergrund: stone (nie reines Weiß `#FFFFFF` für die App-Fläche)
+- Cards: reines Weiß — der Kontrast zum stone-Hintergrund ist gewollt
+- Text: nie reines Schwarz — slate-900 als dunkelster Wert
+
+**Farbe ist niemals einziger Informationsträger** — immer mit Icon, Text oder Form kombinieren (~8 % der Männer sind farbenblind).
+
+### Primärfarben (L3/L4 Tokens)
+
+| Rolle | Token (L3/L4) | Verwendung |
+|---|---|---|
+| Primary | `--color-text-primary` | Hauptaktionen, Links |
+| Primary Subtle | `--color-bg-primary-subtle` | Hintergründe, Badges |
+
+### Nordlicht-Gradient — Verwendungsregel
+
+Der Gradient (sky → cyan → indigo) ist Markenpersönlichkeit — er signalisiert
+Vorwärtsbewegung und Aktion. Gezielt eingesetzt, nie als Hintergrundtapete.
+
+| Verwendung | Gradient | Flat Brand Color |
+|---|---|---|
+| Primäre Buttons (CTA) | ✓ | — |
+| Progress-Ringe / Progress-Bars | ✓ | — |
+| Aktiver Tab-Indikator (Navigation) | ✓ | — |
+| Level-Up / Feier-Moment (Vollbild) | ✓ | — |
+| Logo | ✓ | — |
+| Links, sekundäre Aktionen | — | sky |
+| Badges, Highlights | — | sky / indigo |
+| Icons (aktiver Zustand) | — | sky |
+| Text | — | — |
+| Borders | — | — |
+| Backgrounds (Ausnahme: Level-Up) | — | — |
+
+### Token-Regel (PFLICHT)
+
+- **Nur Level-3/Level-4 Tokens** in der App verwenden
+- **NIEMALS** Level-1/Level-2 (`--color-primary-1-500` etc.)
+- **NIEMALS** hardcodierte Tailwind-Farben (`bg-gray-*`, `text-blue-*`)
+- Syntax: `bg-[var(--color-bg-base)]`, `text-[var(--color-text-primary)]`
+
+---
+
+## 5. Typografie
+
+### Schriftfamilien
+
+| Rolle | Font | Verwendung |
+|---|---|---|
+| Display / Headings | Fraunces | Große, emotionale Überschriften — Begrüßung, Hero, Empty States |
+| UI / Body | DM Sans | Alle UI-Elemente — Labels, Captions, Inputs, Badges, Metriken |
+| Mono | — | <!-- TODO --> |
+
+### Schriftgrößen
+
+Über Nordlig DS Tokens: `--font-size-xs` bis `--font-size-4xl`
+
+### Typografische Hierarchie
+
+| Rolle | Font | Stil | Beispiel |
+|---|---|---|---|
+| Display / Begrüßung | Fraunces | Bold, groß | „Guten Morgen." |
+| Heading | Fraunces | Semibold | „Guten Morgen, Nils." |
+| Subheading | DM Sans | Medium | „Deine Analyse." |
+| Body | DM Sans | Regular | Fließtext, Beschreibungen |
+| Labels / Captions | DM Sans | Regular, klein | Badges, Tabellenwerte |
+| Metriken / Zahlen | DM Sans | Bold, groß | „198", „78", „8.2" |
+
+### Typografische Regeln
+
+- **Max. 3 Schriftgewichte** pro Seite (Regular, Medium, Semibold/Bold)
+- **Body-Text** mind. 16px — kein kleinerer Text für Kerninformationen auf Mobile
+- **Zeilenhöhe Body:** 1,5–1,6× Schriftgröße
+- **Zeilenhöhe Headings:** 1,1–1,3× Schriftgröße
+- **Heading → Inhalt** enger als Inhalt → nächste Sektion (Heading gehört zu seinem Inhalt)
+
+---
+
+## 6. Spacing & Layout
+
+### Container
+
+- **Max-Breite:** `max-w-5xl` (alle Seiten)
+- **Container-Pattern:** `p-4 pt-6 md:p-6 md:pt-8 max-w-5xl mx-auto space-y-6`
+- **Header-Spacing:** Jede `<header>` braucht `pb-2`
+
+### Spacing-Tokens
+
+Über Nordlig DS: `--spacing-1` bis `--spacing-16`
+
+### Breakpoints (Mobile-First)
+
+| Breakpoint | Min-Width | Zielgerät |
+|---|---|---|
+| Default | 0px | iPhone SE (375px) |
+| `sm` | 640px | Große Phones |
+| `md` | 768px | Tablets |
+| `lg` | 1024px | Desktop |
+
+### Whitespace-Prinzipien
+
+Skandinavisches Design lebt von Luft. Wenige, bewusst platzierte Elemente mit
+viel Raum dazwischen — nicht vollgepackte Screens.
+
+| Regel | Wert | Begründung |
+|---|---|---|
+| Weißraumanteil | ~30–40 % einer Screenoberfläche | Gedrängte Layouts verletzen Lagom |
+| Grundraster | 8px (Vielfache von 4 oder 8) | Konsistente Rhythmik |
+| Zusammengehöriges | 8–16px Abstand | Nähe zeigt Zusammengehörigkeit |
+| Getrennte Sektionen | 32–64px Abstand | Klare visuelle Trennung |
+| Innen ≤ Außen | Padding ≤ Margin außerhalb | Elemente wirken als Einheit |
+| Header-Höhe | min. 48px (Mobile), 56px (Desktop) | Markenzeichen braucht Luft |
+
+**Leitfrage:** *Kann ich noch ein Element entfernen, ohne dass die Funktion leidet? Dann tue es.*
+
+---
+
+## 7. Form-Sprache
+
+### Radii
+
+Weiche Kanten, sanfte Formen — organisch, nie hartkantig.
+
+| Kontext | Radius | Token |
+|---|---|---|
+| Buttons, Inputs, Chips | 4–8px | `--radius-sm` |
+| Cards, Container | 8–16px | `--radius-md` |
+| Modale, Panels | 12–24px | `--radius-lg` |
+| Pill (Tags/Badges only) | 9999px | `rounded-full` |
+
+**Pill-Form nur für Tags/Badges** — nicht für primäre Aktionen (reduziert die wahrgenommene Klickfläche).
+
+### Schatten
+
+Weich, diffus, niedrige Opazität — wie Henningsens „menschliches Licht".
+Nie hart, nie übertrieben.
+
+| Ebene | Token/Prop | Verwendung |
+|---|---|---|
+| flat | `elevation="flat"` | Innere Cards, keine Elevation |
+| raised | `--shadow-sm` | Standard-Cards |
+| floating | `--shadow-md` | Modale, Dropdowns, FAB |
+
+- **Keine Card-on-Card Schatten** — innere Cards immer `elevation="flat"`
+- **Max. 2 Schattenebenen** auf einer Seite
+
+### Borders
+
+- **1px**, gedämpfte Farbe (`--color-border-muted`)
+- Keine 2px-Borders außer für den Fokus-Ring (Accessibility)
+
+### Icons
+
+- **Lucide React** — durchgehend konsistent, keine gemischten Icon-Libraries
+- Strichstärke **1,5–2px**, abgerundete Enden
+- Gleiche Größe pro Kontext: 16px in Badges, 20px in Buttons, 24px in Navigation
+
+---
+
+## 8. Komponenten-Regeln
+
+### Nordlig DS (PFLICHT)
+
+Alle UI-Primitives kommen aus `@nordlig/components`:
+- `Button`, `Input`, `Select`, `DatePicker`, `Card`, `Badge`, `Dialog`...
+- **KEINE** nativen HTML-Elemente (`<button>`, `<input>`, `<select>`)
+
+### Cards
+
+- Cards als primäre Strukturierung, nicht als Dekoration
+
+### Touch-Targets
+
+- Minimum **44×44px** für alle interaktiven Elemente
+- Mobile-First: Immer 375px zuerst
+
+### Navigation
+
+- **Breadcrumbs** statt ArrowLeft-Buttons
+- 5-Tab-Struktur: Heute | Training | Fortschritt | Plan | Bibliothek
+
+---
+
+## 9. Tonalität & Sprache
+
+### Grundton
+
+- Persönlich, warmherzig, motivierend
+- Duzend (nicht „Sie")
+- Deutsch mit korrekten Umlauten (ä, ö, ü, ß)
+- Klar und direkt — keine Füllwörter, keine Marketing-Floskeln
+- Nüchtern bei Daten, warm bei Kontext
+
+### Der AI Coach
+
+Der AI Coach ist kein Chatbot — er ist ein persönlicher Trainingsbegleiter.
+Er analysiert abgeschlossene Trainings, gibt konkretes Feedback, schlägt Pläne vor
+und passt diese kontinuierlich an. Er kennt die Ziele des Läufers und erinnert
+ihn daran wenn es darauf ankommt.
+
+**Ton des AI Coach:** Klar, direkt, motivierend — nie bevormundend.
+
+### Fitness-Level-Namen (Ausdauer)
+
+1. Erste Schritte
+2. Im Rhythmus
+3. Auf Kurs
+4. In voller Stärke
+5. Entfesselt
+6. Grenzenlos
+7. Legende
+
+### Fitness-Level-Namen (Kraft)
+
+1. Erste Wiederholung
+2. Im Aufbau
+3. Starke Basis
+4. Volle Kraft
+5. Unaufhaltsam
+
+### Empty States
+
+- Erzählerisch, nicht technisch
+- Beispiel: *„Jede Saga braucht ein Ziel."*
+- Beispiel: *„Jede Saga beginnt mit einem ersten Schritt."*
+
+---
+
+## 10. Fitness Level System
+
+> Vollständige Begründungen und Algorithmen: [FITNESS_LEVEL_SYSTEM_V2.md](FITNESS_LEVEL_SYSTEM_V2.md) · Epic [#694](https://github.com/NCS23/training-analyzer/issues/694)
+
+### Kernkonzept
+
+Der Score kommuniziert zwei Dinge: **„Wie gut ist meine Fitness?"** und **„Wie entwickle ich mich?"**. Goal Readiness (Ziel-Vorbereitung) ist eine dritte, separate Metrik.
+
+Das alte System (CTL / persönliches Maximum) wurde ersetzt weil der Score nach Trainingspausen schrumpft und 100 praktisch unerreichbar ist.
+
+### Level-System
+
+Score 0–100 = Position *innerhalb* des aktuellen Levels. Level-Grenzen sind populationsreferenziert (fix, nicht personal). Das persönliche Höchstlevel ist ein permanentes Achievement — es kann nicht verloren gehen.
+
+**Normalisierung:** `sqrt(CTL / 90) × 100` → auf Level-Grenzen gemappt
+
+**Hysterese:** Level-Up nach 7 Tagen über Schwelle · Level-Down nach 21 Tagen
+
+### Dashboard-Hierarchie
+
+```
+Guten Morgen, Nils.
+[AI Coach Subline — dynamisch, kontextabhängig]
+
+[Ziel-Card — primärer Eyecatcher]
+  Rennen · Zielzeit · Tage-Countdown
+  Goal Readiness % (Ring)
+  4 Komponenten: Fitness (CTL) / Langläufe / Tempoläufe / Konsistenz
+
+[Ausdauer Card]   Level 4 · In voller Stärke · Score 82
+[Kraft Card]      Level 2 · Im Aufbau · Score 54
+```
+
+### Goal Readiness
+
+CTL allein reicht nicht — es misst Volumen, nicht Rennvorbereitung. Deshalb 4 Komponenten:
+
+| Komponente | Misst |
+|-----------|-------|
+| Fitness (CTL) | Trainingsvolumen-Basis |
+| Langläufe | Spezifische Ausdauer (≥18km Läufe) |
+| Tempoläufe | Pace-spezifische Vorbereitung |
+| Konsistenz | Trainingstage / 30 in letzten 42 Tagen |
+
+Schwacher Wert (<70%) wird orange hervorgehoben. AI Coach greift den schwächsten Wert direkt auf.
+
+### AI Coach Subline
+
+Dynamisch generiert, kontextabhängig — keine statische Zeile. Brückt zwischen Begrüßung und Dashboard-Content. Inputs: Tage bis Rennen, gestrige Session, Form (TSB), Trend.
+
+Beispiele:
+- *„Du bist auf dem richtigen Weg. Hier ist dein Stand."* (42 Tage, steigend)
+- *„Gestern hast du geliefert. Heute schaust du, wo du stehst."* (nach hartem Training)
+- *„7 Tage noch. Alles was du brauchst, hast du bereits."* (Rennwoche)
+
+### Empty State (kein Ziel gesetzt)
+
+> *„Jede Saga braucht ein Ziel.*
+> *Ein Rennen. Eine Zeit. Eine Distanz.*
+> *Setz den Horizont — wir zeigen dir den Weg dorthin."*
+
+### Level-Up Feier
+
+Nordlicht-Gradient flutet langsam den Screen, dann Badge-Transformation (alt → neu), dann große Fraunces-Überschrift mit Stat-Zusammenfassung („Es hat dich X Wochen und Y Einheiten gekostet"). Still, warm, verdient. `motion-reduce` wird respektiert.
+
+---
+
+## 11. Animationen & Micro-Interactions
+
+- **motion-reduce:** `motion-reduce:transition-none` auf ALLEN Animationen
+- Micro-Interactions (Color, Opacity): 150ms
+- Standard UI (Accordion, Hover): 200ms
+- Overlays (Modal, Sheet, Toast): 300ms
+- Easing: `ease-out` für Einblendungen, `ease-in-out` für Zustandswechsel
+- Subtile Übergänge: `duration-500` für Progress/Data
+- Keine dramatischen Animationen (`animate-bounce` → max `scale-105`)
+- **Level-Up:** Nordlicht-Gradient flutet langsam den Screen → Badge-Transformation → große Fraunces-Überschrift mit viel Raum. Still, warm, verdient — kein Spektakel
+
+---
+
+## 12. Referenzen
+
+- [REDESIGN_KONZEPT.md](REDESIGN_KONZEPT.md) — UX-Konzept & Informationsarchitektur
+- [DESIGN_REVIEW.md](DESIGN_REVIEW.md) — UX-Review-Checkliste
+- [PROJEKT_REGELN.md](PROJEKT_REGELN.md) — Technische Regeln
+- [CLEAN_CODE.md](CLEAN_CODE.md) — Code-Qualität
+- [FITNESS_LEVEL_SYSTEM_V2.md](FITNESS_LEVEL_SYSTEM_V2.md) — Konzept, Designentscheidungen & Algorithmus-Begründungen
+- Nordlig DS Storybook: http://storybook.89.167.78.223.sslip.io
+- Nordlig DS Designprinzipien: `nordlig-design-system/DESIGN_PRINCIPLES.md`
+- Fitness Level System: GitHub Epic #694
+
+---
+
+## Offene Punkte
+
+- [ ] `teal/50…950` aus Figma (Color Core + Minsaga) entfernen
+- [ ] `red/50…950` in Figma durch `rose/50…950` ersetzen, accent-3 umbiegen
+- [ ] Logo als SVG exportieren und in `/assets/` ablegen
+- [ ] Logo-Mindestgröße und Schutzzone definieren
+- [ ] Mono-Schrift definieren


### PR DESCRIPTION
## Summary

- Erstellt vollständigen Brand & Style Guide (`docs/BRAND_STYLE_GUIDE.md`)
- Designsprache: Berghütte & Nordlicht Metapher als visuelle DNA
- Nordlicht-Gradient Verwendungsregel (wo Gradient, wo flat brand color)
- stone/weiß Hintergrund-Hierarchie dokumentiert
- Form-Sprache: Radii, Schatten, Borders, Icons
- Whitespace-Prinzipien mit 8px Grundraster
- „Nüchtern bei Daten, warm bei Kontext" als vierte visuelle Haltung

## Test plan

- [ ] Dokument auf Konsistenz geprüft (keine Widersprüche)
- [ ] Designsprache beschreibt moderne, nordische, persönliche und emotionale App
- [ ] Alle offenen Punkte in „Offene Punkte" Section dokumentiert

🤖 Generated with [Claude Code](https://claude.com/claude-code)