### PR TITLE
feat(profile): minsaga-Export als UI-Funktion im Athletenprofil (#821)

### DIFF
--- a/frontend/src/components/settings/MinsagaExportCard.tsx
+++ b/frontend/src/components/settings/MinsagaExportCard.tsx
@@ -1,0 +1,80 @@
+// MinsagaExportCard — Export für die minsaga-App-Migration (#821).
+//
+// Sammelt Profilwerte, Ziele und Trainingspläne (inkl. Phasen-Details)
+// über die bestehenden APIs und lädt ein minsaga-export.json herunter,
+// das die iOS-App im Profil einliest. Workouts sind bewusst nicht dabei.
+
+import { useState } from 'react';
+import {
+  Card,
+  CardBody,
+  Button,
+  Alert,
+  AlertDescription,
+  Spinner,
+  useToast,
+} from '@nordlig/components';
+import { getAthleteSettings } from '@/api/athlete';
+import { listGoals } from '@/api/goals';
+import { getTrainingPlan, listTrainingPlans } from '@/api/training-plans';
+import { buildMinsagaExport, downloadMinsagaExportFile } from '@/utils/minsagaExport';
+
+export function MinsagaExportCard() {
+  const { toast } = useToast();
+  const [exporting, setExporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleExport = async () => {
+    setExporting(true);
+    setError(null);
+    try {
+      const [athlete, goalsResponse, plansResponse] = await Promise.all([
+        getAthleteSettings(),
+        listGoals(),
+        listTrainingPlans(),
+      ]);
+      // Die Liste liefert nur Summaries — Phasen kommen aus dem Detail.
+      const plans = await Promise.all(
+        plansResponse.plans.map((summary) => getTrainingPlan(summary.id)),
+      );
+      const exportData = buildMinsagaExport(athlete, goalsResponse.goals, plans);
+      downloadMinsagaExportFile(exportData);
+      toast({
+        title: `Export erstellt: ${exportData.goals.length} Ziele, ${exportData.plans.length} Pläne`,
+        variant: 'success',
+      });
+    } catch {
+      setError('Export fehlgeschlagen — bitte erneut versuchen.');
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  return (
+    <Card elevation="raised" padding="spacious">
+      <CardBody className="flex items-center justify-between gap-4">
+        <div>
+          <h3 className="text-sm font-semibold">Export für minsaga</h3>
+          <p className="text-xs text-[var(--color-text-muted)]">
+            Ziele, Trainingspläne und Profilwerte als minsaga-export.json — in der minsaga-App unter
+            Profil → „Aus Training Analyzer importieren" einlesen. Deine Workouts kommen dort aus
+            Apple Health.
+          </p>
+          {error && (
+            <Alert variant="error" closeable onClose={() => setError(null)} className="mt-3">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+        </div>
+        <Button
+          variant="secondary"
+          onClick={handleExport}
+          disabled={exporting}
+          className="shrink-0"
+        >
+          {exporting ? <Spinner size="sm" aria-hidden="true" /> : 'Herunterladen'}
+        </Button>
+      </CardBody>
+    </Card>
+  );
+}

--- a/frontend/src/pages/AthleteProfile.tsx
+++ b/frontend/src/pages/AthleteProfile.tsx
@@ -16,6 +16,7 @@ import {
 import { getAthleteSettings, updateAthleteSettings } from '@/api/athlete';
 import { useApiKeySettings } from '@/hooks/useApiKeySettings';
 import { ApiKeyCard } from '@/components/settings/ApiKeyCard';
+import { MinsagaExportCard } from '@/components/settings/MinsagaExportCard';
 import { ThresholdTestCard } from '@/components/threshold-test/ThresholdTestCard';
 
 // Karvonen zone definitions — mirrors backend/app/services/hr_zone_calculator.py
@@ -324,6 +325,9 @@ export function AthleteProfilePage() {
 
       {/* API Keys */}
       <ApiKeyCard keys={apiKeys} />
+
+      {/* minsaga-Migration (#821) */}
+      <MinsagaExportCard />
 
       {/* KI Debug Log Link */}
       <Link

--- a/frontend/src/utils/minsagaExport.test.ts
+++ b/frontend/src/utils/minsagaExport.test.ts
@@ -1,0 +1,95 @@
+// minsagaExport.test — Format-Version 1 muss stabil bleiben (#821):
+// die minsaga-iOS-App parst genau diese Struktur.
+
+import { describe, expect, it } from 'vitest';
+import { buildMinsagaExport } from './minsagaExport';
+import type { AthleteSettings } from '@/api/athlete';
+import type { RaceGoal } from '@/api/goals';
+import type { TrainingPlan } from '@/api/training-plans';
+
+const athlete = {
+  lthr: 172,
+  resting_hr: 48,
+  max_hr: 191,
+} as AthleteSettings;
+
+const goal = {
+  title: 'Halbmarathon Hamburg',
+  race_date: '2026-11-05',
+  distance_km: 21.0975,
+  target_time_seconds: 7140,
+  is_active: true,
+} as RaceGoal;
+
+const plan = {
+  name: 'HM Sub 2h',
+  status: 'active',
+  start_date: '2026-08-03',
+  end_date: '2026-11-01',
+  goal_summary: { id: 1, title: 'Halbmarathon Hamburg' },
+  phases: [
+    {
+      name: 'Base',
+      phase_type: 'base',
+      start_week: 1,
+      end_week: 6,
+      weekly_template: {
+        days: [
+          {
+            day_of_week: 2,
+            is_rest_day: false,
+            sessions: [{ training_type: 'running', run_type: 'easy', notes: 'locker' }],
+          },
+          { day_of_week: 1, is_rest_day: true, sessions: [] },
+        ],
+      },
+    },
+  ],
+} as unknown as TrainingPlan;
+
+describe('buildMinsagaExport (#821)', () => {
+  it('baut Format-Version 1 mit athlete, goals und plans', () => {
+    const result = buildMinsagaExport(athlete, [goal], [plan]);
+
+    expect(result.version).toBe(1);
+    expect(result.athlete).toEqual({ lthr: 172, resting_hr: 48, max_hr: 191 });
+    expect(result.goals).toEqual([
+      {
+        title: 'Halbmarathon Hamburg',
+        race_date: '2026-11-05',
+        distance_km: 21.0975,
+        target_time_seconds: 7140,
+        is_active: true,
+      },
+    ]);
+    expect(result.plans[0]).toMatchObject({
+      name: 'HM Sub 2h',
+      status: 'active',
+      goal_title: 'Halbmarathon Hamburg',
+    });
+    expect(result.plans[0].phases[0].weekly_template.days).toHaveLength(2);
+    expect(result.plans[0].phases[0].weekly_template.days[0].sessions[0]).toEqual({
+      training_type: 'running',
+      run_type: 'easy',
+      notes: 'locker',
+    });
+  });
+
+  it('übersteht Plan ohne Ziel und Phase ohne Template', () => {
+    const kahlerPlan = {
+      name: 'Leer',
+      status: 'draft',
+      start_date: '2026-01-01',
+      end_date: '2026-02-01',
+      goal_summary: null,
+      phases: [
+        { name: 'P1', phase_type: 'base', start_week: 1, end_week: 4, weekly_template: null },
+      ],
+    } as unknown as TrainingPlan;
+
+    const result = buildMinsagaExport(athlete, [], [kahlerPlan]);
+
+    expect(result.plans[0].goal_title).toBeNull();
+    expect(result.plans[0].phases[0].weekly_template.days).toEqual([]);
+  });
+});

--- a/frontend/src/utils/minsagaExport.ts
+++ b/frontend/src/utils/minsagaExport.ts
@@ -1,0 +1,110 @@
+// minsagaExport — baut das minsaga-export.json für die App-Migration (#821).
+//
+// Format-Version 1, identisch zum CLI-Script scripts/export_minsaga.py:
+// die minsaga-iOS-App liest die Datei im Profil über „Aus Training
+// Analyzer importieren". Historische Workouts sind bewusst NICHT
+// enthalten — die kommen in minsaga aus Apple Health (Import-Master).
+
+import type { AthleteSettings } from '@/api/athlete';
+import type { RaceGoal } from '@/api/goals';
+import type { TrainingPlan } from '@/api/training-plans';
+
+export interface MinsagaExport {
+  version: 1;
+  athlete: {
+    lthr: number | null;
+    resting_hr: number | null;
+    max_hr: number | null;
+  };
+  goals: Array<{
+    title: string;
+    race_date: string;
+    distance_km: number;
+    target_time_seconds: number | null;
+    is_active: boolean;
+  }>;
+  plans: Array<{
+    name: string;
+    status: string;
+    start_date: string;
+    end_date: string;
+    goal_title: string | null;
+    phases: Array<{
+      name: string;
+      phase_type: string;
+      start_week: number;
+      end_week: number;
+      weekly_template: {
+        days: Array<{
+          day_of_week: number;
+          is_rest_day: boolean;
+          sessions: Array<{
+            training_type: string;
+            run_type: string | null;
+            notes: string | null;
+          }>;
+        }>;
+      };
+    }>;
+  }>;
+}
+
+/** Pure Zusammenstellung — testbar ohne API. */
+export function buildMinsagaExport(
+  athlete: AthleteSettings,
+  goals: RaceGoal[],
+  plans: TrainingPlan[],
+): MinsagaExport {
+  return {
+    version: 1,
+    athlete: {
+      lthr: athlete.lthr,
+      resting_hr: athlete.resting_hr,
+      max_hr: athlete.max_hr,
+    },
+    goals: goals.map((goal) => ({
+      title: goal.title,
+      race_date: goal.race_date,
+      distance_km: goal.distance_km,
+      target_time_seconds: goal.target_time_seconds ?? null,
+      is_active: goal.is_active,
+    })),
+    plans: plans.map((plan) => ({
+      name: plan.name,
+      status: plan.status,
+      start_date: plan.start_date,
+      end_date: plan.end_date,
+      goal_title: plan.goal_summary?.title ?? null,
+      phases: plan.phases.map((phase) => ({
+        name: phase.name,
+        phase_type: phase.phase_type,
+        start_week: phase.start_week,
+        end_week: phase.end_week,
+        weekly_template: {
+          days: (phase.weekly_template?.days ?? []).map((day) => ({
+            day_of_week: day.day_of_week,
+            is_rest_day: day.is_rest_day,
+            sessions: day.sessions.map((session) => ({
+              training_type: session.training_type,
+              run_type: session.run_type ?? null,
+              notes: session.notes ?? null,
+            })),
+          })),
+        },
+      })),
+    })),
+  };
+}
+
+/** Löst den Browser-Download der fertigen Export-Datei aus. */
+export function downloadMinsagaExportFile(exportData: MinsagaExport): void {
+  const blob = new Blob([JSON.stringify(exportData, null, 2)], {
+    type: 'application/json',
+  });
+  const url = window.URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = 'minsaga-export.json';
+  anchor.click();
+  window.URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
Closes #821

- **MinsagaExportCard** im Athletenprofil (unter den API-Keys): Button lädt `minsaga-export.json` direkt im Browser herunter
- Client-seitig über die bestehenden APIs: `athlete/settings`, `goals`, `training-plans` (Liste + Detail je Plan für die Phasen)
- `buildMinsagaExport()` als pure, getestete Funktion — Format identisch zu Script-Version 1 (`scripts/export_minsaga.py`), das die minsaga-iOS-App im Profil einliest
- Workouts bewusst nicht enthalten (kommen in minsaga aus Apple Health)
- 2 neue Vitest-Tests (Format v1 + Robustheit bei Plan ohne Ziel/Template); Gesamtsuite 205 grün, ESLint/Prettier/tsc grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)