### PR TITLE
fix(ui): Combobox-Dropdown Maus-Scroll funktioniert wieder (#784)

### DIFF
--- a/.claude/reviews/784-cmdk-mouse-scroll.md
+++ b/.claude/reviews/784-cmdk-mouse-scroll.md
@@ -1,0 +1,51 @@
+# Design Review — Combobox Maus-Scroll Fix (#784)
+
+> Folge zu #774/#776/#778/#780/#782. User: "Ich kann mit der maus nicht
+> sinnvoll scrollen in den dropdowns". Bekannter cmdk-Bug — onPointerMove
+> auf Items ändert die Selektion bei Maus-Move + scrollt automatisch dahin.
+
+## 1. Nordlig DS Compliance
+
+- [x] Keine hardcodierten Farben
+- [x] Keine hardcodierten Radii
+- [x] Keine hardcodierten Shadows
+- [x] Keine nativen HTML-Elemente
+- [x] Nur Level-3/4 Tokens
+
+Geänderte/neue Dateien:
+- `frontend/src/utils/cmdkScrollFix.ts` — Wheel-Listener (idempotent)
+- `frontend/src/utils/cmdkScrollFix.test.ts` — 4 Tests
+- `frontend/src/main.tsx` — installCmdkScrollFix() Init
+- `frontend/src/index.css` — `[cmdk-list].cmdk-scrolling [cmdk-item] { pointer-events: none; }` + `scroll-behavior: auto`
+
+## 2. Mobile-First Check (375px)
+
+**Screenshot (375px Viewport):**
+screenshot: .claude/screenshots/mobile-375-combobox-scroll.png
+
+(Wiederverwendet — der Fix ist Verhaltens-, kein Layout-Change.)
+
+**Wirkung:**
+- Bei aktivem Wheel-Scroll im `[cmdk-list]` werden für 150ms Pointer-Events auf den Items deaktiviert
+- cmdk's `onPointerMove` triggert nicht mehr → keine Auto-Selection-Änderung → kein scrollIntoView-Konflikt
+- Nach 150ms ohne Wheel-Event sind Items wieder klickbar
+
+## 3. Touch Targets
+
+- [x] Touch-Targets unverändert
+- [x] Klick auf Items funktioniert weiter (Pointer-Down/Up sind keine PointerMove)
+- [x] Tastatur-Navigation (Arrow-Keys) funktioniert weiter (kein Pointer-Event)
+
+## 4. Weissraum & Spacing
+
+- [x] Keine Layout-Veränderungen
+- [x] Combobox-Optik bleibt 1:1
+
+## 5. Gesamtbewertung
+
+**Verdict:** PASS
+
+**Anmerkungen:**
+Bekannter cmdk-Workaround (Issue #267 dort): Wheel-Detect → temporär pointer-events disable → cmdk's onPointerMove triggert nicht mehr während Scroll. Saubere CSS+JS-Lösung ohne cmdk-Code zu patchen. Wenn NDS später `disablePointerSelection` durchreicht, kann das hier weg.
+
+Quality Gates: ESLint, Prettier, TSC, Vitest 203 — alle grün.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -145,6 +145,17 @@
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
   touch-action: pan-y;
+  /* Smooth-Scroll abschalten — vermeidet Konflikt mit cmdk's scrollIntoView (#784) */
+  scroll-behavior: auto !important;
+}
+
+/* cmdk-Scroll-Fix (#784): Während Wheel-Scroll setzt utils/cmdkScrollFix.ts
+ * die `cmdk-scrolling` Class auf [cmdk-list]. CSS deaktiviert dann
+ * pointer-events auf den Items, damit cmdk's onPointerMove die Selektion
+ * NICHT bei jedem Maus-Move aendert (sonst springt der Scroll). Klick und
+ * Tastatur-Navigation bleiben unbeeinflusst (passieren ohne Pointer-Move). */
+[cmdk-list].cmdk-scrolling [cmdk-item] {
+  pointer-events: none;
 }
 
 @keyframes typing-dot {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,9 +2,13 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import { installCmdkScrollFix } from './utils/cmdkScrollFix';
 
 // Dark mode tokens loaded async — not needed for initial render
 import('./dark-tokens.css');
+
+// Wheel-Listener fuer cmdk Combobox-Scroll-Fix (#784).
+installCmdkScrollFix();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/frontend/src/utils/cmdkScrollFix.test.ts
+++ b/frontend/src/utils/cmdkScrollFix.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { installCmdkScrollFix } from './cmdkScrollFix';
+
+function buildCmdkFixture(): { list: HTMLElement; item: HTMLElement } {
+  const list = document.createElement('div');
+  list.setAttribute('cmdk-list', '');
+  const item = document.createElement('div');
+  item.setAttribute('cmdk-item', '');
+  item.textContent = 'Item 1';
+  list.appendChild(item);
+  document.body.appendChild(list);
+  return { list, item };
+}
+
+describe('cmdkScrollFix (#784)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.replaceChildren();
+    installCmdkScrollFix();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.replaceChildren();
+  });
+
+  it('adds cmdk-scrolling class on wheel inside [cmdk-list]', () => {
+    const { list, item } = buildCmdkFixture();
+
+    item.dispatchEvent(new Event('wheel', { bubbles: true }));
+
+    expect(list.classList.contains('cmdk-scrolling')).toBe(true);
+  });
+
+  it('removes cmdk-scrolling class 150ms after last wheel event', () => {
+    const { list, item } = buildCmdkFixture();
+
+    item.dispatchEvent(new Event('wheel', { bubbles: true }));
+    expect(list.classList.contains('cmdk-scrolling')).toBe(true);
+
+    vi.advanceTimersByTime(150);
+
+    expect(list.classList.contains('cmdk-scrolling')).toBe(false);
+  });
+
+  it('keeps the class active while wheel events keep firing (debounce)', () => {
+    const { list, item } = buildCmdkFixture();
+
+    item.dispatchEvent(new Event('wheel', { bubbles: true }));
+    vi.advanceTimersByTime(100);
+    expect(list.classList.contains('cmdk-scrolling')).toBe(true);
+
+    // Another wheel event resets the timeout
+    item.dispatchEvent(new Event('wheel', { bubbles: true }));
+    vi.advanceTimersByTime(100);
+    // Still scrolling because we're within 150ms of the latest event
+    expect(list.classList.contains('cmdk-scrolling')).toBe(true);
+
+    vi.advanceTimersByTime(60);
+    // Now > 150ms after the latest event → cleaned up
+    expect(list.classList.contains('cmdk-scrolling')).toBe(false);
+  });
+
+  it('does nothing for wheel events outside [cmdk-list]', () => {
+    const { list } = buildCmdkFixture();
+    const otherDiv = document.createElement('div');
+    document.body.appendChild(otherDiv);
+
+    otherDiv.dispatchEvent(new Event('wheel', { bubbles: true }));
+
+    expect(list.classList.contains('cmdk-scrolling')).toBe(false);
+  });
+});

--- a/frontend/src/utils/cmdkScrollFix.ts
+++ b/frontend/src/utils/cmdkScrollFix.ts
@@ -1,0 +1,48 @@
+/**
+ * Workaround für den bekannten cmdk-Bug (#784):
+ * `Command.Item` hat ein `onPointerMove` das bei jedem Maus-Move die Selektion
+ * ändert und mit `scrollIntoView` springt. Bei Wheel-Scroll bewegt sich der
+ * Cursor relativ zu den Items → die Selektion springt rauf/runter, der
+ * Scroll-Effekt wird unflüssig oder bricht ab.
+ *
+ * Lösung: Während aktiv gewheelt wird, setzen wir `cmdk-scrolling` Class auf
+ * dem `[cmdk-list]`. CSS in `index.css` deaktiviert dann `pointer-events` auf
+ * den Items für die Dauer des Scroll-Bursts (150 ms nach letztem Wheel-Event).
+ * Klick/Tastatur-Navigation bleiben unbeeinflusst.
+ *
+ * Referenz: https://github.com/pacocoursey/cmdk/issues/267
+ */
+
+const SCROLL_END_DELAY_MS = 150;
+const scrollTimeouts = new WeakMap<Element, number>();
+
+function handleWheel(event: Event): void {
+  const target = event.target as Element | null;
+  const list = target?.closest('[cmdk-list]');
+  if (!list) return;
+
+  list.classList.add('cmdk-scrolling');
+
+  const previousTimeout = scrollTimeouts.get(list);
+  if (previousTimeout !== undefined) {
+    window.clearTimeout(previousTimeout);
+  }
+
+  const timeout = window.setTimeout(() => {
+    list.classList.remove('cmdk-scrolling');
+    scrollTimeouts.delete(list);
+  }, SCROLL_END_DELAY_MS);
+
+  scrollTimeouts.set(list, timeout);
+}
+
+let installed = false;
+
+/** Installiert den globalen Wheel-Listener. Idempotent. */
+export function installCmdkScrollFix(): void {
+  if (installed || typeof window === 'undefined') return;
+  // capture: true — wir hören das Event bevor cmdk's eigene Listener greifen.
+  // passive: true — wir verhindern niemals den Default-Scroll.
+  window.addEventListener('wheel', handleWheel, { capture: true, passive: true });
+  installed = true;
+}


### PR DESCRIPTION
Closes #784

## Bug

User: \"Ich kann mit der maus nicht sinnvoll scrollen in den dropdowns\".

Bekannter cmdk-Bug ([Issue #267](https://github.com/pacocoursey/cmdk/issues/267)): \`Command.Item\` hat \`onPointerMove\` der bei jedem Maus-Move die Selektion ändert und scrollIntoView triggert. Beim Wheel-Scroll bewegt sich der Cursor relativ zu den Items → Items springen hin/her, der Scroll wird unflüssig.

## Fix

Globaler Wheel-Listener (\`cmdkScrollFix.ts\`) fügt während aktivem Scroll die Class \`cmdk-scrolling\` an \`[cmdk-list]\` an. CSS deaktiviert dann \`pointer-events\` auf den Items für 150ms — cmdk's \`onPointerMove\` triggert nicht mehr → kein Selection-Wechsel → flüssiger Scroll.

Klick + Tastatur-Navigation bleiben unbeeinflusst (sind keine Pointer-Move-Events).

## Test plan

- [x] Vitest 203 (4 neue für cmdkScrollFix), ESLint, Prettier, TSC: clean
- [ ] Smoke Chrome Desktop: Wochenplan → Lauftraining bearbeiten → Combobox öffnen → Mausrad scrollt sauber
- [ ] Klicken bleibt funktional
- [ ] Tastatur (Arrow-Keys) navigiert weiter

## Refs
- #774/#775, #776/#777, #778/#779, #780/#781, #782/#783

🤖 Generated with [Claude Code](https://claude.com/claude-code)