### PR TITLE
fix(ci): Backend-CI für frische PRs reparieren — Ruff-Pin, PLR0917, Datums-Zeitbomben (#810)

### DIFF
--- a/backend/app/api/v1/sessions.py
+++ b/backend/app/api/v1/sessions.py
@@ -375,7 +375,7 @@ def _has_session_data(parsed: dict) -> bool:
     return has_duration or has_distance or has_laps or has_hr_timeseries
 
 
-async def _upload_session(  # noqa: PLR0913
+async def _upload_session(  # noqa: PLR0913, PLR0917
     content: bytes,
     parser: TrainingCSVParser | TrainingFITParser,
     form: SessionUploadForm,
@@ -514,7 +514,7 @@ async def upload_fit(
 
 
 @router.get("", response_model=SessionListResponse)
-async def list_sessions(  # noqa: PLR0913
+async def list_sessions(  # noqa: PLR0913, PLR0917
     page: int = Query(1, ge=1, description="Seitennummer"),
     page_size: int = Query(20, ge=1, le=100, description="Eintraege pro Seite"),
     workout_type: Optional[TrainingType] = Query(None, description="Filter nach Workout-Typ"),

--- a/backend/app/api/v1/strength.py
+++ b/backend/app/api/v1/strength.py
@@ -92,7 +92,7 @@ def _parse_training_file(content: bytes, filename: str) -> Optional[dict]:
 
 
 @router.post("", status_code=201)
-async def create_strength_session(  # noqa: PLR0913
+async def create_strength_session(  # noqa: PLR0913, PLR0917
     exercises_json: str = Form(..., description="JSON-Array der Übungen"),
     training_date: date = Form(..., description="Datum (YYYY-MM-DD)"),
     duration_minutes: int = Form(..., ge=1, le=600, description="Dauer in Minuten"),

--- a/backend/app/services/km_split_calculator.py
+++ b/backend/app/services/km_split_calculator.py
@@ -187,7 +187,7 @@ def _calc_corrected_pace(
     return corrected
 
 
-def _build_split(  # noqa: PLR0913  # TODO: E16 Refactoring
+def _build_split(  # noqa: PLR0913, PLR0917  # TODO: E16 Refactoring
     km_number: int,
     distance_km: float,
     duration_sec: int,

--- a/backend/app/services/plan_generator.py
+++ b/backend/app/services/plan_generator.py
@@ -1048,7 +1048,7 @@ def _insert_race_day(
 # --- Main Generator ---
 
 
-def generate_weekly_plans(  # noqa: C901, PLR0912, PLR0913, PLR0915  # TODO: E16 Refactoring
+def generate_weekly_plans(  # noqa: C901, PLR0912, PLR0913, PLR0915, PLR0917  # TODO: E16 Refactoring
     plan: TrainingPlanModel,
     phases: list[TrainingPhaseModel],
     rest_days: list[int],

--- a/backend/app/services/yaml_validator.py
+++ b/backend/app/services/yaml_validator.py
@@ -478,7 +478,7 @@ def _check_run_details(
                     )
 
 
-def _check_type_value(  # noqa: PLR0913  # TODO: E16 Refactoring
+def _check_type_value(  # noqa: PLR0913, PLR0917  # TODO: E16 Refactoring
     value: str,
     valid_set: frozenset[str],
     migration_map: dict[str, str],

--- a/backend/app/tests/factories.py
+++ b/backend/app/tests/factories.py
@@ -6,7 +6,7 @@ from typing import Any, Optional
 from app.domain.entities.workout import Workout
 
 
-def make_workout(  # noqa: PLR0913  # TODO: E16 Refactoring
+def make_workout(  # noqa: PLR0913, PLR0917  # TODO: E16 Refactoring
     id: Optional[int] = 1,
     date: Optional[datetime] = None,
     workout_type: str = "running",

--- a/backend/app/tests/test_progression.py
+++ b/backend/app/tests/test_progression.py
@@ -1,6 +1,7 @@
 """Tests fuer Krafttraining Progression-Tracking (Issue #17)."""
 
 import json
+from datetime import date, timedelta
 
 import pytest
 from httpx import AsyncClient
@@ -553,7 +554,9 @@ async def test_personal_records_for_session(client: AsyncClient) -> None:
 
 @pytest.mark.anyio
 async def test_tonnage_trend(client: AsyncClient) -> None:
-    await _create_strength_session(client)
+    # Datum relativ zu heute, damit die Session im "days"-Fenster des Endpoints liegt
+    recent = date.today() - timedelta(days=7)
+    await _create_strength_session(client, date_str=recent.isoformat())
 
     response = await client.get(
         "/api/v1/sessions/strength/tonnage-trend",

--- a/backend/app/tests/test_strength.py
+++ b/backend/app/tests/test_strength.py
@@ -1,6 +1,7 @@
 """Tests fuer Krafttraining (Issue #15, #151, #285)."""
 
 import json
+from datetime import date, timedelta
 
 import pytest
 from httpx import AsyncClient
@@ -843,7 +844,10 @@ async def test_create_validation_no_sets(client: AsyncClient) -> None:
 @pytest.mark.anyio
 async def test_category_tonnage_trend_endpoint(client: AsyncClient) -> None:
     """Neuer Endpoint liefert Kategorie-Tonnage nach Wochen."""
-    await client.post("/api/v1/sessions/strength", data=VALID_FORM_DATA)
+    # Datum relativ zu heute, damit die Session im "days"-Fenster des Endpoints liegt
+    recent = date.today() - timedelta(days=7)
+    form_data = {**VALID_FORM_DATA, "training_date": recent.isoformat()}
+    await client.post("/api/v1/sessions/strength", data=form_data)
 
     response = await client.get(
         "/api/v1/sessions/strength/category-tonnage-trend",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -70,9 +70,10 @@ dev = [
     "aiosqlite>=0.20.0",  # Async SQLite for test DB
     "greenlet>=3.0.0",  # Required by async SQLAlchemy
 
-    # Code Quality
-    "ruff>=0.1.14",
-    "mypy>=1.8.0",
+    # Code Quality — exakt gepinnt, damit CI und lokal identisch linten (#810).
+    # Versionshebungen bewusst durchführen: Pin erhöhen + `ruff check app/` / `mypy app/` lokal prüfen.
+    "ruff==0.16.0",
+    "mypy==2.3.0",
     "black>=24.1.1",
     "isort>=5.13.2",
     


### PR DESCRIPTION
## Zusammenfassung

Die Backend-CI war für **jeden frischen PR rot**, unabhängig vom Diff (verifiziert an #809, Docs-only). Dieser PR behebt beide Ursachen. Closes #810.

### 1. Ruff PLR0917 (Backend Lint & Typecheck)

- `ruff>=0.1.14` war ungepinnt → CI zog 0.16.0, das **PLR0917** („Too many positional arguments") stabilisiert hat; unsere Config selektiert `PLR` pauschal. Lokal (0.15.6) bestand der Check → Local/CI-Drift.
- **Fix:** `ruff==0.16.0` und `mypy==2.3.0` exakt gepinnt (Hebungen künftig bewusst per Pin-Erhöhung + lokalem Gate-Lauf). Die 7 betroffenen Stellen trugen bereits `# noqa: PLR0913` — um `PLR0917` erweitert. Kein globales Ignore: Die Regel bleibt für neuen Code aktiv; die Stellen sind bereits als „TODO: E16 Refactoring" markiert.

### 2. Datums-Zeitbomben in Tests (Backend Tests)

- `test_progression.py::test_tonnage_trend` und `test_strength.py::test_category_tonnage_trend_endpoint` erzeugten Sessions mit hartkodiertem Datum `2026-02-27` und fragten Endpoints mit 90-Tage-Fenster **relativ zu heute** ab → seit ~2026-05-28 dauerhaft rot. (Der zweite Test war im CI-Log unsichtbar, weil pytest mit `-x` nach dem ersten Fehler stoppt.)
- **Fix:** Beide Tests nutzen jetzt ein dynamisches Datum (heute − 7 Tage). Die volle Suite ohne `-x` hat keine weiteren datumsabhängigen Fehler ergeben.

## Quality Gates (lokal)

- ✅ `ruff check app/` mit **ruff 0.16.0** (CI-Version) und 0.15.6
- ✅ `ruff format --check app/` (204 Dateien)
- ✅ `mypy app/` (204 Dateien, 0 Fehler)
- ✅ `pytest app/tests/` — **1329 passed**

## Nach dem Merge

- Checks auf #809 (falls noch offen) re-runnen — sollte dann grün sein

🤖 Generated with [Claude Code](https://claude.com/claude-code)