### PR TITLE
docs: Coach-Wording nachziehen + Phase-1-Privacy-Verweis (#819)

### DIFF
--- a/docs/AI_PRESENCE_CONCEPT.md
+++ b/docs/AI_PRESENCE_CONCEPT.md
@@ -10,7 +10,7 @@
 
 ## Kontext
 
-Der AI Coach in minsaga war ursprünglich auf Alerts mit Robo-Icon beschränkt. Das Konzept
+Der Coach in minsaga war ursprünglich auf Alerts mit Robo-Icon beschränkt. Das Konzept
 beschreibt die emotionale Erweiterung zu einer **durchgehenden KI-Präsenz**, die
 den Nutzer onboarded und durch die App begleitet — unter Einhaltung der Marken-DNA
 (*„Coach, nicht Werkzeug"*, *„nüchtern bei Daten, warm bei Kontext"*, Tidlöshet,
@@ -120,7 +120,7 @@ Die KI-Präsenz hat einen **festen Wohnsitz in der App** (den FAB), aber sie spr
 
 | Ort | Sichtbarkeit | Dominante Stimme |
 |---|---|---|
-| **Heute-Dashboard** | AI-Coach-Insight (erstes Element, Fuchsia-Akzent) | Begleiter, Coach bei Warnung |
+| **Heute-Dashboard** | Coach-Insight (erstes Element, Fuchsia-Akzent) | Begleiter, Coach bei Warnung |
 | **FAB** | permanent als Symbol | — *(wartet)* |
 | **Chat (FAB geöffnet)** | Avatar neben jeder Antwort | Coach-dominant |
 | **Analyse / Insights** | Insight-Cards (1–2 sichtbar, rotierend) | Coach |
@@ -137,7 +137,7 @@ Kontinuitätsschichten:
 kein Schein). Wenn etwas Neues wartet (Insight, Warnung, Coach-Subline), wird der
 Schein wacher. Wenn der Nutzer es liest, kehrt Ruhe ein.
 
-**Sprachlich — Erinnerungs-Schicht:** Die AI-Coach-Subline ist nicht stateless —
+**Sprachlich — Erinnerungs-Schicht:** Die Coach-Subline ist nicht stateless —
 sie referenziert die letzten 1–3 Tage explizit, wo es Sinn macht.
 
 > „Gestern hast du geliefert. Heute schaust du, wo du stehst."
@@ -258,8 +258,8 @@ Erledigt seit v1: Form final (v4) · Stimmen-Varianten visualisiert (`comp-ai-pr
 
 ## Referenzen
 
-- [BRAND_STYLE_GUIDE.md](design/BRAND_STYLE_GUIDE.md) §3 (Designprinzipien), §5 (Farbsystem, Fuchsia für AI), §10 (Tonalität & AI Coach), §12 (Animationen)
-- [PRD](PRD.md) §1.3 (Leitprinzipien) · §5.3 (AI Coach) · §5.6 (Voice & Copy) · §9.5 (Marken-Wortmaterial) · §11.4 (EU AI Act)
+- [BRAND_STYLE_GUIDE.md](design/BRAND_STYLE_GUIDE.md) §3 (Designprinzipien), §5 (Farbsystem, Fuchsia für AI), §10 (Tonalität & Coach), §12 (Animationen)
+- [PRD](PRD.md) §1.3 (Leitprinzipien) · §5.3 (Coach) · §5.6 (Voice & Copy) · §9.5 (Marken-Wortmaterial) · §11.4 (EU AI Act)
 - Claude-Design-Projekt „Minsaga Design System" — `preview/comp-ai-presence*.html`, `preview/comp-feier-moment.html`, `uploads/BRAND_STYLE_GUIDE.md` („Das Präsenz-Zeichen")
 - Handoff-Paket `minsaga/.import/design_handoff_saga_ai_presence/` — verbindliche SVG-Geometrie, Transforms, Animationswerte *(Hinweis: Paket entstand vor der Namens-Entscheidung und nennt den Coach noch „Saga" — §2 gilt)*
 - [PR #749](https://github.com/NCS23/training-analyzer/pull/749) — Symbol-Iteration v1 (Polarstern, verworfen)

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -181,7 +181,7 @@ Wochenstruktur: **4 Läufe + 2 Krafttrainings + 1 Ruhetag**
 **Zwischendurch (anlassbezogen):**
 - *„Wo stehe ich bezüglich Ziel?"* → Goal Readiness (Heute oder Analyse)
 - *„Wie habe ich mich entwickelt?"* → Analyse-Tab
-- *„Ich habe ein Trainings-Problem (Technik, Pace, Verletzung)"* → AI Coach Chat (FAB)
+- *„Ich habe ein Trainings-Problem (Technik, Pace, Verletzung)"* → Coach-Chat (FAB)
 
 #### 2.2.2 Makro: Wettkampf-Vorbereitung (HM Sub-2h, ~16 Wochen)
 
@@ -258,7 +258,7 @@ Format: *„Wenn [Situation], möchte ich [Job], damit [Outcome]."*
 
 7. **Trainings-Problem lösen**
    *„Wenn ich ein konkretes Trainings-Problem habe (z.B. Technik-Element ergänzen, Verletzungsverdacht), möchte ich die KI fragen können und kontextualisierte Antworten erhalten."*
-   → **AI Coach Chat (FAB)** — auf jeder Seite verfügbar
+   → **Coach-Chat (FAB)** — auf jeder Seite verfügbar
 
 #### Race-bezogene Jobs
 
@@ -282,7 +282,7 @@ Format: *„Wenn [Situation], möchte ich [Job], damit [Outcome]."*
 
 12. **Insight-getriebene Plan-Anpassung**
     *„Wenn nach einem einzelnen Training ein wichtiger Insight rauskommt (Form kippt, Verletzungssignal, Pace-Sprung), möchte ich darauf hingewiesen werden und einen Anpassungs-Vorschlag bekommen."*
-    → **AI Coach Insight** (Heute) → **Plan-Anpassung-Vorschlag** (siehe §5.7)
+    → **Coach-Insight** (Heute) → **Plan-Anpassung-Vorschlag** (siehe §5.7)
 
 #### Equipment-Jobs (Vision)
 
@@ -308,7 +308,7 @@ Format: *„Wenn [Situation], möchte ich [Job], damit [Outcome]."*
 **Hauptpfad:**
 1. App öffnen → Heute-Tab
 2. **Erste Sicht (Top → Bottom):**
-   - **AI Coach Insight** (Alert variant=ai)
+   - **Coach-Insight** (Alert variant=ai)
      — *bei Form-Issue oder Anpassungs-Empfehlung: hier sofort*
    - **GoalCard (Hero)** — Race + Tage-Countdown + ReadinessRing + 4 Faktoren
    - **WeekOverviewCard mit heutiger Session-Detail** — Trainings-Typ, Pace, Distanz, CTA
@@ -329,7 +329,7 @@ Format: *„Wenn [Situation], möchte ich [Job], damit [Outcome]."*
 **Edge Cases:**
 - Heute kein Training → *„Heute kein Training."* (Copy §5.6)
 - Kein Ziel gesetzt → Empty State *„Jede Saga braucht ein Ziel."* (§5.4)
-- Form schlecht → AI Coach Insight schlägt Anpassung vor (§5.8 Goal-Realism-Check)
+- Form schlecht → Coach-Insight schlägt Anpassung vor (§5.8 Goal-Realism-Check)
 
 **Screen-Anforderungen (für Figma):**
 - Heute · Default
@@ -361,7 +361,7 @@ Format: *„Wenn [Situation], möchte ich [Job], damit [Outcome]."*
 2. **Ein-Tap-Upload** mit auto-ausgefülltem Datum + erkanntem Typ
 3. Direkt nach Upload: Session-Detail-Page mit **automatisch generierter KI-Analyse** (Pre-fetch)
 4. **Erste Sicht (Top → Bottom):**
-   - **AI Coach Insight (Hero)** — Kurz-Quittung in Begleiter-/Zeugen-Stimme, z.B. *„Solide Einheit. Pace 6s/km schneller als Schnitt für Tempoläufe. HR-Drift im normalen Bereich."*
+   - **Coach-Insight (Hero)** — Kurz-Quittung in Begleiter-/Zeugen-Stimme, z.B. *„Solide Einheit. Pace 6s/km schneller als Schnitt für Tempoläufe. HR-Drift im normalen Bereich."*
    - **Eckdaten-Stat-Reihe** kompakt: Pace · HR · Distanz · Dauer
    - **Soll/Ist-Vergleich-Card** (nur wenn Plan-Verknüpfung)
    - **Sub-Sektionen** (HR-Zonen · Laps · GPS-Karte · RPE/Notizen) **collapsed by default**, Tap zum Aufklappen
@@ -856,7 +856,7 @@ Was die App **nicht** für mich tun soll:
 ### 3.2 Sondernavigation (nicht in Bottom Nav)
 
 - **Profil & Einstellungen:** Avatar oben rechts im Header. Keine eigene Tab-Position.
-- **AI Coach Chat:** Floating Action Button (FAB) rechts unten. Auf allen Seiten verfügbar, kontextbezogen.
+- **Coach-Chat:** Floating Action Button (FAB) rechts unten. Auf allen Seiten verfügbar, kontextbezogen.
 
 ### 3.3 URL-Struktur
 
@@ -904,7 +904,7 @@ Was die App **nicht** für mich tun soll:
 
 **Komposition (von oben nach unten):**
 
-1. **AI Coach Insight** (Alert variant=ai oder eigenständige Card) — eine Zeile, kontextbezogen
+1. **Coach-Insight** (Alert variant=ai oder eigenständige Card) — eine Zeile, kontextbezogen
 2. **Goal Readiness Card** (Hero) — Race + Zielzeit + Tage-Countdown + ReadinessRing + Faktoren-Aufschlüsselung
 3. **WeekOverviewCard** — Wochenstruktur mit 7-Tage-Statusleiste; Detail-Sektion zeigt heutige Session + ist Sprungpunkt zu anderen Tagen der Woche
 
@@ -926,7 +926,7 @@ Was die App **nicht** für mich tun soll:
 **Verwandte Jobs:** §2.3 #2, #5, #11, #12, #13
 
 **Phasen-Spezifisches:**
-- Tapering: GoalCard zeigt Tapering-State; AI Coach Insight ist Tapering-fokussiert
+- Tapering: GoalCard zeigt Tapering-State; Coach-Insight ist Tapering-fokussiert
 - Race-Tag: GoalCard wechselt in `state=raceday` (Caption: *„Du hast alles getan. Jetzt lauf deine Saga."*)
 - Post-Race: GoalCard wechselt in `state=postrace` (Caption: *„Dein Kapitel ist geschrieben."*)
 
@@ -1014,13 +1014,20 @@ Was die App **nicht** für mich tun soll:
 
 *[tbd — Definition + Ableitung + Verweis auf reference/DOMAIN_MODEL.md]*
 
-### 5.3 AI Coach (Insights + Chat)
+### 5.3 Coach (Insights + Chat)
 
 *[Migration aus `archive/AI_ANALYSIS_INTEGRATION.md`]*
 
+> **Verbindliches Wording (Entscheid Juli 2026, minsaga-Umsetzung):** Der Coach ist
+> **namenlos** — „Saga" bezeichnet ausschließlich die Bildmarke/das Zeichen, nie den
+> Coach. Die frühere Bezeichnung „AI Coach" ist verworfen. Das UI-Label der
+> Insight-Card lautet **„Insight · KI-GENERIERT"**, der Chat heißt schlicht
+> **Coach-Chat**. Visuelle Präsenz: Saga-Zeichen nach `AI_PRESENCE_CONCEPT.md`
+> (kein Bot-/Robo-Icon).
+
 **Komponenten:**
-- **AICoachInsight Card** auf Dashboard — Bot-Icon + Header „Insight · KI-GENERIERT" + Body-Text
-- **Chat-FAB** rechts unten auf allen Seiten — kontextbezogen
+- **Insight-Card** auf Dashboard/Heute — Saga-Zeichen + Header „Insight · KI-GENERIERT" + Body-Text
+- **Chat-FAB** rechts unten — öffnet den Coach-Chat, kontextbezogen
 
 *[Detailspezifikation TBD]*
 
@@ -1169,7 +1176,7 @@ Pro Feature/Bereich eines von vier Labels:
 |---|---|---|
 | 🟢 **KEEP** | Existiert, wird übernommen, keine Änderung | CSV-Parser für Apple Watch Format |
 | 🟡 **ADAPT** | Existiert, muss angepasst werden (UI, API, Naming) | Sessions-Liste → unter Tab „Training" einordnen |
-| 🔵 **NEW** | Existiert nicht, wird neu gebaut | Goal Readiness, AI Coach Chat-FAB |
+| 🔵 **NEW** | Existiert nicht, wird neu gebaut | Goal Readiness, Coach-Chat-FAB |
 | 🔴 **REMOVE** | Existiert, wird ersatzlos entfernt | Level-System (FITNESS_LEVEL_SYSTEM_V2 → siehe Archiv) |
 
 ### 6.2 Routen-Map (Frontend) — Ist-Zustand
@@ -1193,7 +1200,7 @@ Pro Feature/Bereich eines von vier Labels:
 | `/plan/exercises` (+ `/:id`) | `ExerciseLibrary*` | Übungsbibliothek | **Sammlung** | 🟡 ADAPT — Routing → `/sammlung/uebungen` |
 | `/plan/routes` (+ `/new`, `/:id`) | `Routes*` / `RouteEditorPage` | Routen zeichnen, OSRM-Snap, Segmente, Pacing, GPX/FIT-Export | **Sammlung** | 🟡 ADAPT — Routing → `/sammlung/routen` |
 | `/profile` | `AthleteProfilePage` | Profil, HF, KI-Keys, Provider | Header-Avatar | 🟢 KEEP |
-| `/chat` | `ChatPage` | KI-Chat (Konversationen, Streaming, Plan-Anwendung) | AI Coach FAB | 🟡 ADAPT — Chat als FAB überall, nicht eigene Seite |
+| `/chat` | `ChatPage` | KI-Chat (Konversationen, Streaming, Plan-Anwendung) | Coach FAB | 🟡 ADAPT — Chat als FAB überall, nicht eigene Seite |
 | `/ki-log` | `KiLogPage` | Alle KI-Calls (Debug) | (intern) | 🔴 REMOVE oder → `/admin` |
 | `/admin/users` | `AdminUsersPage` | User-Verwaltung | (Admin) | 🟢 KEEP |
 
@@ -1258,7 +1265,7 @@ Pro Feature/Bereich eines von vier Labels:
 
 **Heute-Tab (§4.1):**
 - GoalCard als Hero (mit ReadinessRing + Faktoren) — nicht implementiert
-- AI Coach Insight als erstes Element — falsche Reihenfolge
+- Coach-Insight als erstes Element — falsche Reihenfolge
 - WeekOverviewCard mit eingebetteter PlannedSessionCard-Detail — `WeekProgress` existiert, aber ohne Detail-Section
 - GoalCard Tapering-/Race-Day-/Post-Race-State — alle nicht implementiert
 
@@ -1437,7 +1444,7 @@ In `training-analyzer/docs/PRD.md` (Anfang):
 | **1.0** | Apple Developer Account + TestFlight-Setup | klein |
 | **1.1** | Native iOS-App-Setup (SwiftUI, Architektur, AppShell, Navigation) | groß |
 | **1.2** | HealthKit-Integration + Auto-FIT-Import + Auto-Workout-Erkennung | mittel |
-| **1.3** | Heute-Tab nativ (GoalCard-Hero, WeekOverview, AI Coach Insight) | groß |
+| **1.3** | Heute-Tab nativ (GoalCard-Hero, WeekOverview, Coach-Insight) | groß |
 | **1.4** | Training-Tab nativ (Sessions, Detail, Soll/Ist-Compare, Collapse-Sektionen) | mittel |
 | **1.5** | Plan-Tab nativ + Pacing-Rechner | mittel |
 | **1.6** | Analyse-Tab nativ + Insights-Engine | mittel |
@@ -1630,7 +1637,7 @@ Jeder Trainings-Begriff fällt in eine von vier Klassen:
 | Routen, Übungs-Bibliothek | ✅ | ✅ | ✅ | ✅ |
 | Algo-Wochen-Review (regel-basiert) | ✅ | ✅ | ✅ | ✅ |
 | **KI-Insights nach Sessions** | ❌ | ✅ | ✅ | ✅ |
-| **AI Coach Chat** | ❌ | ✅ | ✅ | ✅ |
+| **Coach-Chat** | ❌ | ✅ | ✅ | ✅ |
 | **KI-Wochen-Review** | ❌ | ✅ | ✅ | ✅ |
 | **KI-Plan-Generierung** | **1× Lifetime beim Onboarding** | ✅ unbegrenzt | ✅ | ✅ |
 | **Plan-Anpassungs-Vorschläge** | ❌ | ✅ | ✅ | ✅ |
@@ -1939,6 +1946,12 @@ Der eigentliche Grund für UG/GmbH ist **nicht** Apple oder Stripe, sondern Haft
 ### 11.1 DSGVO-Pflichten
 
 #### Datenschutzerklärung (Privacy Policy)
+
+> **Phase 1 (umgesetzt):** Die reduzierte Datenschutzerklärung der iOS-App liegt in
+> [`NCS23/minsaga` → `docs/PRIVACY.md`](https://github.com/NCS23/minsaga/blob/main/docs/PRIVACY.md)
+> und ist in der App als Screen (Profil + Onboarding-Link) verfügbar. Sie deckt den
+> On-Device-Zuschnitt ab: keine Konten, private CloudKit-DB, KI on-device. Der
+> folgende volle Umfang gilt für Phase 3 (Markt-Launch).
 
 Pflicht auf Website + in der App (Settings + Onboarding-Link). Inhalt:
 

--- a/docs/design/BRAND_STYLE_GUIDE.md
+++ b/docs/design/BRAND_STYLE_GUIDE.md
@@ -241,7 +241,7 @@ Im Logo sichtbar als Nordlicht-Gradient (sky → cyan → indigo):
 | accent-4 | fuchsia | `#d946ef` | AI / Coach |
 | accent-5 | slate | `#64748b` | Info |
 
-**Fuchsia für den AI Coach:** Klar getrennt von allen anderen Systemfarben.
+**Fuchsia für den Coach:** Klar getrennt von allen anderen Systemfarben.
 Signalisiert sofort: das ist KI-generierter Inhalt.
 
 ### Neutral Colors
@@ -515,7 +515,7 @@ Wenn mehrere Cards gleichzeitig sichtbar sind und Dichte wichtiger ist als Lufti
 Default-Wahl. Wenn du dich fragst „welches Padding?" — nimm `normal`.
 
 - Single primary content cards — die „Als Nächstes"-Card auf dem Heute-Dashboard
-- AI Coach Messages
+- Coach-Nachrichten
 - Form-Cards (Einstellungen, Eingabefelder gruppiert)
 - Die meisten Main-Content-Situationen
 
@@ -551,7 +551,7 @@ Wenn die Card der **Fokus** eines Screens oder Moments ist. Luft als Aussage.
 
 Default für jede Card, die **selbst** auf der Page oder in einem Container steht. Wenn du dich fragst „welche Elevation?" — nimm `raised`.
 
-- Dashboard-Cards auf der Page — Goal-Card, Stat-Cards, AI-Coach-Messages
+- Dashboard-Cards auf der Page — Goal-Card, Stat-Cards, Coach-Messages
 - Listen-Items die eigenständig wirken sollen — z.B. SessionCard in der Trainingshistorie
 - Alle Top-Level-Cards auf einem Screen
 
@@ -612,16 +612,16 @@ Default für jede Card, die **selbst** auf der Page oder in einem Container steh
 - Klar und direkt — keine Füllwörter, keine Marketing-Floskeln
 - Nüchtern bei Daten, warm bei Kontext
 
-### Der AI Coach
+### Der Coach
 
 > Vollständiges Konzept (drei Stimmen, Symbol, FAB-Verankerung, Form): [AI_PRESENCE_CONCEPT.md](AI_PRESENCE_CONCEPT.md) · Issue [#751](https://github.com/NCS23/training-analyzer/issues/751)
 
-Der AI Coach ist kein Chatbot — er ist ein persönlicher Trainingsbegleiter.
+Der Coach ist kein Chatbot — er ist ein persönlicher Trainingsbegleiter.
 Er analysiert abgeschlossene Trainings, gibt konkretes Feedback, schlägt Pläne vor
 und passt diese kontinuierlich an. Er kennt die Ziele des Läufers und erinnert
 ihn daran wenn es darauf ankommt.
 
-**Ton des AI Coach:** Klar, direkt, motivierend — nie bevormundend.
+**Ton des Coaches:** Klar, direkt, motivierend — nie bevormundend.
 
 **Drei Stimmen, eine Präsenz:**
 
@@ -726,7 +726,7 @@ CTL allein reicht nicht — es misst Volumen, nicht Rennvorbereitung. Deshalb 4 
 | Tempoläufe | Pace-spezifische Vorbereitung |
 | Konsistenz | Trainingstage / 30 in letzten 42 Tagen |
 
-Schwacher Wert (<70 %) wird orange hervorgehoben. AI Coach greift den schwächsten
+Schwacher Wert (<70 %) wird orange hervorgehoben. Coach greift den schwächsten
 Wert direkt auf und macht daraus eine Empfehlung.
 
 ### Krafttraining
@@ -764,7 +764,7 @@ Beispiele:
 > *Setz den Horizont — wir zeigen dir den Weg dorthin."*
 
 Wenn kein Ziel gesetzt ist, fällt die Goal-Card weg. Die WeekOverviewCard kann
-trotzdem angezeigt werden — mit allgemeinen Empfehlungen des AI Coach in den
+trotzdem angezeigt werden — mit allgemeinen Empfehlungen des Coaches in den
 Tages-Details.
 
 ### Goal-Achievement-Feier


### PR DESCRIPTION
Closes #819

- **Wording:** „AI Coach" → „Coach" / „Coach-Insight" / „Coach-Chat" in PRD.md (15 Stellen), AI_PRESENCE_CONCEPT.md und BRAND_STYLE_GUIDE.md — Archiv-Dokumente bewusst unangetastet.
- **PRD §5.3:** Verbindliches Wording als Entscheid dokumentiert: Coach namenlos („Saga" = nur das Zeichen), UI-Label „Insight · KI-GENERIERT", Saga-Zeichen statt Bot-Icon.
- **PRD §11.1:** Verweis auf die umgesetzte Phase-1-Datenschutzerklärung (NCS23/minsaga docs/PRIVACY.md); voller Compliance-Stack bleibt Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)