### PR TITLE
feat(export): vollständiger minsaga-Export v2 — Wochenplan + Changelog + Schwellentests (#823)

### DIFF
--- a/backend/app/api/v1/export_minsaga.py
+++ b/backend/app/api/v1/export_minsaga.py
@@ -1,0 +1,252 @@
+"""Vollstaendiger Export fuer die minsaga-Migration (#823, Format-Version 2).
+
+Sammelt serverseitig ALLES, was fuer nahtloses Weitertrainieren in der
+minsaga-iOS-App noetig ist: Profilwerte + Schwellentests, Ziele, Plaene
+mit Phasen-Templates UND Changelog (Entscheidungen samt Begruendung),
+sowie saemtliche gespeicherten Wochenplan-Wochen inklusive aller
+Anpassungen (run_details, Status, edited-Flag).
+
+Historische Workouts sind bewusst NICHT enthalten — die kommen in
+minsaga aus Apple Health (Import-Master).
+"""
+
+import json
+from datetime import datetime
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dependencies import get_current_active_user
+from app.infrastructure.database.models import (
+    AthleteModel,
+    PlanChangeLogModel,
+    PlannedSessionModel,
+    RaceGoalModel,
+    ThresholdTestModel,
+    TrainingPhaseModel,
+    TrainingPlanModel,
+    UserModel,
+    WeeklyPlanDayModel,
+)
+from app.infrastructure.database.session import get_db
+
+router = APIRouter(prefix="/export", tags=["export"])
+
+
+def _parse_json(raw: str | None) -> object:
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _iso(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+async def _athlete_block(db: AsyncSession, user_id: int) -> dict[str, object]:
+    athlete_result = await db.execute(select(AthleteModel).where(AthleteModel.user_id == user_id))
+    athlete = athlete_result.scalars().first()
+
+    latest_test_result = await db.execute(
+        select(ThresholdTestModel)
+        .where(ThresholdTestModel.user_id == user_id)
+        .order_by(ThresholdTestModel.test_date.desc())
+        .limit(1)
+    )
+    latest_test = latest_test_result.scalars().first()
+
+    return {
+        "resting_hr": athlete.resting_hr if athlete else None,
+        "max_hr": athlete.max_hr if athlete else None,
+        "lthr": latest_test.lthr if latest_test else None,
+        "threshold_pace_sec_per_km": latest_test.avg_pace_sec if latest_test else None,
+    }
+
+
+async def _threshold_tests_block(db: AsyncSession, user_id: int) -> list[dict[str, object]]:
+    result = await db.execute(
+        select(ThresholdTestModel)
+        .where(ThresholdTestModel.user_id == user_id)
+        .order_by(ThresholdTestModel.test_date)
+    )
+    return [
+        {
+            "test_date": _iso(test.test_date),
+            "lthr": test.lthr,
+            "max_hr_measured": test.max_hr_measured,
+            "avg_pace_sec": test.avg_pace_sec,
+        }
+        for test in result.scalars().all()
+    ]
+
+
+async def _goals_block(db: AsyncSession, user_id: int) -> list[dict[str, object]]:
+    result = await db.execute(
+        select(RaceGoalModel)
+        .where(RaceGoalModel.user_id == user_id)
+        .order_by(RaceGoalModel.race_date)
+    )
+    return [
+        {
+            "title": goal.title,
+            "race_date": _iso(goal.race_date),
+            "distance_km": goal.distance_km,
+            "target_time_seconds": goal.target_time_seconds,
+            "is_active": goal.is_active,
+        }
+        for goal in result.scalars().all()
+    ]
+
+
+async def _changelog_block(db: AsyncSession, plan_id: int) -> list[dict[str, object]]:
+    result = await db.execute(
+        select(PlanChangeLogModel)
+        .where(PlanChangeLogModel.plan_id == plan_id)
+        .order_by(PlanChangeLogModel.created_at)
+    )
+    return [
+        {
+            "change_type": entry.change_type,
+            "category": entry.category,
+            "summary": entry.summary,
+            "details": _parse_json(entry.details_json),
+            "reason": entry.reason,
+            "created_by": entry.created_by,
+            "created_at": _iso(entry.created_at),
+        }
+        for entry in result.scalars().all()
+    ]
+
+
+async def _plans_block(db: AsyncSession, user_id: int) -> list[dict[str, object]]:
+    plans_result = await db.execute(
+        select(TrainingPlanModel)
+        .where(TrainingPlanModel.user_id == user_id)
+        .order_by(TrainingPlanModel.start_date)
+    )
+    plans: list[dict[str, object]] = []
+    for plan in plans_result.scalars().all():
+        goal_title = None
+        if plan.goal_id:
+            goal_result = await db.execute(
+                select(RaceGoalModel.title).where(RaceGoalModel.id == plan.goal_id)
+            )
+            goal_title = goal_result.scalar_one_or_none()
+
+        phases_result = await db.execute(
+            select(TrainingPhaseModel)
+            .where(TrainingPhaseModel.training_plan_id == plan.id)
+            .order_by(TrainingPhaseModel.start_week)
+        )
+        phases = [
+            {
+                "name": phase.name,
+                "phase_type": phase.phase_type,
+                "start_week": phase.start_week,
+                "end_week": phase.end_week,
+                "notes": phase.notes,
+                "weekly_template": _parse_json(phase.weekly_template_json) or {"days": []},
+                "weekly_templates": _parse_json(phase.weekly_templates_json),
+            }
+            for phase in phases_result.scalars().all()
+        ]
+
+        plans.append(
+            {
+                "id": plan.id,
+                "name": plan.name,
+                "description": plan.description,
+                "status": plan.status,
+                "start_date": _iso(plan.start_date),
+                "end_date": _iso(plan.end_date),
+                "target_event_date": _iso(plan.target_event_date),
+                "goal_title": goal_title,
+                "phases": phases,
+                "changelog": await _changelog_block(db, plan.id),
+            }
+        )
+    return plans
+
+
+async def _weekly_plans_block(
+    db: AsyncSession, user_id: int, plan_names: dict[int, str]
+) -> list[dict[str, object]]:
+    days_result = await db.execute(
+        select(WeeklyPlanDayModel)
+        .where(WeeklyPlanDayModel.user_id == user_id)
+        .order_by(WeeklyPlanDayModel.week_start, WeeklyPlanDayModel.day_of_week)
+    )
+    days = list(days_result.scalars().all())
+    if not days:
+        return []
+
+    sessions_result = await db.execute(
+        select(PlannedSessionModel)
+        .where(PlannedSessionModel.day_id.in_([day.id for day in days]))
+        .order_by(PlannedSessionModel.day_id, PlannedSessionModel.position)
+    )
+    sessions_by_day: dict[int, list[PlannedSessionModel]] = {}
+    for session in sessions_result.scalars().all():
+        sessions_by_day.setdefault(int(session.day_id), []).append(session)
+
+    weeks: dict[str, dict[str, object]] = {}
+    for day in days:
+        week_key = _iso(day.week_start) or ""
+        week = weeks.setdefault(week_key, {"week_start": week_key, "days": []})
+        day_sessions = [
+            {
+                "position": session.position,
+                "training_type": session.training_type,
+                "run_details": _parse_json(session.run_details_json),
+                "notes": session.notes,
+                "status": session.status,
+            }
+            for session in sessions_by_day.get(day.id, [])
+        ]
+        assert isinstance(week["days"], list)
+        week["days"].append(
+            {
+                "day_of_week": day.day_of_week,
+                "is_rest_day": day.is_rest_day,
+                "edited": day.edited,
+                "notes": day.notes,
+                "plan_name": plan_names.get(day.plan_id) if day.plan_id else None,
+                "sessions": day_sessions,
+            }
+        )
+    return list(weeks.values())
+
+
+@router.get("/minsaga")
+async def export_minsaga(
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_active_user),
+) -> dict[str, object]:
+    """Kompletter minsaga-Export (Format-Version 2)."""
+    user_id = int(current_user.id)
+
+    plans = await _plans_block(db, user_id)
+    plan_names = {
+        int(plan["id"]): str(plan["name"]) for plan in plans if isinstance(plan["id"], int)
+    }
+    # Interne Plan-IDs gehoeren nicht in den Export — nur zum Aufloesen benutzt.
+    for plan in plans:
+        plan.pop("id", None)
+
+    return {
+        "version": 2,
+        "exported_at": datetime.utcnow().isoformat(),
+        "athlete": await _athlete_block(db, user_id),
+        "threshold_tests": await _threshold_tests_block(db, user_id),
+        "goals": await _goals_block(db, user_id),
+        "plans": plans,
+        "weekly_plans": await _weekly_plans_block(db, user_id, plan_names),
+    }

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -7,6 +7,7 @@ from app.api.v1 import (
     athlete,
     auth,
     exercise_library,
+    export_minsaga,
     fitness,
     goals,
     health,
@@ -36,6 +37,7 @@ api_router.include_router(strength.router, tags=["strength"])
 api_router.include_router(sessions.router, tags=["sessions"])
 api_router.include_router(athlete.router, tags=["athlete"])
 api_router.include_router(threshold_tests.router, tags=["threshold-tests"])
+api_router.include_router(export_minsaga.router, tags=["export"])
 api_router.include_router(goals.router, tags=["goals"])
 api_router.include_router(pacing.router, tags=["pacing"])
 api_router.include_router(ai.router, tags=["ai"])

--- a/backend/app/tests/test_export_minsaga.py
+++ b/backend/app/tests/test_export_minsaga.py
@@ -1,0 +1,111 @@
+"""Tests fuer den vollstaendigen minsaga-Export (#823, Format-Version 2)."""
+
+import pytest
+from httpx import AsyncClient
+
+PLAN_DATA = {
+    "name": "HM Sub 2h",
+    "description": "Halbmarathon-Vorbereitung",
+    "start_date": "2026-08-03",
+    "end_date": "2026-11-01",
+    "status": "active",
+}
+
+WEEK = "2026-08-03"
+
+WEEKLY_PLAN = {
+    "week_start": WEEK,
+    "entries": [
+        {
+            "day_of_week": 0,
+            "sessions": [
+                {
+                    "training_type": "running",
+                    "position": 0,
+                    "notes": "getauscht wegen Termin",
+                    "run_details": {
+                        "run_type": "easy",
+                        "target_duration_minutes": 45,
+                        "target_pace_min": "6:00",
+                        "target_pace_max": "6:30",
+                    },
+                }
+            ],
+        },
+        {"day_of_week": 1, "is_rest_day": True},
+        {
+            "day_of_week": 3,
+            "sessions": [
+                {
+                    "training_type": "running",
+                    "position": 0,
+                    "status": "skipped",
+                    "run_details": {"run_type": "intervals", "target_duration_minutes": 60},
+                }
+            ],
+        },
+    ],
+}
+
+
+@pytest.mark.anyio
+async def test_export_enthaelt_wochenplan_und_changelog(client: AsyncClient) -> None:
+    plan_resp = await client.post("/api/v1/training-plans", json=PLAN_DATA)
+    assert plan_resp.status_code == 201
+
+    save_resp = await client.put("/api/v1/weekly-plan", json=WEEKLY_PLAN)
+    assert save_resp.status_code == 200
+
+    export_resp = await client.get("/api/v1/export/minsaga")
+    assert export_resp.status_code == 200
+    export = export_resp.json()
+
+    assert export["version"] == 2
+    assert "exported_at" in export
+
+    # Plan mit Changelog (plan_created ist immer da), interne IDs draussen
+    assert len(export["plans"]) == 1
+    plan = export["plans"][0]
+    assert plan["name"] == "HM Sub 2h"
+    assert "id" not in plan
+    change_types = [entry["change_type"] for entry in plan["changelog"]]
+    assert "plan_created" in change_types
+
+    # Wochenplan: Anpassungen inkl. run_details, Status und Notizen
+    assert len(export["weekly_plans"]) == 1
+    week = export["weekly_plans"][0]
+    assert week["week_start"] == WEEK
+    montag = next(day for day in week["days"] if day["day_of_week"] == 0)
+    session = montag["sessions"][0]
+    assert session["run_details"]["run_type"] == "easy"
+    assert session["run_details"]["target_pace_min"] == "6:00"
+    assert session["notes"] == "getauscht wegen Termin"
+    donnerstag = next(day for day in week["days"] if day["day_of_week"] == 3)
+    assert donnerstag["sessions"][0]["status"] == "skipped"
+    dienstag = next(day for day in week["days"] if day["day_of_week"] == 1)
+    assert dienstag["is_rest_day"] is True
+
+
+@pytest.mark.anyio
+async def test_export_athlete_aus_schwellentest(client: AsyncClient) -> None:
+    test_resp = await client.post(
+        "/api/v1/threshold-tests",
+        json={"test_date": "2026-07-15", "lthr": 172, "avg_pace_sec": 310.0},
+    )
+    assert test_resp.status_code == 201
+
+    export = (await client.get("/api/v1/export/minsaga")).json()
+
+    assert export["athlete"]["lthr"] == 172
+    assert export["athlete"]["threshold_pace_sec_per_km"] == 310.0
+    assert export["threshold_tests"][0]["test_date"] == "2026-07-15"
+
+
+@pytest.mark.anyio
+async def test_export_leerer_zustand(client: AsyncClient) -> None:
+    export = (await client.get("/api/v1/export/minsaga")).json()
+
+    assert export["version"] == 2
+    assert export["goals"] == []
+    assert export["plans"] == []
+    assert export["weekly_plans"] == []

--- a/frontend/src/components/settings/MinsagaExportCard.tsx
+++ b/frontend/src/components/settings/MinsagaExportCard.tsx
@@ -1,8 +1,9 @@
-// MinsagaExportCard — Export für die minsaga-App-Migration (#821).
+// MinsagaExportCard — Export für die minsaga-App-Migration (#821, #823).
 //
-// Sammelt Profilwerte, Ziele und Trainingspläne (inkl. Phasen-Details)
-// über die bestehenden APIs und lädt ein minsaga-export.json herunter,
-// das die iOS-App im Profil einliest. Workouts sind bewusst nicht dabei.
+// Der Export kommt komplett vom Backend (Format-Version 2): Profil +
+// Schwellentests, Ziele, Pläne mit Changelog (Entscheidungen samt
+// Begründung) und alle Wochenplan-Wochen mit ihren Anpassungen.
+// Workouts sind bewusst nicht dabei — die kommen aus Apple Health.
 
 import { useState } from 'react';
 import {
@@ -14,10 +15,7 @@ import {
   Spinner,
   useToast,
 } from '@nordlig/components';
-import { getAthleteSettings } from '@/api/athlete';
-import { listGoals } from '@/api/goals';
-import { getTrainingPlan, listTrainingPlans } from '@/api/training-plans';
-import { buildMinsagaExport, downloadMinsagaExportFile } from '@/utils/minsagaExport';
+import { downloadMinsagaExport } from '@/utils/minsagaExport';
 
 export function MinsagaExportCard() {
   const { toast } = useToast();
@@ -28,19 +26,9 @@ export function MinsagaExportCard() {
     setExporting(true);
     setError(null);
     try {
-      const [athlete, goalsResponse, plansResponse] = await Promise.all([
-        getAthleteSettings(),
-        listGoals(),
-        listTrainingPlans(),
-      ]);
-      // Die Liste liefert nur Summaries — Phasen kommen aus dem Detail.
-      const plans = await Promise.all(
-        plansResponse.plans.map((summary) => getTrainingPlan(summary.id)),
-      );
-      const exportData = buildMinsagaExport(athlete, goalsResponse.goals, plans);
-      downloadMinsagaExportFile(exportData);
+      const summary = await downloadMinsagaExport();
       toast({
-        title: `Export erstellt: ${exportData.goals.length} Ziele, ${exportData.plans.length} Pläne`,
+        title: `Export erstellt: ${summary.goals} Ziele, ${summary.plans} Pläne, ${summary.weeks} Wochen`,
         variant: 'success',
       });
     } catch {
@@ -56,9 +44,10 @@ export function MinsagaExportCard() {
         <div>
           <h3 className="text-sm font-semibold">Export für minsaga</h3>
           <p className="text-xs text-[var(--color-text-muted)]">
-            Ziele, Trainingspläne und Profilwerte als minsaga-export.json — in der minsaga-App unter
-            Profil → „Aus Training Analyzer importieren" einlesen. Deine Workouts kommen dort aus
-            Apple Health.
+            Kompletter Stand als minsaga-export.json: Ziele, Pläne samt Änderungshistorie, alle
+            Wochenplan-Anpassungen, Schwellentests und Profilwerte — in der minsaga-App unter Profil
+            → „Aus Training Analyzer importieren" einlesen. Deine Workouts kommen dort aus Apple
+            Health.
           </p>
           {error && (
             <Alert variant="error" closeable onClose={() => setError(null)} className="mt-3">

--- a/frontend/src/utils/minsagaExport.test.ts
+++ b/frontend/src/utils/minsagaExport.test.ts
@@ -1,95 +1,31 @@
-// minsagaExport.test — Format-Version 1 muss stabil bleiben (#821):
-// die minsaga-iOS-App parst genau diese Struktur.
+// minsagaExport.test — Download-Wrapper für den Server-Export (#823).
 
-import { describe, expect, it } from 'vitest';
-import { buildMinsagaExport } from './minsagaExport';
-import type { AthleteSettings } from '@/api/athlete';
-import type { RaceGoal } from '@/api/goals';
-import type { TrainingPlan } from '@/api/training-plans';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { downloadMinsagaExport } from './minsagaExport';
+import { apiClient } from '@/api/client';
 
-const athlete = {
-  lthr: 172,
-  resting_hr: 48,
-  max_hr: 191,
-} as AthleteSettings;
-
-const goal = {
-  title: 'Halbmarathon Hamburg',
-  race_date: '2026-11-05',
-  distance_km: 21.0975,
-  target_time_seconds: 7140,
-  is_active: true,
-} as RaceGoal;
-
-const plan = {
-  name: 'HM Sub 2h',
-  status: 'active',
-  start_date: '2026-08-03',
-  end_date: '2026-11-01',
-  goal_summary: { id: 1, title: 'Halbmarathon Hamburg' },
-  phases: [
-    {
-      name: 'Base',
-      phase_type: 'base',
-      start_week: 1,
-      end_week: 6,
-      weekly_template: {
-        days: [
-          {
-            day_of_week: 2,
-            is_rest_day: false,
-            sessions: [{ training_type: 'running', run_type: 'easy', notes: 'locker' }],
-          },
-          { day_of_week: 1, is_rest_day: true, sessions: [] },
-        ],
-      },
-    },
-  ],
-} as unknown as TrainingPlan;
-
-describe('buildMinsagaExport (#821)', () => {
-  it('baut Format-Version 1 mit athlete, goals und plans', () => {
-    const result = buildMinsagaExport(athlete, [goal], [plan]);
-
-    expect(result.version).toBe(1);
-    expect(result.athlete).toEqual({ lthr: 172, resting_hr: 48, max_hr: 191 });
-    expect(result.goals).toEqual([
-      {
-        title: 'Halbmarathon Hamburg',
-        race_date: '2026-11-05',
-        distance_km: 21.0975,
-        target_time_seconds: 7140,
-        is_active: true,
-      },
-    ]);
-    expect(result.plans[0]).toMatchObject({
-      name: 'HM Sub 2h',
-      status: 'active',
-      goal_title: 'Halbmarathon Hamburg',
-    });
-    expect(result.plans[0].phases[0].weekly_template.days).toHaveLength(2);
-    expect(result.plans[0].phases[0].weekly_template.days[0].sessions[0]).toEqual({
-      training_type: 'running',
-      run_type: 'easy',
-      notes: 'locker',
-    });
+describe('downloadMinsagaExport (#823)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
-  it('übersteht Plan ohne Ziel und Phase ohne Template', () => {
-    const kahlerPlan = {
-      name: 'Leer',
-      status: 'draft',
-      start_date: '2026-01-01',
-      end_date: '2026-02-01',
-      goal_summary: null,
-      phases: [
-        { name: 'P1', phase_type: 'base', start_week: 1, end_week: 4, weekly_template: null },
-      ],
-    } as unknown as TrainingPlan;
+  it('holt den v2-Export, lädt ihn herunter und liefert die Zusammenfassung', async () => {
+    const exportData = {
+      version: 2,
+      goals: [{}, {}],
+      plans: [{}],
+      weekly_plans: [{}, {}, {}],
+    };
+    const getSpy = vi.spyOn(apiClient, 'get').mockResolvedValue({ data: exportData });
+    const createUrlSpy = vi.spyOn(window.URL, 'createObjectURL').mockReturnValue('blob:test');
+    vi.spyOn(window.URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
 
-    const result = buildMinsagaExport(athlete, [], [kahlerPlan]);
+    const summary = await downloadMinsagaExport();
 
-    expect(result.plans[0].goal_title).toBeNull();
-    expect(result.plans[0].phases[0].weekly_template.days).toEqual([]);
+    expect(getSpy).toHaveBeenCalledWith('/api/v1/export/minsaga');
+    expect(createUrlSpy).toHaveBeenCalledOnce();
+    expect(clickSpy).toHaveBeenCalledOnce();
+    expect(summary).toEqual({ goals: 2, plans: 1, weeks: 3 });
   });
 });

--- a/frontend/src/utils/minsagaExport.ts
+++ b/frontend/src/utils/minsagaExport.ts
@@ -1,103 +1,29 @@
-// minsagaExport — baut das minsaga-export.json für die App-Migration (#821).
+// minsagaExport — Download des Server-Exports für die App-Migration (#823).
 //
-// Format-Version 1, identisch zum CLI-Script scripts/export_minsaga.py:
-// die minsaga-iOS-App liest die Datei im Profil über „Aus Training
-// Analyzer importieren". Historische Workouts sind bewusst NICHT
-// enthalten — die kommen in minsaga aus Apple Health (Import-Master).
+// Der Export wird komplett im Backend zusammengestellt (Format-Version 2,
+// GET /api/v1/export/minsaga): Profil + Schwellentests, Ziele, Pläne mit
+// Phasen UND Changelog (Entscheidungen samt Begründung) sowie alle
+// gespeicherten Wochenplan-Wochen mit ihren Anpassungen. Workouts sind
+// bewusst nicht enthalten — die kommen in minsaga aus Apple Health.
 
-import type { AthleteSettings } from '@/api/athlete';
-import type { RaceGoal } from '@/api/goals';
-import type { TrainingPlan } from '@/api/training-plans';
+import { apiClient } from '@/api/client';
 
-export interface MinsagaExport {
-  version: 1;
-  athlete: {
-    lthr: number | null;
-    resting_hr: number | null;
-    max_hr: number | null;
-  };
-  goals: Array<{
-    title: string;
-    race_date: string;
-    distance_km: number;
-    target_time_seconds: number | null;
-    is_active: boolean;
-  }>;
-  plans: Array<{
-    name: string;
-    status: string;
-    start_date: string;
-    end_date: string;
-    goal_title: string | null;
-    phases: Array<{
-      name: string;
-      phase_type: string;
-      start_week: number;
-      end_week: number;
-      weekly_template: {
-        days: Array<{
-          day_of_week: number;
-          is_rest_day: boolean;
-          sessions: Array<{
-            training_type: string;
-            run_type: string | null;
-            notes: string | null;
-          }>;
-        }>;
-      };
-    }>;
-  }>;
+export interface MinsagaExportSummary {
+  goals: number;
+  plans: number;
+  weeks: number;
 }
 
-/** Pure Zusammenstellung — testbar ohne API. */
-export function buildMinsagaExport(
-  athlete: AthleteSettings,
-  goals: RaceGoal[],
-  plans: TrainingPlan[],
-): MinsagaExport {
-  return {
-    version: 1,
-    athlete: {
-      lthr: athlete.lthr,
-      resting_hr: athlete.resting_hr,
-      max_hr: athlete.max_hr,
-    },
-    goals: goals.map((goal) => ({
-      title: goal.title,
-      race_date: goal.race_date,
-      distance_km: goal.distance_km,
-      target_time_seconds: goal.target_time_seconds ?? null,
-      is_active: goal.is_active,
-    })),
-    plans: plans.map((plan) => ({
-      name: plan.name,
-      status: plan.status,
-      start_date: plan.start_date,
-      end_date: plan.end_date,
-      goal_title: plan.goal_summary?.title ?? null,
-      phases: plan.phases.map((phase) => ({
-        name: phase.name,
-        phase_type: phase.phase_type,
-        start_week: phase.start_week,
-        end_week: phase.end_week,
-        weekly_template: {
-          days: (phase.weekly_template?.days ?? []).map((day) => ({
-            day_of_week: day.day_of_week,
-            is_rest_day: day.is_rest_day,
-            sessions: day.sessions.map((session) => ({
-              training_type: session.training_type,
-              run_type: session.run_type ?? null,
-              notes: session.notes ?? null,
-            })),
-          })),
-        },
-      })),
-    })),
-  };
-}
+/** Holt den Export vom Backend und löst den Browser-Download aus. */
+export async function downloadMinsagaExport(): Promise<MinsagaExportSummary> {
+  const response = await apiClient.get<{
+    version: number;
+    goals: unknown[];
+    plans: unknown[];
+    weekly_plans: unknown[];
+  }>('/api/v1/export/minsaga');
+  const exportData = response.data;
 
-/** Löst den Browser-Download der fertigen Export-Datei aus. */
-export function downloadMinsagaExportFile(exportData: MinsagaExport): void {
   const blob = new Blob([JSON.stringify(exportData, null, 2)], {
     type: 'application/json',
   });
@@ -107,4 +33,10 @@ export function downloadMinsagaExportFile(exportData: MinsagaExport): void {
   anchor.download = 'minsaga-export.json';
   anchor.click();
   window.URL.revokeObjectURL(url);
+
+  return {
+    goals: exportData.goals.length,
+    plans: exportData.plans.length,
+    weeks: exportData.weekly_plans.length,
+  };
 }

--- a/scripts/export_minsaga.py
+++ b/scripts/export_minsaga.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
-"""Exportiert Ziele, Trainingsplaene und Profilwerte fuer die minsaga-Migration.
+"""Exportiert den kompletten Stand fuer die minsaga-Migration (Format v2).
 
-Erzeugt ein versioniertes `minsaga-export.json`, das die minsaga-iOS-App
-im Profil ueber "Aus Training Analyzer importieren" einliest.
-Historische Workouts werden bewusst NICHT exportiert - die kommen in
+Duenner Wrapper um `GET /api/v1/export/minsaga` — der Server stellt alles
+zusammen: Profil + Schwellentests, Ziele, Plaene mit Changelog
+(Entscheidungen samt Begruendung) und alle Wochenplan-Wochen inklusive
+Anpassungen. Einfacher geht es direkt im Web-UI: Athletenprofil →
+"Export fuer minsaga".
+
+Historische Workouts sind bewusst NICHT enthalten - die kommen in
 minsaga aus Apple Health (Import-Master).
 
 Verwendung:
@@ -47,10 +51,6 @@ def api_login(base_url: str, email: str, password: str) -> str:
     return token
 
 
-def pick(quelle: dict, *schluessel: str) -> dict:
-    return {k: quelle.get(k) for k in schluessel}
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--base-url", required=True)
@@ -66,58 +66,15 @@ def main() -> None:
             sys.exit("Entweder --token oder --email/--password angeben.")
         token = api_login(args.base_url, args.email, args.password)
 
-    athlete_raw = api_get(args.base_url, token, "/api/v1/athlete/settings")
-    athlete = pick(athlete_raw, "lthr", "resting_hr", "max_hr")
+    export = api_get(args.base_url, token, "/api/v1/export/minsaga")
 
-    goals_raw = api_get(args.base_url, token, "/api/v1/goals")
-    goals = [
-        pick(g, "title", "race_date", "distance_km", "target_time_seconds", "is_active")
-        for g in goals_raw.get("goals", goals_raw if isinstance(goals_raw, list) else [])
-    ]
-
-    plans_raw = api_get(args.base_url, token, "/api/v1/training-plans")
-    plan_liste = plans_raw.get("plans", plans_raw if isinstance(plans_raw, list) else [])
-    plans = []
-    for eintrag in plan_liste:
-        detail = api_get(args.base_url, token, f"/api/v1/training-plans/{eintrag['id']}")
-        phases = []
-        for phase in detail.get("phases", []):
-            template = phase.get("weekly_template") or {}
-            days = []
-            for day in template.get("days", []):
-                days.append(
-                    {
-                        "day_of_week": day.get("day_of_week"),
-                        "is_rest_day": day.get("is_rest_day", False),
-                        "sessions": [
-                            pick(s, "training_type", "run_type", "notes")
-                            for s in day.get("sessions", [])
-                        ],
-                    }
-                )
-            phases.append(
-                {
-                    **pick(phase, "name", "phase_type", "start_week", "end_week"),
-                    "weekly_template": {"days": days},
-                }
-            )
-        goal_title = None
-        if detail.get("race_goal"):
-            goal_title = detail["race_goal"].get("title")
-        plans.append(
-            {
-                **pick(detail, "name", "status", "start_date", "end_date"),
-                "goal_title": goal_title,
-                "phases": phases,
-            }
-        )
-
-    export = {"version": 1, "athlete": athlete, "goals": goals, "plans": plans}
     with open(args.output, "w", encoding="utf-8") as datei:
         json.dump(export, datei, ensure_ascii=False, indent=2)
     print(
         f"Export geschrieben: {args.output} — "
-        f"{len(goals)} Ziele, {len(plans)} Plaene."
+        f"{len(export.get('goals', []))} Ziele, "
+        f"{len(export.get('plans', []))} Plaene, "
+        f"{len(export.get('weekly_plans', []))} Wochen."
     )
 
 


### PR DESCRIPTION
Closes #823

Der v1-Export enthielt nur die Phasen-Templates — die tatsächlichen Wochenplan-Anpassungen und die Entscheidungen dahinter fehlten. v2 stellt den Export **serverseitig** zusammen:

**Neuer Endpoint `GET /api/v1/export/minsaga`** (Format-Version 2):
- `athlete`: resting_hr, max_hr + lthr/threshold_pace aus dem letzten Schwellentest
- `threshold_tests`: komplette Historie
- `goals`: wie v1
- `plans`: Phasen/Templates **+ `changelog`** — jede Plan-Änderung mit change_type, category, summary, details, **reason** und created_by (chronologisch)
- `weekly_plans`: **alle gespeicherten Wochen** mit Tagen (is_rest_day, edited, notes, plan_name) und Sessions (position, training_type, volle run_details inkl. Intervalle/Ziel-Paces, notes, status active/skipped)
- interne DB-IDs bleiben draußen; Workouts bewusst nicht enthalten (Apple Health)

**UI:** Export-Card ruft den Endpoint auf (statt client-seitigem Zusammenbau); Toast zeigt jetzt auch die Wochen-Anzahl. **Script:** `scripts/export_minsaga.py` ist ein dünner Wrapper um den Endpoint.

QA: 3 neue API-Tests (Wochenplan+Changelog im Export, Athlet aus Schwellentest, leerer Zustand); Backend gesamt 1332 Tests grün, ruff + mypy grün; Frontend-Suite grün, eslint/prettier/tsc grün.

Gegenstück (minsaga-Importer v2) folgt als eigener PR im minsaga-Repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)