### PR TITLE
fix(hooks): pre-push-Hook erkennt Worktree-Branches korrekt (#753)

### DIFF
--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -38,7 +38,11 @@ if check_bypass; then
 fi
 
 # --- Get current branch ---
-BRANCH=$(git -C "$PROJECT_ROOT" branch --show-current 2>/dev/null || echo "unknown")
+# Use the working directory of the push (not $PROJECT_ROOT). When the user pushes
+# from a worktree, the worktree's branch is what's actually being pushed — not
+# the branch checked out in the main repo. Hardcoding $PROJECT_ROOT would falsely
+# block worktree pushes whenever the main repo happens to sit on a merged branch.
+BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
 
 if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
   cat <<EOF


### PR DESCRIPTION
## Summary

Der pre-push-Hook nutzte `git -C "$PROJECT_ROOT"` mit hardcoded Pfad auf das Hauptverzeichnis. Beim Push aus einem Worktree prüfte er dadurch den **falschen** Branch — nämlich den des Hauptverzeichnisses, nicht den tatsächlich gepushten Worktree-Branch.

Stand das Hauptverzeichnis zufällig auf einem Branch mit gemergtem PR (was nach jedem Doc-Branch-Merge der Fall ist), blockierte der Hook **jeden Worktree-Push** mit *„Branch hat bereits gemergten PR"* — auch wenn der Worktree-Branch frisch und unbeteiligt war.

Closes #753.

## Fix

Eine Zeile: `git -C "$PROJECT_ROOT" branch --show-current` → `git branch --show-current`. Damit nutzt der Hook den Working Directory des git-push-Aufrufs, der bei einem Worktree-Push korrekterweise der Worktree-Pfad ist.

## Test plan

- [x] Push aus Worktree mit frischem Branch funktioniert auch wenn Hauptverzeichnis auf gemergtem Branch steht — verifiziert (dieser PR wurde aus genau dieser Konstellation gepusht: Hauptrepo auf `docs/751-ai-presence-concept` neu erstellt, Worktree auf `fix/753-pre-push-hook-worktree`)
- [ ] Push-Block für tatsächlich gemergte Branches funktioniert weiterhin (manuelle Verifikation nach Merge)
- [ ] Push-Block auf `main`/`master` funktioniert weiterhin (manuelle Verifikation nach Merge)

## Hinweis

Der gleiche Bug-Pattern (`git -C "$PROJECT_ROOT"` statt CWD) könnte in weiteren Hooks (`track-qa-gates.sh`, `pre-commit-gate.sh`) auch vorkommen. Dieser PR fixt nur den gemeldeten Fall (pre-push). Falls weitere Hooks dasselbe Problem zeigen, wäre ein Folge-Issue sinnvoll.