### PR TITLE
feat(export): Trainings-Historie im minsaga-Export — Format-Version 3 (#825)

### DIFF
--- a/backend/app/api/v1/export_minsaga.py
+++ b/backend/app/api/v1/export_minsaga.py
@@ -1,13 +1,17 @@
-"""Vollstaendiger Export fuer die minsaga-Migration (#823, Format-Version 2).
+"""Vollstaendiger Export fuer die minsaga-Migration (#823/#825, Format-Version 3).
 
 Sammelt serverseitig ALLES, was fuer nahtloses Weitertrainieren in der
 minsaga-iOS-App noetig ist: Profilwerte + Schwellentests, Ziele, Plaene
 mit Phasen-Templates UND Changelog (Entscheidungen samt Begruendung),
-sowie saemtliche gespeicherten Wochenplan-Wochen inklusive aller
-Anpassungen (run_details, Status, edited-Flag).
+saemtliche gespeicherten Wochenplan-Wochen inklusive aller Anpassungen
+(run_details, Status, edited-Flag) — und seit v3 die Trainings-Historie.
 
-Historische Workouts sind bewusst NICHT enthalten — die kommen in
-minsaga aus Apple Health (Import-Master).
+Zur Historie (#825): v2 schloss Workouts bewusst aus, weil Apple Health
+als Import-Master galt. Das war ein Irrtum — Apple Health enthaelt nur
+die junge Apple-Watch-Aera, die Garmin-Jahre liegen ausschliesslich hier.
+Ohne sie rechnet minsaga Trainingslast, Langlauf-Basis und Pace-Spezifitaet
+systematisch falsch. Der `sessions`-Block liefert deshalb Kerndaten plus
+Laps je Workout; GPS-Tracks und Zeitreihen bleiben aussen vor.
 """
 
 import json
@@ -28,6 +32,7 @@ from app.infrastructure.database.models import (
     TrainingPlanModel,
     UserModel,
     WeeklyPlanDayModel,
+    WorkoutModel,
 )
 from app.infrastructure.database.session import get_db
 
@@ -225,12 +230,58 @@ async def _weekly_plans_block(
     return list(weeks.values())
 
 
+def _lap_eintrag(lap: object) -> dict[str, object] | None:
+    if not isinstance(lap, dict):
+        return None
+    return {
+        "lap_number": lap.get("lap_number"),
+        "duration_seconds": lap.get("duration_seconds"),
+        "distance_km": lap.get("distance_km"),
+        "avg_pace_min_per_km": lap.get("avg_pace_min_per_km"),
+        "avg_hr_bpm": lap.get("avg_hr_bpm"),
+        # Nutzer-Korrektur schlaegt die Klassifikation.
+        "type": lap.get("user_override") or lap.get("suggested_type"),
+    }
+
+
+async def _sessions_block(db: AsyncSession, user_id: int) -> list[dict[str, object]]:
+    """Trainings-Historie (#825): Kerndaten + Laps, keine Zeitreihen."""
+    result = await db.execute(
+        select(WorkoutModel).where(WorkoutModel.user_id == user_id).order_by(WorkoutModel.date)
+    )
+    sessions: list[dict[str, object]] = []
+    for workout in result.scalars().all():
+        laps_raw = _parse_json(workout.laps_json)
+        laps = (
+            [eintrag for lap in laps_raw if (eintrag := _lap_eintrag(lap)) is not None]
+            if isinstance(laps_raw, list)
+            else []
+        )
+        sessions.append(
+            {
+                "id": workout.id,
+                "date": _iso(workout.date),
+                "workout_type": workout.workout_type,
+                "subtype": workout.subtype,
+                "duration_sec": workout.duration_sec,
+                "distance_km": workout.distance_km,
+                "hr_avg": workout.hr_avg,
+                "hr_max": workout.hr_max,
+                "cadence_avg": workout.cadence_avg,
+                "rpe": workout.rpe,
+                "notes": workout.notes,
+                "laps": laps,
+            }
+        )
+    return sessions
+
+
 @router.get("/minsaga")
 async def export_minsaga(
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_active_user),
 ) -> dict[str, object]:
-    """Kompletter minsaga-Export (Format-Version 2)."""
+    """Kompletter minsaga-Export (Format-Version 3)."""
     user_id = int(current_user.id)
 
     plans = await _plans_block(db, user_id)
@@ -242,11 +293,12 @@ async def export_minsaga(
         plan.pop("id", None)
 
     return {
-        "version": 2,
+        "version": 3,
         "exported_at": datetime.utcnow().isoformat(),
         "athlete": await _athlete_block(db, user_id),
         "threshold_tests": await _threshold_tests_block(db, user_id),
         "goals": await _goals_block(db, user_id),
         "plans": plans,
         "weekly_plans": await _weekly_plans_block(db, user_id, plan_names),
+        "sessions": await _sessions_block(db, user_id),
     }

--- a/backend/app/tests/test_export_minsaga.py
+++ b/backend/app/tests/test_export_minsaga.py
@@ -1,7 +1,12 @@
-"""Tests fuer den vollstaendigen minsaga-Export (#823, Format-Version 2)."""
+"""Tests fuer den vollstaendigen minsaga-Export (#823/#825, Format-Version 3)."""
+
+import json
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.infrastructure.database.models import WorkoutModel
 
 PLAN_DATA = {
     "name": "HM Sub 2h",
@@ -60,7 +65,7 @@ async def test_export_enthaelt_wochenplan_und_changelog(client: AsyncClient) -> 
     assert export_resp.status_code == 200
     export = export_resp.json()
 
-    assert export["version"] == 2
+    assert export["version"] == 3
     assert "exported_at" in export
 
     # Plan mit Changelog (plan_created ist immer da), interne IDs draussen
@@ -105,7 +110,73 @@ async def test_export_athlete_aus_schwellentest(client: AsyncClient) -> None:
 async def test_export_leerer_zustand(client: AsyncClient) -> None:
     export = (await client.get("/api/v1/export/minsaga")).json()
 
-    assert export["version"] == 2
+    assert export["version"] == 3
     assert export["goals"] == []
     assert export["plans"] == []
     assert export["weekly_plans"] == []
+    assert export["sessions"] == []
+
+
+@pytest.mark.anyio
+async def test_export_enthaelt_trainings_historie(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """#825: Die Garmin-Historie liegt nur hier — sie MUSS in den Export."""
+    from datetime import datetime
+
+    db_session.add(
+        WorkoutModel(
+            user_id=1,
+            date=datetime(2024, 3, 15, 7, 30),
+            workout_type="running",
+            subtype="intervals",
+            duration_sec=3_600,
+            distance_km=10.5,
+            hr_avg=155,
+            hr_max=178,
+            cadence_avg=172,
+            rpe=7,
+            laps_json=json.dumps(
+                [
+                    {
+                        "lap_number": 1,
+                        "duration_seconds": 600,
+                        "distance_km": 1.6,
+                        "avg_pace_min_per_km": 6.25,
+                        "avg_hr_bpm": 132,
+                        "suggested_type": "warmup",
+                        "user_override": None,
+                    },
+                    {
+                        "lap_number": 2,
+                        "duration_seconds": 300,
+                        "distance_km": 1.0,
+                        "avg_pace_min_per_km": 5.0,
+                        "avg_hr_bpm": 168,
+                        "suggested_type": "steady",
+                        "user_override": "work",
+                    },
+                ]
+            ),
+        )
+    )
+    await db_session.commit()
+
+    export = (await client.get("/api/v1/export/minsaga")).json()
+
+    assert len(export["sessions"]) == 1
+    session = export["sessions"][0]
+    assert session["workout_type"] == "running"
+    assert session["subtype"] == "intervals"
+    assert session["duration_sec"] == 3_600
+    assert session["distance_km"] == 10.5
+    assert session["hr_avg"] == 155
+    assert session["cadence_avg"] == 172
+    assert session["rpe"] == 7
+    assert len(session["laps"]) == 2
+    # Nutzer-Korrektur schlaegt die Klassifikation.
+    assert session["laps"][1]["type"] == "work"
+    assert session["laps"][0]["type"] == "warmup"
+    # Zeitreihen und GPS bleiben bewusst draussen.
+    assert "gps_track_json" not in session
+    assert "csv_data" not in session


### PR DESCRIPTION
Closes #825.

## Warum
Der v2-Export schloss historische Workouts bewusst aus („kommen aus Apple Health") — Irrtum: Apple Health enthält nur die junge Apple-Watch-Ära, die Garmin-Jahre liegen ausschließlich im Analyzer. Ohne sie rechnet minsaga Trainingslast (CTL 7 statt real), Langlauf-Basis („kein Langlauf") und Pace-Spezifität („0 km in Zielpace") systematisch falsch.

## Was
- `sessions`-Block im `GET /api/v1/export/minsaga`: Kerndaten je Workout (id, date, workout_type, subtype, duration_sec, distance_km, hr_avg/hr_max, cadence_avg, rpe, notes) + Laps (lap_number, duration_seconds, distance_km, avg_pace_min_per_km, avg_hr_bpm, type mit Nutzer-Override-Vorrang)
- GPS-Tracks, Zeitreihen und Original-Dateien bleiben bewusst draußen
- Format-Version 2 → 3; Frontend ist versionsagnostisch (keine Änderung nötig)

## Tests
- Neuer Test `test_export_enthaelt_trainings_historie` (Kerndaten, Lap-Override, Ausschluss von GPS/CSV)
- Bestehende Export-Tests auf Version 3 angepasst — 4/4 grün, ruff sauber

Gegenstück in minsaga: NCS23/minsaga#155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)