### PR TITLE
fix(auth): Tokens auch in flachem ta_access_token Key persistieren (#767)

### DIFF
--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -54,13 +54,21 @@ interface AuthState {
   isAdmin: boolean;
 }
 
-/** Setzt Tokens im Store und im API-Client. */
+/** Setzt Tokens im Store, im API-Client UND im flachen localStorage-Key.
+ *
+ * Der flache `ta_access_token`-Key wird vom Request-Interceptor
+ * (`apiClient.interceptors.request.use`) UND vom Stream-Auth-Pfad
+ * (`streamChatMessage`) gelesen. Ohne diesen Key sendet der Stream
+ * keinen Authorization-Header und es gibt 401 (#765 Folge-Fix).
+ */
 function applyTokens(
   set: (state: Partial<AuthState>) => void,
   tokens: { access_token: string; refresh_token: string },
 ) {
   set({ accessToken: tokens.access_token, refreshToken: tokens.refresh_token });
   apiClient.defaults.headers.common['Authorization'] = `Bearer ${tokens.access_token}`;
+  localStorage.setItem('ta_access_token', tokens.access_token);
+  localStorage.setItem('ta_refresh_token', tokens.refresh_token);
 }
 
 /** Laedt den User und setzt den authentifizierten Zustand. */
@@ -82,6 +90,7 @@ async function tryAccessToken(
 ): Promise<boolean> {
   if (!accessToken) return false;
   apiClient.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
+  localStorage.setItem('ta_access_token', accessToken);
   try {
     await loadUserAndSetState(set);
     return true;
@@ -102,6 +111,8 @@ function clearAuthState(set: (state: Partial<AuthState>) => void) {
     isAdmin: false,
   });
   delete apiClient.defaults.headers.common['Authorization'];
+  localStorage.removeItem('ta_access_token');
+  localStorage.removeItem('ta_refresh_token');
 }
 
 export const useAuth = create<AuthState>()(
@@ -222,7 +233,15 @@ export const useAuth = create<AuthState>()(
         refreshToken: state.refreshToken,
       }),
       onRehydrateStorage: () => {
-        return () => {
+        return (state) => {
+          // Tokens nach Rehydrierung auch in flachen localStorage-Key syncen,
+          // damit Request-Interceptor und Stream-Auth-Pfad sie finden.
+          if (state?.accessToken) {
+            localStorage.setItem('ta_access_token', state.accessToken);
+          }
+          if (state?.refreshToken) {
+            localStorage.setItem('ta_refresh_token', state.refreshToken);
+          }
           // Nach Rehydrierung: checkStatus automatisch auslösen
           void useAuth.getState().checkStatus();
         };


### PR DESCRIPTION
Closes #767

## Problem (Folge zu #765)

Apple Sign-In speicherte Tokens nur via Zustand persist (JSON-Object unter Key `training-analyzer-auth`) und im `apiClient.defaults.headers`. Der **Request-Interceptor** und der neue **Stream-Auth-Pfad** lasen aber den flachen Key `ta_access_token` — der nirgends gesetzt wurde.

Folgen:
- Apple-Sign-In-Sessions: nach Browser-Reload kein Token im Stream-Pfad → 401 → Refresh schlägt fehl (auch `ta_refresh_token` leer) → Login-Redirect
- Andere apiClient-Calls funktionierten zufällig nur weil `apiClient.defaults.headers` nach Apple Sign-In direkt gesetzt war — bis zum nächsten Reload

Aus Coolify-Log:
```
06:44:13 GET  /api/v1/auth/me              → 200  (Token im apiClient.defaults)
06:44:32 GET  /api/v1/ai/conversations/53  → 200
06:44:52 POST /api/v1/.../messages/stream  → 401  (Stream las ta_access_token = null)
06:44:52 → /login
```

## Fix

In `useAuth.ts`:
- `applyTokens()` schreibt zusätzlich `localStorage.setItem('ta_access_token'/'ta_refresh_token', ...)`
- `clearAuthState()` räumt beide flachen Keys auf
- `tryAccessToken()` (Re-use-Pfad) synct ebenfalls den flachen Key
- `onRehydrateStorage` synct nach Browser-Reload aus persist-State in den flachen Key

Zustand persist bleibt Source of Truth; flache Keys sind nur Cache für Request-Interceptor und Stream-Pfad.

## Test plan

- [x] Vitest: 196 grün, ESLint, Prettier, TSC: clean
- [ ] Smoke nach Deploy: iPhone → Login → Chat → Nachricht schicken → sollte Stream-Antwort kriegen, kein 401/404
- [ ] Browser-Reload → erneute Nachricht sollte ohne Re-Login funktionieren

Hinweis: useAuth-Unit-Test weggelassen (zustand persist + jsdom localStorage spielen in Vitest schlecht zusammen). Verhalten wird durch manuellen Smoke-Test verifiziert.

## Refs
- #765 / PR #766 — Stream-Auth + Refresh-Retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)