### PR TITLE
fix(fit-export): Sprechender Workout-Name aus Run-Type-Label (#799)

### DIFF
--- a/.claude/reviews/799-fit-workout-name-readable.md
+++ b/.claude/reviews/799-fit-workout-name-readable.md
@@ -1,0 +1,53 @@
+# Design Review — Issue #799
+
+> Backend-Verhaltensänderung (Workout-Name in FIT-Datei) plus eine
+> Frontend-Signaturanpassung (`notes`-Argument entfernt). Kein neuer
+> visueller Surface, kein Layout, kein Spacing, keine neuen Komponenten.
+
+## 1. Nordlig DS Compliance
+
+- [x] Keine hardcodierten Farben (bg-white, bg-gray-*, text-red-* etc.)
+- [x] Keine hardcodierten Radii (rounded-sm/md/lg/xl/2xl)
+- [x] Keine hardcodierten Shadows (shadow-sm/md/lg)
+- [x] Keine nativen HTML-Elemente (button, input, select, textarea)
+- [x] Nur Level-3/4 Tokens verwendet (keine L1/L2)
+
+Frontend-Diff entfernt nur einen Funktionsparameter — keine Tokens, Farben
+oder Komponenten betroffen.
+
+## 2. Mobile-First Check (375px)
+
+**Screenshot (375px Viewport):**
+screenshot: .claude/screenshots/mobile-375-fit-export-toast.png
+
+**Befunde:**
+- Layout unverändert — kein UI-Surface betroffen
+- Wochenplan-Dialog rendert identisch
+- Screenshot wiederverwendet aus #796 (zeigt den Wochenplan-Kontext)
+
+## 3. Touch Targets
+
+- [x] Alle interaktiven Elemente >= 44x44px
+- [x] Buttons haben ausreichend Padding
+- [x] Links/Icons haben genug Abstand zueinander
+
+Keine neuen interaktiven Elemente.
+
+## 4. Weissraum & Spacing
+
+- [x] Container-Padding 24-32px
+- [x] Sektionen-Abstand 32-64px
+- [x] Weißraum-Anteil visuell ~30-40%
+- [x] Keine Card-on-Card Schatten
+
+Keine Layout-/Spacing-Änderungen.
+
+## 5. Gesamtbewertung
+
+**Verdict:** PASS
+
+**Anmerkungen:**
+Reine Verhaltensänderung im Backend: der Workout-Name in der exportierten
+FIT-Datei kommt jetzt aus `SESSION_TYPE_LABELS` (z. B. "Langer Lauf")
+statt aus den Notizen. Frontend wurde nur an die neue API-Signatur
+angepasst — `notes`-Argument entfernt. Keine sichtbaren UI-Änderungen.

--- a/backend/app/api/v1/weekly_plan.py
+++ b/backend/app/api/v1/weekly_plan.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -1447,7 +1447,6 @@ class PlannedSessionFitExportRequest(BaseModel):
     """
 
     run_details: RunDetails
-    notes: Optional[str] = Field(default=None, max_length=500)
 
 
 @router.post("/export/fit")
@@ -1463,6 +1462,7 @@ async def export_planned_session_fit(
     """
     import re
 
+    from app.models.taxonomy import SESSION_TYPE_LABELS
     from app.services.fit_export import export_template_to_fit
 
     run_details = payload.run_details
@@ -1473,10 +1473,10 @@ async def export_planned_session_fit(
             detail="Session hat keine Segmente fuer den Export.",
         )
 
-    # Workout-Name: Notizen-Erstzeile oder Run-Type
-    workout_name = str(payload.notes or "").split("\n")[0][:50] if payload.notes else None
-    if not workout_name:
-        workout_name = run_details.run_type or "Lauftraining"
+    # Workout-Name: Deutsche Run-Type-Bezeichnung — sprechend auf der Uhr.
+    # Notizen werden bewusst NICHT verwendet, da sie oft KI-generierte
+    # Freitexte enthalten ("Long Run 63 min - Lauf-ABC mit ...").
+    workout_name = SESSION_TYPE_LABELS.get(run_details.run_type or "", "") or "Lauftraining"
 
     fit_bytes = export_template_to_fit(
         template_name=workout_name,

--- a/backend/app/models/taxonomy.py
+++ b/backend/app/models/taxonomy.py
@@ -37,6 +37,20 @@ SEGMENT_TYPES = frozenset(
 
 SEGMENT_TYPE_REGEX = "^(" + "|".join(sorted(SEGMENT_TYPES)) + ")$"
 
+# Deutsche Anzeigenamen fuer Session-Types — Single Source of Truth
+# (gespiegelt im Frontend in `frontend/src/constants/plan.ts:RUN_TYPE_LABELS`).
+SESSION_TYPE_LABELS: dict[str, str] = {
+    "recovery": "Regeneration",
+    "easy": "Lockerer Lauf",
+    "long_run": "Langer Lauf",
+    "progression": "Steigerungslauf",
+    "tempo": "Tempolauf",
+    "intervals": "Intervalle",
+    "repetitions": "Repetitions",
+    "fartlek": "Fahrtspiel",
+    "race": "Wettkampf",
+}
+
 # Intensity classification for training balance
 EASY_SESSION_TYPES = frozenset({"recovery", "easy", "long_run"})
 MODERATE_SESSION_TYPES = frozenset({"tempo", "progression", "fartlek"})

--- a/backend/app/tests/test_weekly_plan.py
+++ b/backend/app/tests/test_weekly_plan.py
@@ -1176,14 +1176,31 @@ async def test_export_fit_returns_workout_file(client: AsyncClient) -> None:
                 {"position": 2, "segment_type": "cooldown", "target_duration_minutes": 10},
             ],
         },
-        "notes": "5x1000m Schwellentempo",
     }
     response = await client.post("/api/v1/weekly-plan/export/fit", json=payload)
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/octet-stream"
-    assert "filename=" in response.headers["content-disposition"]
+    # Workout-Name = deutsche Run-Type-Bezeichnung → Dateiname enthaelt "intervalle"
+    assert "intervalle" in response.headers["content-disposition"].lower()
     assert response.headers["content-disposition"].endswith('.fit"')
     assert len(response.content) > 0
+
+
+@pytest.mark.anyio
+async def test_export_fit_uses_run_type_label_not_notes(client: AsyncClient) -> None:
+    """Workout-Name kommt aus dem Run-Type-Label, NICHT aus der Notiz (#799)."""
+    payload = {
+        "run_details": {
+            "run_type": "long_run",
+            "segments": [
+                {"position": 0, "segment_type": "steady", "target_duration_minutes": 60},
+            ],
+        },
+    }
+    response = await client.post("/api/v1/weekly-plan/export/fit", json=payload)
+    assert response.status_code == 200
+    # "Langer Lauf" → safe_name "langer-lauf"
+    assert "langer-lauf" in response.headers["content-disposition"].lower()
 
 
 @pytest.mark.anyio
@@ -1191,7 +1208,6 @@ async def test_export_fit_rejects_empty_segments(client: AsyncClient) -> None:
     """Ohne Segmente liefert der Export 422."""
     payload = {
         "run_details": {"run_type": "easy", "target_duration_minutes": 30},
-        "notes": None,
     }
     response = await client.post("/api/v1/weekly-plan/export/fit", json=payload)
     # _ensure_segments-Validator legt automatisch ein 'steady'-Segment an,

--- a/frontend/src/api/weekly-plan.ts
+++ b/frontend/src/api/weekly-plan.ts
@@ -307,15 +307,12 @@ async function _extractBlobError(err: unknown): Promise<string> {
   return err instanceof Error ? err.message : 'Unbekannter Fehler';
 }
 
-export async function exportPlannedSessionFit(
-  runDetails: RunDetails,
-  notes?: string | null,
-): Promise<void> {
+export async function exportPlannedSessionFit(runDetails: RunDetails): Promise<void> {
   let response;
   try {
     response = await apiClient.post(
       `/api/v1/weekly-plan/export/fit`,
-      { run_details: runDetails, notes: notes ?? null },
+      { run_details: runDetails },
       { responseType: 'blob' },
     );
   } catch (err) {

--- a/frontend/src/components/day-card/SessionDetailDialog.tsx
+++ b/frontend/src/components/day-card/SessionDetailDialog.tsx
@@ -296,7 +296,7 @@ export function SessionDetailDialog({
                         onSelect={async () => {
                           if (!session.run_details) return;
                           try {
-                            await exportPlannedSessionFit(session.run_details, session.notes);
+                            await exportPlannedSessionFit(session.run_details);
                           } catch (err) {
                             console.error('FIT-Export fehlgeschlagen:', err);
                             const detail =


### PR DESCRIPTION
## Summary
- Workout-Name in der FIT-Datei kommt jetzt aus `SESSION_TYPE_LABELS` (z. B. \"Langer Lauf\", \"Intervalle\", \"Tempolauf\") — kurz und sprechend auf der Uhr.
- Notizen werden ignoriert (waren oft KI-generierte Freitexte wie \"Long Run 63 min - Lauf-ABC mit excercise_name, korr\").
- `notes`-Feld aus Request-Body und Frontend-Aufruf entfernt.

## Test plan
- [x] Backend-Pytest grün (1328 passed, neuer Test prüft \"Langer Lauf\" → \"langer-lauf-*.fit\")
- [x] Frontend-TSC, ESLint, Prettier, Vitest grün
- [ ] CI grün
- [ ] Manuell: Long-Run aus Wochenplan exportieren → FIT zeigt \"Langer Lauf\" auf der Uhr

Refs #799