### PR TITLE
fix(fit-export): Segment-Name aus Typ statt Notiz (#794)

### DIFF
--- a/backend/app/services/fit_export.py
+++ b/backend/app/services/fit_export.py
@@ -89,12 +89,19 @@ def pace_to_speed_mps(pace_str: str) -> float:
 def _generate_step_name(segment: Segment) -> str:
     """Generiert einen lesbaren deutschen Step-Namen fuer HealthFit-Anzeige.
 
-    Priorisiert notes > generierter Name mit Ziel-Info > Segment-Type.
-    """
-    if segment.notes:
-        return segment.notes[:50]
+    Basis ist immer der Segment-Typ (Anzeigename). Notizen fliessen NICHT ein,
+    damit Uhren-Anzeige und HealthFit konsistent bleiben.
 
+    Sonderfaelle:
+    - drills (Lauf-ABC) mit exercise_name → "Lauf-ABC: <Uebung>"
+    - work/steady/strides/tempo_block/pace_building bekommen Ziel-Info-Suffix
+    """
     base = _SEGMENT_DISPLAY_NAMES.get(segment.segment_type, segment.segment_type)
+
+    # Lauf-ABC: konkrete Uebung anhaengen, falls gepflegt
+    if segment.segment_type == "drills" and segment.exercise_name:
+        base = f"{base}: {segment.exercise_name}"
+        return base[:50]
 
     # Ziel-Info fuer Work/Steady/Strides anhaengen
     if segment.segment_type in ("work", "steady", "strides", "tempo_block", "pace_building"):

--- a/backend/app/tests/test_fit_export.py
+++ b/backend/app/tests/test_fit_export.py
@@ -58,9 +58,24 @@ class TestPaceToSpeedMps:
 
 
 class TestGenerateStepName:
-    def test_notes_take_priority(self) -> None:
+    def test_notes_are_ignored(self) -> None:
+        """Notizen flieSsen NICHT in den Step-Namen ein (Issue #794)."""
         seg = Segment(position=0, segment_type="work", notes="Schnelle 1km")
-        assert _generate_step_name(seg) == "Schnelle 1km"
+        assert _generate_step_name(seg) == "Intervall"
+
+    def test_drills_with_exercise_name(self) -> None:
+        """Lauf-ABC haengt exercise_name an (Issue #794)."""
+        seg = Segment(position=0, segment_type="drills", exercise_name="Skipping")
+        assert _generate_step_name(seg) == "Lauf-ABC: Skipping"
+
+    def test_drills_without_exercise_name(self) -> None:
+        """Lauf-ABC ohne exercise_name bleibt beim Typ-Namen."""
+        seg = Segment(position=0, segment_type="drills")
+        assert _generate_step_name(seg) == "Lauf-ABC"
+
+    def test_drills_long_exercise_name_truncated(self) -> None:
+        seg = Segment(position=0, segment_type="drills", exercise_name="A" * 100)
+        assert len(_generate_step_name(seg)) == 50
 
     def test_warmup_name(self) -> None:
         seg = Segment(position=0, segment_type="warmup", target_duration_minutes=10)
@@ -115,9 +130,10 @@ class TestGenerateStepName:
         seg = Segment(position=0, segment_type="work", target_distance_km=0.4)
         assert _generate_step_name(seg) == "Intervall 0.4km"
 
-    def test_long_notes_truncated(self) -> None:
+    def test_long_notes_are_ignored(self) -> None:
+        """Lange Notizen werden ignoriert, nicht gekuerzt (Issue #794)."""
         seg = Segment(position=0, segment_type="work", notes="A" * 100)
-        assert len(_generate_step_name(seg)) == 50
+        assert _generate_step_name(seg) == "Intervall"
 
 
 # --- _build_workout_step ---
@@ -253,10 +269,17 @@ class TestBuildWorkoutStep:
         step = _build_workout_step(seg, message_index=0)
         assert step.workout_step_name == "Einlaufen"
 
-    def test_step_name_from_notes(self) -> None:
+    def test_step_name_ignores_notes(self) -> None:
+        """Notizen werden im Step-Namen ignoriert (Issue #794)."""
         seg = Segment(position=0, segment_type="work", target_distance_km=1.0, notes="Schnelle 1km")
         step = _build_workout_step(seg, message_index=0)
-        assert step.workout_step_name == "Schnelle 1km"
+        assert step.workout_step_name == "Intervall 1km"
+
+    def test_step_name_drills_with_exercise(self) -> None:
+        """Lauf-ABC haengt exercise_name im Step-Namen an (Issue #794)."""
+        seg = Segment(position=0, segment_type="drills", exercise_name="Skipping")
+        step = _build_workout_step(seg, message_index=0)
+        assert step.workout_step_name == "Lauf-ABC: Skipping"
 
 
 # --- _build_recovery_step ---


### PR DESCRIPTION
## Summary
- `_generate_step_name` in `fit_export.py` priorisiert nicht mehr `notes`, sondern nutzt den Segment-Typ-Anzeigenamen.
- Bei `segment_type == "drills"` (Lauf-ABC) wird `exercise_name` angehängt → `"Lauf-ABC: Skipping"`.
- Bestehende Ziel-Info-Suffixe für Work/Steady/Strides bleiben erhalten.

## Test plan
- [x] `pytest app/tests/test_fit_export.py` (50 passed)
- [x] Volles Backend-Pytest (1325 passed)
- [x] Ruff + Mypy grün
- [ ] CI-Workflow grün
- [ ] Manuell: FIT-Export einer Session mit Lauf-ABC-Segment in HealthFit prüfen

Closes #794