### PR TITLE
fix(chat): Plan-Erstellung bricht nicht mehr kommentarlos ab (#770)

### DIFF
--- a/backend/app/infrastructure/ai/providers/claude_provider.py
+++ b/backend/app/infrastructure/ai/providers/claude_provider.py
@@ -131,14 +131,22 @@ class ClaudeProvider(AIProvider):
         tool_handler: Any,
         api_key: str | None = None,
     ) -> AsyncIterator[dict]:
-        """Streamt Chat mit Tool Use. Yields dicts mit type: tool_call | token."""
+        """Streamt Chat mit Tool Use. Yields dicts mit type: tool_call | token.
+
+        max_tool_rounds (#770): Plan-Erstellung kann viele Rounds brauchen
+        (get_training_stats + get_personal_records + search_training_knowledge
+        + generate_training_plan + Follow-up-Korrekturen). Bei zu niedrigem
+        Limit brach der Stream frueher kommentarlos ab — jetzt 12 Rounds und
+        explizites error-Event wenn das Limit erreicht ist, damit der User
+        eine klare Fehlermeldung sieht statt eines stillen Abbruchs.
+        """
         client = self._get_async_client(api_key)
         api_messages: list[anthropic.types.MessageParam] = [
             {"role": m["role"], "content": m["content"]}
             for m in messages  # type: ignore[misc]
         ]
 
-        max_tool_rounds = 5
+        max_tool_rounds = 12
         for round_idx in range(max_tool_rounds):
             # Signal: Neuer API-Call startet (nach Tool-Verarbeitung)
             if round_idx > 0:
@@ -181,6 +189,21 @@ class ClaudeProvider(AIProvider):
                     )
 
             api_messages.append({"role": "user", "content": tool_results})  # type: ignore[arg-type,typeddict-item]
+
+        # Tool-Round-Limit erreicht ohne dass die KI fertig wurde —
+        # explizit signalisieren, sonst sieht der User einen stillen Abbruch.
+        logger.warning(
+            "stream_chat_with_tools: max_tool_rounds=%d erreicht ohne Abschluss",
+            max_tool_rounds,
+        )
+        yield {
+            "type": "error",
+            "message": (
+                f"Die KI hat das Tool-Limit ({max_tool_rounds} Runden) erreicht, ohne "
+                "fertig zu werden. Bitte formuliere die Anfrage konkreter oder teile "
+                "sie in mehrere Schritte auf."
+            ),
+        }
 
     def is_available(self, api_key: str | None = None) -> bool:
         """Prüft ob ein API Key vorhanden ist (kein teurer Test-Call)."""

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -230,6 +230,7 @@ async def stream_sse_events(
     yield f"data: {json.dumps({'type': 'start', 'conversation_id': ctx.conversation_id})}\n\n"
 
     full_response = ""
+    aborted_with_error = False
     try:
         async for event in stream:
             if event["type"] == "token":
@@ -239,9 +240,20 @@ async def stream_sse_events(
                 yield f"data: {json.dumps({'type': 'tool_call', 'name': event['name']})}\n\n"
             elif event["type"] == "thinking":
                 yield f"data: {json.dumps({'type': 'thinking'})}\n\n"
+            elif event["type"] == "error":
+                # Provider hat einen kontrollierten Fehler signalisiert
+                # (z.B. Tool-Round-Limit erreicht — siehe #770).
+                aborted_with_error = True
+                msg = event.get("message", "Stream abgebrochen")
+                yield f"data: {json.dumps({'type': 'error', 'message': msg})}\n\n"
     except Exception as e:
         logger.error("Streaming-Fehler: %s", e)
         yield f"data: {json.dumps({'type': 'error', 'message': str(e)})}\n\n"
+        return
+
+    if aborted_with_error:
+        # Bei kontrolliertem Abbruch keine done-Event und keine Persistierung —
+        # die Konversation wurde nicht erfolgreich beendet.
         return
 
     # Antwort persistieren

--- a/backend/app/tests/test_chat_stream_error_propagation.py
+++ b/backend/app/tests/test_chat_stream_error_propagation.py
@@ -1,0 +1,101 @@
+"""Tests for chat_service.stream_sse_events error propagation (#770).
+
+Stellt sicher, dass kontrollierte Provider-Fehler (z.B. max_tool_rounds
+erreicht) als 'error'-Event an den Client durchgereicht werden — statt
+einen stillen Abbruch zu erzeugen.
+"""
+
+import json
+from collections.abc import AsyncIterator
+from unittest.mock import patch
+
+import pytest
+
+
+def _events_from_payload(payload: str) -> list[dict]:
+    """Parst die SSE-Lines aus einem yield-Payload zu dict-Events."""
+    events: list[dict] = []
+    for line in payload.split("\n"):
+        line = line.strip()
+        if line.startswith("data: "):
+            events.append(json.loads(line[6:]))
+    return events
+
+
+@pytest.mark.anyio
+async def test_stream_sse_propagates_provider_error_event_and_skips_done() -> None:
+    """Wenn der Provider ein error-Event yieldet, wird es weitergereicht
+    und KEIN done-Event gesendet (weil die Antwort nicht abgeschlossen ist)."""
+    from app.services import chat_service
+
+    async def fake_stream() -> AsyncIterator[dict]:
+        yield {"type": "token", "content": "Hallo"}
+        yield {
+            "type": "error",
+            "message": "Die KI hat das Tool-Limit (12 Runden) erreicht.",
+        }
+
+    class FakeCtx:
+        conversation_id = 999
+
+    async def fake_prepare(*_args: object, **_kwargs: object) -> tuple:
+        return fake_stream(), FakeCtx()
+
+    finalize_called = False
+
+    async def fake_finalize(*_args: object, **_kwargs: object) -> None:
+        nonlocal finalize_called
+        finalize_called = True
+
+    with (
+        patch.object(chat_service, "prepare_stream_with_tools", fake_prepare),
+        patch.object(chat_service, "finalize_stream", fake_finalize),
+    ):
+        chunks: list[str] = []
+        async for chunk in chat_service.stream_sse_events("hi", None, db=None):  # type: ignore[arg-type]
+            chunks.append(chunk)
+
+    events = _events_from_payload("".join(chunks))
+    types = [e["type"] for e in events]
+
+    # Reihenfolge: start, token, error — KEIN done
+    assert types == ["start", "token", "error"]
+    error_event = events[-1]
+    assert "Tool-Limit" in error_event["message"]
+    # Persistierung darf NICHT stattfinden, wenn abgebrochen wurde
+    assert finalize_called is False
+
+
+@pytest.mark.anyio
+async def test_stream_sse_normal_flow_still_finalizes_and_sends_done() -> None:
+    """Regression: Bei normalem Stream-Ende (ohne error) bleiben finalize
+    und done-Event erhalten."""
+    from app.services import chat_service
+
+    async def fake_stream() -> AsyncIterator[dict]:
+        yield {"type": "token", "content": "Antwort fertig"}
+
+    class FakeCtx:
+        conversation_id = 42
+
+    async def fake_prepare(*_args: object, **_kwargs: object) -> tuple:
+        return fake_stream(), FakeCtx()
+
+    finalize_called = False
+
+    async def fake_finalize(*_args: object, **_kwargs: object) -> None:
+        nonlocal finalize_called
+        finalize_called = True
+
+    with (
+        patch.object(chat_service, "prepare_stream_with_tools", fake_prepare),
+        patch.object(chat_service, "finalize_stream", fake_finalize),
+    ):
+        chunks: list[str] = []
+        async for chunk in chat_service.stream_sse_events("hi", None, db=None):  # type: ignore[arg-type]
+            chunks.append(chunk)
+
+    events = _events_from_payload("".join(chunks))
+    types = [e["type"] for e in events]
+    assert types == ["start", "token", "done"]
+    assert finalize_called is True


### PR DESCRIPTION
Closes #770

## Bug

> "der chat funktioniert jetzt wieder, allerdings bricht der bei der planerstellung kommentarlos ab"

Stream wurde abgebrochen ohne 'done' oder 'error' — Frontend zeigte keine Fehlermeldung.

## Root Cause

\`claude_provider.stream_chat_with_tools\` hatte \`max_tool_rounds = 5\` und beendete die for-Loop nach Erreichen mit einem schlichten \`return\`. Plan-Erstellung braucht aber häufig 6-8 Tool-Rounds (\`get_training_stats\` + \`get_personal_records\` + \`search_training_knowledge\` + \`generate_training_plan\` + ggf. Follow-up). Der Stream endete dann ohne irgendein Signal an den Client.

## Fix

1. **max_tool_rounds 5 → 12** in \`claude_provider.py\` — gibt Plan-Erstellung Luft
2. **Explizites \`error\`-Event bei Limit-Erreichen** mit deutscher Erklärung — statt still abzubrechen
3. **\`chat_service.stream_sse_events\` leitet \`error\`-Events durch** und überspringt \`finalize\`/\`done\` bei kontrolliertem Abbruch (sonst würde unvollständige Antwort als gelungen persistiert)
4. **2 Tests** sichern beide Pfade ab

## Test plan

- [x] Pytest: 1321 grün (inkl. 2 neue), Ruff, Mypy: clean
- [ ] Smoke nach Deploy: KI-Plan-Erstellung läuft durch, oder bricht mit klarer Fehlermeldung ab

🤖 Generated with [Claude Code](https://claude.com/claude-code)