### PR TITLE
fix(ci): veraltete Coolify/App-URLs in Workflows bereinigen (#813)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,7 +467,7 @@ jobs:
           ### Nächste Schritte
           1. CI Run Log prüfen
           2. Produktion manuell testen: https://training.nordliggrad.com
-          3. Bei Bedarf: Coolify Dashboard prüfen (Port 8000)"
+          3. Bei Bedarf: Coolify Dashboard prüfen: https://coolify.nordliggrad.com"
 
           if [ -n "$EXISTING_ISSUE" ]; then
             gh issue comment "$EXISTING_ISSUE" -R "$REPO" \

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -17,7 +17,7 @@ jobs:
         id: lighthouse
         with:
           urls: |
-            http://training.89.167.78.223.sslip.io
+            https://training.nordliggrad.com
           runs: 3
           configPath: .github/.lighthouserc.json
           budgetPath: .github/lighthouse-budget.json


### PR DESCRIPTION
## Zusammenfassung

Bereinigt zwei veraltete Referenzen in den GitHub-Workflows (Kontext: Coolify läuft seit 29.07.2026 unter https://coolify.nordliggrad.com, Port 8000 ist per Firewall geschlossen; App-URL ist https://training.nordliggrad.com):

- **ci.yml** (Failure-Notification): „Coolify Dashboard prüfen (Port 8000)" → verweist jetzt auf https://coolify.nordliggrad.com
- **lighthouse.yml**: Audit-URL `http://training.89.167.78.223.sslip.io` → `https://training.nordliggrad.com` (der Workflow schlug mit der alten URL fehl)

Keine weiteren Vorkommen von `sslip.io` oder „Port 8000" in `.github/workflows/`.

Closes #813
Ref #812

## Test

- [ ] CI grün
- [ ] Nach Merge: Lighthouse-Workflow per `workflow_dispatch` triggern und prüfen ob er durchläuft

🤖 Generated with [Claude Code](https://claude.com/claude-code)