### PR TITLE
docs(readiness): Long-Run-Schwelle auch über die Dauer

### DIFF
--- a/docs/archive/GOAL_READINESS_CONCEPT.md
+++ b/docs/archive/GOAL_READINESS_CONCEPT.md
@@ -77,7 +77,10 @@ Diese Dimensionen sind in der Trainingsliteratur etabliert (Daniels, Pfitzinger,
 ### 3.2 Langlauf (bzw. Aerobic Base für 5K/10K)
 
 **Für Halbmarathon und Marathon:**
-- **Schwellwert:** ≥ 18 km (HM) bzw. ≥ 28 km (M)
+- **Schwellwert:** ≥ 18 km (HM) bzw. ≥ 28 km (M) — **oder** ≥ 105 min (HM) bzw. ≥ 150 min (M)
+  Dauer-Regel (Ergänzung Aug 2026): Die reine km-Schwelle bestraft langsamere
+  Läufer — ein 16-km-Lauf über 1:45 h ist ein voller Long Run (Pfitzinger
+  definiert Long Runs über die Dauer).
 - **Metriken:** Anzahl Long Runs in letzten 12 Wochen + längste Distanz
 - **Targets:**
   - HM: 6–10 Long Runs; längster ≥ 22 km


### PR DESCRIPTION
Doku-Nachzug zu NCS23/minsaga#185: Long Run zählt ab km-Schwelle ODER Dauer (HM ≥ 105 min, M ≥ 150 min) — die reine km-Schwelle bestrafte langsamere Läufer (16 km über 1:45 h zählte nicht). Konzept und App sind damit wieder deckungsgleich.

🤖 Generated with [Claude Code](https://claude.com/claude-code)