### PR TITLE
fix(ui): Dialog Inner-Scroll bekommt min-height:0 für Chrome (#778)

### DIFF
--- a/.claude/reviews/778-dialog-flex-scroll.md
+++ b/.claude/reviews/778-dialog-flex-scroll.md
@@ -1,0 +1,45 @@
+# Design Review — Dialog Flex-Scroll-Fix (#778)
+
+> Folge zu #774/#776. Inner-Scroll-Container im Dialog war Flex-Child
+> ohne `min-height: 0` → Overflow-Scroll war im Chrome unflüssig.
+
+## 1. Nordlig DS Compliance
+
+- [x] Keine hardcodierten Farben
+- [x] Keine hardcodierten Radii
+- [x] Keine hardcodierten Shadows
+- [x] Keine nativen HTML-Elemente — nur Style-Properties am bestehenden div
+- [x] Nur Level-3/4 Tokens — keine Token-Verwendung berührt
+
+Geänderte Datei: `frontend/src/components/day-card/SessionDetailDialog.tsx` — zwei zusätzliche Flex-Properties (`flex: 1 1 auto`, `min-height: 0`) am bestehenden Scroll-Container.
+
+## 2. Mobile-First Check (375px)
+
+**Screenshot (375px Viewport):**
+screenshot: .claude/screenshots/mobile-375-combobox-scroll.png
+
+(Wiederverwendet aus #774 — kein neues visuelles Layout, nur Render-/Scroll-Verhalten verbessert.)
+
+**Bekanntes Flex-Scroll-Verhalten:**
+- Default Flex-Item hat `min-height: auto` → schrumpft NICHT unter intrinsische Content-Höhe → `overflow-y: auto` greift nicht zuverlässig
+- Mit `min-height: 0` + `flex: 1 1 auto` schrumpft das Item sauber innerhalb des Flex-Parents → `overflow-y: auto` arbeitet wie erwartet
+
+## 3. Touch Targets
+
+- [x] Keine Touch-Target-Änderungen
+- [x] Touch-Scroll bleibt aktiv (Properties aus #776 unverändert)
+
+## 4. Weissraum & Spacing
+
+- [x] Keine Layout-Veränderung
+- [x] `space-y-4` bleibt
+- [x] Bestehende max-height (`calc(100dvh - 180px)`) bleibt
+
+## 5. Gesamtbewertung
+
+**Verdict:** PASS
+
+**Anmerkungen:**
+Bekanntes CSS-Flex-Scroll-Pattern: `flex: 1 1 auto; min-height: 0; overflow-y: auto`. Behebt das ruckelige Verhalten in Chrome ohne andere Layout-Eigenschaften zu verändern.
+
+Quality Gates: ESLint, Prettier, TSC, Vitest 199 — alle grün.

--- a/frontend/src/components/day-card/SessionDetailDialog.tsx
+++ b/frontend/src/components/day-card/SessionDetailDialog.tsx
@@ -322,6 +322,13 @@ export function SessionDetailDialog({
         <div
           className="space-y-4 overflow-y-auto"
           style={{
+            // Flex-Scroll-Fix (#778): Der Dialog ist `flex flex-col` und dieser
+            // div ist ein Flex-Child. Ohne `min-height: 0` und `flex: 1 1 auto`
+            // bleibt er auf intrinsischer Content-Hoehe stehen und overflow-auto
+            // wird unfluessig. Mit `flex: 1` schrumpft er sauber im Dialog und
+            // scrollt zuverlaessig per Mausrad/Touch.
+            flex: '1 1 auto',
+            minHeight: 0,
             // Viewport minus Dialog-Padding + Header + Footer (geschaetzt 180px)
             // dvh statt vh fuer iOS Safari (beruecksichtigt Adressleisten-Animation).
             maxHeight: 'calc(100dvh - 180px)',


### PR DESCRIPTION
Closes #778

## Bug

Folge zu #776 — User-Report: \"Das scrollen funktioniert im chrome immer noch nicht wirklich flüssig\".

## Root Cause

Inner Scroll-Container ist Flex-Child im Nordlig DialogContent (`flex flex-col gap-...`). Default `min-height: auto` verhindert dass der Container unter die intrinsische Content-Höhe schrumpft → `overflow-y: auto` greift dann nicht zuverlässig (klassischer Flex-Scroll-Bug).

## Fix

\`flex: 1 1 auto\` + \`min-height: 0\` auf dem Scroll-Container ergänzt. Bewährtes CSS-Pattern für scrollbare Flex-Children. Andere Properties (max-height, Touch-Properties) aus #776 bleiben.

## Test plan

- [x] Vitest 199, ESLint, Prettier, TSC: clean
- [ ] Smoke nach Deploy: Chrome Desktop → Wochenplan → Lauftraining bearbeiten → Scroll mit Mausrad sollte 60fps flüssig sein
- [ ] iPhone Safari: Touch-Scroll bleibt flüssig

## Refs
- #774 / PR #775 — Combobox Scroll-Fix
- #776 / PR #777 — Dialog Touch-Scroll Properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)