### PR TITLE
fix(deploy): Healthcheck für frontend-Service in Coolify-Compose ergänzen (#815)

### DIFF
--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -49,6 +49,12 @@ services:
       backend:
         condition: service_healthy
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost/ || exit 1"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## Zusammenfassung

Coolify meldete die App dauerhaft als `running:unhealthy`, obwohl alles funktioniert. Ursache: `postgres` und `backend` haben in `docker-compose.coolify.yml` einen Healthcheck, der `frontend`-Service nicht — der im Frontend-Dockerfile vorhandene `HEALTHCHECK` (seit #492) greift bei Coolify-Compose-Deployments nicht. Docker meldet für den Container „no healthcheck", Coolify aggregiert das zu `unhealthy`.

## Änderung

- `healthcheck`-Block für den `frontend`-Service: `wget -q --spider http://localhost/` (BusyBox-wget im `nginx:alpine`-Image, nginx auf Port 80), Parameter konsistent zum `backend`-Service (interval 30s, timeout 5s, retries 3, start_period 10s)

## Verifikation

- `docker compose -f docker-compose.coolify.yml config` valide
- Nach Merge + Deploy: Coolify-API-Status muss `running:healthy` melden (wird nach Deploy geprüft)

Fixes #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)