### PR TITLE
fix(auth): Stream-Endpoint umgeht Auth nicht mehr + Login-Redirect (#765)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -40,7 +40,9 @@ class Settings(BaseSettings):
     # Security / JWT
     secret_key: str = "dev-secret-key-change-in-production"
     algorithm: str = "HS256"
-    access_token_expire_minutes: int = 15
+    # 60 min: balance zwischen Sicherheit und UX (Mobile Streaming, lange Sessions);
+    # bei 401 wird ohnehin transparent ueber den Refresh-Token erneuert (#765).
+    access_token_expire_minutes: int = 60
     refresh_token_expire_days: int = 30
 
     # OAuth

--- a/frontend/src/api/chat.test.ts
+++ b/frontend/src/api/chat.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock client.ts BEFORE importing chat.ts so the named imports
+// resolve to mocks. apiClient is also referenced for baseURL.
+vi.mock('./client', () => {
+  return {
+    apiClient: { defaults: { baseURL: 'http://test' } },
+    getAccessToken: vi.fn(),
+    refreshAccessTokenOrRedirect: vi.fn(),
+    clearTokensAndRedirectToLogin: vi.fn(),
+  };
+});
+
+import { streamChatMessage } from './chat';
+import {
+  clearTokensAndRedirectToLogin,
+  getAccessToken,
+  refreshAccessTokenOrRedirect,
+} from './client';
+
+function makeStreamResponse(status: number, body = ''): Response {
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(body));
+      controller.close();
+    },
+  });
+  return new Response(stream, { status });
+}
+
+describe('streamChatMessage — Auth + Refresh-Retry (#765)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.mocked(getAccessToken).mockReset();
+    vi.mocked(refreshAccessTokenOrRedirect).mockReset();
+    vi.mocked(clearTokensAndRedirectToLogin).mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('sends Authorization header from getAccessToken (no longer relies on apiClient defaults)', async () => {
+    vi.mocked(getAccessToken).mockReturnValue('initial-token');
+    fetchMock.mockResolvedValueOnce(makeStreamResponse(200, 'data: {"type":"done"}\n'));
+
+    await streamChatMessage({ message: 'hi' }, () => {});
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init as RequestInit).headers).toMatchObject({
+      Authorization: 'Bearer initial-token',
+    });
+  });
+
+  it('on 401 refreshes token once and retries with new token', async () => {
+    vi.mocked(getAccessToken).mockReturnValue('expired-token');
+    vi.mocked(refreshAccessTokenOrRedirect).mockResolvedValueOnce('fresh-token');
+    fetchMock
+      .mockResolvedValueOnce(makeStreamResponse(401))
+      .mockResolvedValueOnce(makeStreamResponse(200, 'data: {"type":"done"}\n'));
+
+    const events: unknown[] = [];
+    await streamChatMessage({ message: 'hi' }, (e) => events.push(e));
+
+    expect(refreshAccessTokenOrRedirect).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [, retryInit] = fetchMock.mock.calls[1];
+    expect((retryInit as RequestInit).headers).toMatchObject({
+      Authorization: 'Bearer fresh-token',
+    });
+    expect(events).toEqual([{ type: 'done' }]);
+  });
+
+  it('on persistent 401 after refresh, clears tokens and redirects', async () => {
+    vi.mocked(getAccessToken).mockReturnValue('expired-token');
+    vi.mocked(refreshAccessTokenOrRedirect).mockResolvedValueOnce('fresh-token');
+    fetchMock
+      .mockResolvedValueOnce(makeStreamResponse(401))
+      .mockResolvedValueOnce(makeStreamResponse(401));
+
+    await expect(streamChatMessage({ message: 'hi' }, () => {})).rejects.toThrow(/401/);
+    expect(clearTokensAndRedirectToLogin).toHaveBeenCalledTimes(1);
+  });
+
+  it('on refresh failure, propagates error (refresh helper itself redirects)', async () => {
+    vi.mocked(getAccessToken).mockReturnValue('expired-token');
+    vi.mocked(refreshAccessTokenOrRedirect).mockRejectedValueOnce(new Error('No refresh token'));
+    fetchMock.mockResolvedValueOnce(makeStreamResponse(401));
+
+    await expect(streamChatMessage({ message: 'hi' }, () => {})).rejects.toThrow(
+      /No refresh token/,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('parses multiple data: events from the stream body', async () => {
+    vi.mocked(getAccessToken).mockReturnValue('t');
+    fetchMock.mockResolvedValueOnce(
+      makeStreamResponse(
+        200,
+        'data: {"type":"start"}\ndata: {"type":"token","content":"Hi"}\ndata: {"type":"done"}\n',
+      ),
+    );
+
+    const events: unknown[] = [];
+    await streamChatMessage({ message: 'hi' }, (e) => events.push(e));
+    expect(events).toEqual([{ type: 'start' }, { type: 'token', content: 'Hi' }, { type: 'done' }]);
+  });
+});

--- a/frontend/src/api/chat.ts
+++ b/frontend/src/api/chat.ts
@@ -1,4 +1,9 @@
-import { apiClient } from './client';
+import {
+  apiClient,
+  clearTokensAndRedirectToLogin,
+  getAccessToken,
+  refreshAccessTokenOrRedirect,
+} from './client';
 
 // --- Types ---
 
@@ -65,23 +70,72 @@ export async function streamChatMessage(
   onEvent: (event: StreamEvent) => void,
   signal?: AbortSignal,
 ): Promise<void> {
+  const response = await sendStreamRequest(params, signal);
+  await consumeEventStream(response, onEvent);
+}
+
+/**
+ * POSTet den Stream-Request mit aktuellem Access-Token.
+ * Bei 401 wird einmal automatisch refresht und retried — analog zum
+ * Axios-Response-Interceptor in client.ts. Bei Refresh-Fehler greift
+ * clearTokensAndRedirectToLogin und navigiert zu /login.
+ */
+async function sendStreamRequest(
+  params: ChatMessageRequest,
+  signal?: AbortSignal,
+): Promise<Response> {
   const baseUrl = apiClient.defaults.baseURL ?? '';
-  const authHeader = apiClient.defaults.headers.common['Authorization'];
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-  if (typeof authHeader === 'string') {
-    headers['Authorization'] = authHeader;
-  }
-  const response = await fetch(`${baseUrl}/api/v1/ai/conversations/messages/stream`, {
+  const url = `${baseUrl}/api/v1/ai/conversations/messages/stream`;
+  const body = JSON.stringify(params);
+
+  const firstResponse = await fetch(url, {
     method: 'POST',
-    headers,
-    body: JSON.stringify(params),
+    headers: buildStreamHeaders(getAccessToken()),
+    body,
     signal,
   });
 
-  if (!response.ok || !response.body) {
-    throw new Error(`Stream-Fehler: ${response.status}`);
+  if (firstResponse.status !== 401) {
+    if (!firstResponse.ok || !firstResponse.body) {
+      throw new Error(`Stream-Fehler: ${firstResponse.status}`);
+    }
+    return firstResponse;
   }
 
+  // 401 → einmal refresh + retry
+  const newToken = await refreshAccessTokenOrRedirect();
+  const retryResponse = await fetch(url, {
+    method: 'POST',
+    headers: buildStreamHeaders(newToken),
+    body,
+    signal,
+  });
+
+  if (retryResponse.status === 401) {
+    clearTokensAndRedirectToLogin();
+    throw new Error('Stream-Fehler: 401 nach Token-Refresh');
+  }
+  if (!retryResponse.ok || !retryResponse.body) {
+    throw new Error(`Stream-Fehler: ${retryResponse.status}`);
+  }
+  return retryResponse;
+}
+
+function buildStreamHeaders(token: string | null): Record<string, string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+async function consumeEventStream(
+  response: Response,
+  onEvent: (event: StreamEvent) => void,
+): Promise<void> {
+  if (!response.body) {
+    throw new Error('Stream-Fehler: kein Response-Body');
+  }
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
   let buffer = '';

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2,6 +2,8 @@ import axios from 'axios';
 import type { AxiosError, InternalAxiosRequestConfig } from 'axios';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || '';
+const ACCESS_TOKEN_KEY = 'ta_access_token';
+const REFRESH_TOKEN_KEY = 'ta_refresh_token';
 
 export const apiClient = axios.create({
   baseURL: API_BASE_URL,
@@ -10,9 +12,52 @@ export const apiClient = axios.create({
   },
 });
 
+/** Aktuelles Access-Token aus localStorage, oder null. */
+export function getAccessToken(): string | null {
+  return localStorage.getItem(ACCESS_TOKEN_KEY);
+}
+
+/** Tokens loeschen und zum Login navigieren — bei abgelaufenem Refresh-Token. */
+export function clearTokensAndRedirectToLogin(): void {
+  localStorage.removeItem(ACCESS_TOKEN_KEY);
+  localStorage.removeItem(REFRESH_TOKEN_KEY);
+  if (typeof window !== 'undefined' && window.location.pathname !== '/login') {
+    window.location.href = '/login';
+  }
+}
+
+/**
+ * Erzwingt einen Token-Refresh und gibt das neue Access-Token zurueck.
+ * Wird sowohl vom Response-Interceptor (Axios-Calls) als auch von
+ * streamChatMessage (nativer fetch-Call) genutzt.
+ *
+ * Wirft, wenn kein Refresh-Token da ist oder der Refresh fehlschlaegt.
+ * Beide Faelle loesen den Login-Redirect aus.
+ */
+export async function refreshAccessTokenOrRedirect(): Promise<string> {
+  const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY);
+  if (!refreshToken) {
+    clearTokensAndRedirectToLogin();
+    throw new Error('No refresh token');
+  }
+  try {
+    const resp = await apiClient.post('/api/v1/auth/refresh', { refresh_token: refreshToken });
+    const { access_token, refresh_token } = resp.data as {
+      access_token: string;
+      refresh_token: string;
+    };
+    localStorage.setItem(ACCESS_TOKEN_KEY, access_token);
+    localStorage.setItem(REFRESH_TOKEN_KEY, refresh_token);
+    return access_token;
+  } catch (err) {
+    clearTokensAndRedirectToLogin();
+    throw err;
+  }
+}
+
 // Request interceptor: Authorization Header
 apiClient.interceptors.request.use((config) => {
-  const token = localStorage.getItem('ta_access_token');
+  const token = getAccessToken();
   if (token && config.headers) {
     config.headers.Authorization = `Bearer ${token}`;
   }
@@ -67,25 +112,13 @@ async function attemptTokenRefresh(
   originalRequest._retry = true;
   isRefreshing = true;
 
-  const refreshToken = localStorage.getItem('ta_refresh_token');
-  if (!refreshToken) {
-    isRefreshing = false;
-    processQueue(new Error('No refresh token'), null);
-    return Promise.reject(new Error('No refresh token'));
-  }
-
   try {
-    const resp = await apiClient.post('/api/v1/auth/refresh', { refresh_token: refreshToken });
-    const { access_token, refresh_token } = resp.data;
-    localStorage.setItem('ta_access_token', access_token);
-    localStorage.setItem('ta_refresh_token', refresh_token);
-    originalRequest.headers.Authorization = `Bearer ${access_token}`;
-    processQueue(null, access_token);
+    const accessToken = await refreshAccessTokenOrRedirect();
+    originalRequest.headers.Authorization = `Bearer ${accessToken}`;
+    processQueue(null, accessToken);
     return apiClient(originalRequest);
   } catch (refreshError) {
     processQueue(refreshError, null);
-    localStorage.removeItem('ta_access_token');
-    localStorage.removeItem('ta_refresh_token');
     return Promise.reject(refreshError);
   } finally {
     isRefreshing = false;


### PR DESCRIPTION
Closes #765

## Problem

Trotz vorhandenem Auto-Refresh-Interceptor in `apiClient` lief der KI-Chat auf Mobile nach 15 min Token-Lifetime in 401-Endlosschleifen.

**Root Cause #1:** `streamChatMessage` umging den apiClient komplett — natives `fetch()` und las `apiClient.defaults.headers.common['Authorization']`, das aber nie gesetzt ist (das Token wird vom Request-Interceptor pro-Request angehängt). → Stream-Calls hatten praktisch nie ein gültiges Token.

**Root Cause #2:** Bei Refresh-Failure blieb der User mit Console-Error stranden statt zum Login navigiert zu werden.

## Fix

**S1 — `streamChatMessage` richtig auth'en**
- Sendet Authorization-Header aus `localStorage` via `getAccessToken()`
- Bei 401: einmalig refreshen + retry
- Bei Persistenz-401 nach Refresh: Login-Redirect

**S2 — Auth-Failure UX**
- Neue Helper in `client.ts`: `getAccessToken`, `refreshAccessTokenOrRedirect`, `clearTokensAndRedirectToLogin` (DRY für Axios- und Fetch-Pfad)
- Refresh-Fehler navigiert IMMER zu `/login` statt nur Console-Error
- `attemptTokenRefresh` umgestellt auf den neuen Helper — gleiches Verhalten für alle Endpoints

**S3 — Token-Lifetime**
- `access_token_expire_minutes`: 15 → 60 (15 min war für Trainings-App sehr aggressiv)
- Refresh greift weiterhin transparent

## Tests

5 neue Vitest-Tests für `streamChatMessage`:
- Auth-Header aus `getAccessToken`
- Refresh-Retry bei 401
- Login-Redirect bei Persistenz-401
- Error-Propagation bei Refresh-Failure
- Multi-Event-Parsing aus Stream-Body

## Test plan

- [x] Vitest: 196 grün (inkl. 5 neue)
- [x] Pytest: 1319 grün
- [x] ESLint, Prettier, TSC, Ruff, Mypy: clean
- [ ] Smoke nach Deploy: Mobile → Chat → Token >60 min ablaufen lassen → nächste Nachricht sollte transparent durchgehen (Refresh im Hintergrund), bei abgelaufenem Refresh-Token landet User auf `/login`

## Refs
- #761 / PR #762 — System-Prompt-Fix
- #763 / PR #764 — Mobile-Logout-Button

🤖 Generated with [Claude Code](https://claude.com/claude-code)