### PR TITLE
fix(ui): SessionDetailDialog scrollt direkt auf DialogContent (#780)

### DIFF
--- a/.claude/reviews/780-dialogcontent-scroll.md
+++ b/.claude/reviews/780-dialogcontent-scroll.md
@@ -1,0 +1,49 @@
+# Design Review — DialogContent direkt scrollbar (#780)
+
+> Folge zu #774/#776/#778. Verschachtelter Inner-Scroll-Container raus,
+> stattdessen DialogContent selbst scrollt. Eliminiert Konkurrenz mit
+> Combobox-Popover und Radix Body-Scroll-Lock.
+
+## 1. Nordlig DS Compliance
+
+- [x] Keine hardcodierten Farben
+- [x] Keine hardcodierten Radii
+- [x] Keine hardcodierten Shadows
+- [x] Keine nativen HTML-Elemente — nur className-Override am Nordlig DialogContent
+- [x] Nur Level-3/4 Tokens — keine Token-Verwendung berührt
+
+Geänderte Datei: `frontend/src/components/day-card/SessionDetailDialog.tsx`
+- `DialogContent` bekommt `className="max-h-[calc(100dvh-32px)] overflow-y-auto"` + Touch-Properties
+- Bisheriger innerer Scroll-div (`max-h + overflow-y-auto + flex 1 1 auto + min-height: 0`) wird zu schlichtem `<div className="space-y-4">`
+
+## 2. Mobile-First Check (375px)
+
+**Screenshot (375px Viewport):**
+screenshot: .claude/screenshots/mobile-375-combobox-scroll.png
+
+(Wiederverwendet aus #774 — Layout-mässig keine Veränderung. Verbessertes Verhalten ist nicht im Standbild sichtbar.)
+
+**Berechnung:**
+- `100dvh - 32px` = ~668px auf 700px iPhone (16px Rand oben/unten)
+- Vorher (#776/#778): `100dvh - 180px` = ~520px für nur den Body
+- → Mehr Platz für Inhalt; kein verschachtelter Scroll
+
+## 3. Touch Targets
+
+- [x] Touch-Targets unverändert (Buttons im Header/Footer + Form-Felder)
+- [x] Touch-Scroll: `touch-action: pan-y` + `overscroll-behavior: contain` + `WebkitOverflowScrolling: touch` direkt auf DialogContent
+
+## 4. Weissraum & Spacing
+
+- [x] `space-y-4` bleibt im inneren div
+- [x] DialogContent-Padding (Nordlig DS Tokens) bleibt
+- [x] Kein doppeltes Scroll mehr → einfacheres Layout
+
+## 5. Gesamtbewertung
+
+**Verdict:** PASS
+
+**Anmerkungen:**
+Architektur-Vereinfachung: ein Scroll-Container statt zwei. Behebt potenzielle Konflikte zwischen Inner-Scroll und Radix-Popover-Body-Scroll-Lock. Wenn der Dialog-Body sehr lang wird, scrollen Header und Footer mit — bei dem aktuellen Edit-Form akzeptabel (kompakter Header, kompakter Footer). Falls später visuell stört: Header/Footer als sticky setzen via CSS-Override.
+
+Quality Gates: ESLint, Prettier, TSC, Vitest 199 — alle grün.

--- a/frontend/src/components/day-card/SessionDetailDialog.tsx
+++ b/frontend/src/components/day-card/SessionDetailDialog.tsx
@@ -233,7 +233,15 @@ export function SessionDetailDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent
+        className="max-h-[calc(100dvh-32px)] overflow-y-auto"
+        style={{
+          // Touch-Scroll innerhalb des Dialogs nicht an den Body weiterreichen (#780).
+          overscrollBehavior: 'contain',
+          touchAction: 'pan-y',
+          WebkitOverflowScrolling: 'touch',
+        }}
+      >
         <DialogHeader>
           <div className="flex items-center justify-between">
             <DialogTitle>
@@ -319,25 +327,7 @@ export function SessionDetailDialog({
           </div>
         </DialogHeader>
 
-        <div
-          className="space-y-4 overflow-y-auto"
-          style={{
-            // Flex-Scroll-Fix (#778): Der Dialog ist `flex flex-col` und dieser
-            // div ist ein Flex-Child. Ohne `min-height: 0` und `flex: 1 1 auto`
-            // bleibt er auf intrinsischer Content-Hoehe stehen und overflow-auto
-            // wird unfluessig. Mit `flex: 1` schrumpft er sauber im Dialog und
-            // scrollt zuverlaessig per Mausrad/Touch.
-            flex: '1 1 auto',
-            minHeight: 0,
-            // Viewport minus Dialog-Padding + Header + Footer (geschaetzt 180px)
-            // dvh statt vh fuer iOS Safari (beruecksichtigt Adressleisten-Animation).
-            maxHeight: 'calc(100dvh - 180px)',
-            // Touch-Scroll innerhalb des Dialogs nicht an den Body weiterreichen (#776).
-            overscrollBehavior: 'contain',
-            touchAction: 'pan-y',
-            WebkitOverflowScrolling: 'touch',
-          }}
-        >
+        <div className="space-y-4">
           {/* --- READ-ONLY --- */}
           {!isEditing && (
             <SessionReadOnlyView


### PR DESCRIPTION
Closes #780

## Bug

Folge zu #774/#776/#778 — User-Report: \"Das scrollen funktioniert im chrome immer noch nicht wirklich flüssig\".

Trotz Flex-min-height-Fix konkurriert der verschachtelte Scroll-Container mit Radix Dialog Body-Scroll-Lock und dem Combobox-Popover.

## Fix

Architektur-Vereinfachung: nur EIN Scroll-Container. DialogContent selbst wird scrollbar via className-Override:

\`\`\`tsx
<DialogContent
  className=\"max-h-[calc(100dvh-32px)] overflow-y-auto\"
  style={{ overscrollBehavior: 'contain', touchAction: 'pan-y', WebkitOverflowScrolling: 'touch' }}
>
\`\`\`

Bisheriger innerer Scroll-div (mit max-h, overflow, flex 1 1 auto, min-height: 0) → schlichter \`<div className=\"space-y-4\">\`.

**Vorteile:**
- EIN Scroll-Container → kein Konflikt mit Combobox-Popover
- Mehr Platz für Inhalt (~668px statt ~520px auf iPhone)
- Einfacheres Layout
- Header/Footer scrollen mit — bei kompaktem Edit-Dialog OK

## Test plan

- [x] Vitest 199, ESLint, Prettier, TSC: clean
- [ ] Smoke: Chrome Desktop → Wochenplan → Lauftraining bearbeiten → Mausrad-Scroll flüssig
- [ ] iPhone Safari: Touch-Scroll flüssig

## Refs
- #774/#775, #776/#777, #778/#779

🤖 Generated with [Claude Code](https://claude.com/claude-code)