### PR TITLE
fix(auth): clearTokens räumt auch zustand-persist auf — fixt /login 404 (#769)

### DIFF
--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Install an in-memory localStorage BEFORE importing client.ts.
+// jsdom in this project's setup provides a partial Storage that doesn't
+// expose removeItem reliably under spies, so we replace it cleanly.
+const memoryStore = new Map<string, string>();
+const memoryStorage = {
+  getItem: (k: string) => memoryStore.get(k) ?? null,
+  setItem: (k: string, v: string) => {
+    memoryStore.set(k, v);
+  },
+  removeItem: (k: string) => {
+    memoryStore.delete(k);
+  },
+  clear: () => memoryStore.clear(),
+  key: (i: number) => Array.from(memoryStore.keys())[i] ?? null,
+  get length() {
+    return memoryStore.size;
+  },
+};
+Object.defineProperty(globalThis, 'localStorage', {
+  value: memoryStorage,
+  configurable: true,
+  writable: true,
+});
+
+import { clearTokensAndRedirectToLogin } from './client';
+
+describe('clearTokensAndRedirectToLogin (#769)', () => {
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    memoryStore.clear();
+    memoryStore.set('ta_access_token', 'a');
+    memoryStore.set('ta_refresh_token', 'r');
+    memoryStore.set('training-analyzer-auth', '{"state":{"accessToken":"a","refreshToken":"r"}}');
+    originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { pathname: '/chat', href: 'http://test/chat' },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    });
+    memoryStore.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('clears flat ta_access_token, ta_refresh_token AND zustand persist-store key', () => {
+    clearTokensAndRedirectToLogin();
+    expect(memoryStore.has('ta_access_token')).toBe(false);
+    expect(memoryStore.has('ta_refresh_token')).toBe(false);
+    // Critical for #769: without this, zustand rehydrates an invalid token
+    // and the user lands on /login → NotFoundPage instead of the login screen.
+    expect(memoryStore.has('training-analyzer-auth')).toBe(false);
+  });
+
+  it('navigates to /login when not already there', () => {
+    clearTokensAndRedirectToLogin();
+    expect((window.location as { href: string }).href).toBe('/login');
+  });
+
+  it('does not redirect when already on /login (avoids redirect loop)', () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { pathname: '/login', href: 'http://test/login' },
+    });
+    clearTokensAndRedirectToLogin();
+    expect((window.location as { href: string }).href).toBe('http://test/login');
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -4,6 +4,10 @@ import type { AxiosError, InternalAxiosRequestConfig } from 'axios';
 const API_BASE_URL = import.meta.env.VITE_API_URL || '';
 const ACCESS_TOKEN_KEY = 'ta_access_token';
 const REFRESH_TOKEN_KEY = 'ta_refresh_token';
+// Zustand persist-Storage-Key fuer den Auth-Store (siehe useAuth.ts:persist.name).
+// Wird beim Token-Cleanup mit-geloescht, damit Browser-Reload nicht stillschweigend
+// einen abgelaufenen/invaliden Token rehydratet (#769).
+const ZUSTAND_AUTH_KEY = 'training-analyzer-auth';
 
 export const apiClient = axios.create({
   baseURL: API_BASE_URL,
@@ -17,10 +21,20 @@ export function getAccessToken(): string | null {
   return localStorage.getItem(ACCESS_TOKEN_KEY);
 }
 
-/** Tokens loeschen und zum Login navigieren — bei abgelaufenem Refresh-Token. */
+/** Tokens loeschen und zum Login navigieren — bei abgelaufenem Refresh-Token.
+ *
+ * Loescht ALLE Auth-Storages: flache Keys (ta_access_token/ta_refresh_token)
+ * UND den zustand-persist-Store (training-analyzer-auth). Sonst wuerde der
+ * persist-Store beim naechsten Reload den Token rehydrieren und den
+ * onRehydrateStorage-Sync (#767) wuerde die geloeschten flachen Keys gleich
+ * wieder befuellen — der User waere stillschweigend "wieder eingeloggt"
+ * mit einem invaliden Token, und /login wuerde NotFound zeigen, weil
+ * AuthGuard isAuthenticated=true sieht (#769).
+ */
 export function clearTokensAndRedirectToLogin(): void {
   localStorage.removeItem(ACCESS_TOKEN_KEY);
   localStorage.removeItem(REFRESH_TOKEN_KEY);
+  localStorage.removeItem(ZUSTAND_AUTH_KEY);
   if (typeof window !== 'undefined' && window.location.pathname !== '/login') {
     window.location.href = '/login';
   }


### PR DESCRIPTION
Closes #769

## Bug

Nach jedem 401 vom Stream-Endpoint landete der User auf einer **404-NotFound-Page** statt auf dem Login-Screen — und konnte sich nicht mehr einloggen.

## Root Cause

Folge-Bug zu #765/#767. \`clearTokensAndRedirectToLogin\` löschte nur die flachen \`ta_access_token\`/\`ta_refresh_token\`. Aber Zustand persist speichert das Token zusätzlich unter dem JSON-Key \`training-analyzer-auth\`. Beim Page-Reload:

1. Zustand persist rehydratet → \`accessToken\`-State zurück
2. \`onRehydrateStorage\` (#767) synct den Token zurück in \`ta_access_token\` → hebt clearTokens auf
3. \`AuthGuard\` sieht \`isAuthenticated=true\` → rendert children
4. React Router hat keine \`/login\`-Route → matcht \`path="*"\` → NotFoundPage

## Fix

\`clearTokensAndRedirectToLogin\` löscht jetzt zusätzlich \`localStorage.removeItem('training-analyzer-auth')\`. Damit wird der zustand-persist-Store invalidiert und der nächste Reload landet sauber im Login.

## Test plan

- [x] Vitest: 199 grün (inkl. 3 neue für clearTokens), ESLint, Prettier, TSC clean
- [ ] Smoke nach Deploy: 401 vom Stream-Endpoint → User landet auf Login-Screen, nicht NotFound

## Refs
- #765 / PR #766 (Stream-Auth + Refresh-Retry)
- #767 / PR #768 (Token-Storage-Sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)