### PR TITLE
docs(#828): PRD §5.9 Watch-Standalone — die Uhr ist nicht aufs iPhone angewiesen

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -203,6 +203,9 @@ Wochenstruktur: **4 Läufe + 2 Krafttrainings + 1 Ruhetag**
 
 → Mit nativer iOS-App + Apple-Watch-Companion realisierbar (siehe §6.8 Strategie-Pivot).
 
+> „Companion" heißt hier **nicht** „auf das iPhone angewiesen". Was die Uhr
+> ohne Handy in Reichweite können muss, steht in §5.9 Watch-Standalone.
+
 #### Wochen-Review (Pflicht, automatisch)
 
 Am Ende jeder Woche:
@@ -1151,7 +1154,53 @@ Nutzer kann:
 - **Akzeptieren** → neues Ziel + neuer Plan
 - **Ablehnen** → ursprüngliches Ziel bleibt, App akzeptiert die Entscheidung
 
+### 5.9 Watch-Standalone
 
+> Ergänzt 2026-08-03 (#828). Vorher beschrieb dieses Dokument die Uhr
+> durchgehend als „Companion" — ohne Aussage, was sie **ohne iPhone**
+> können muss. Die Lücke hat dazu geführt, dass die Watch-App gegen den
+> Companion-Gedanken gebaut wurde und ein dort aufgezeichneter Lauf auf
+> der Uhr selbst erst auftauchte, nachdem das iPhone ihn importiert und
+> zurückgespiegelt hatte.
+
+**Grundsatz:** Das Handy liegt zu Hause, und das ist ein normaler Fall —
+kein Ausnahmezustand. Ein Athlet muss sein Training auf der Uhr starten,
+durchführen, beenden und einordnen können, ohne dass ein iPhone in
+Reichweite ist.
+
+#### Muss ohne iPhone funktionieren
+
+| Fähigkeit | Warum |
+|---|---|
+| Training aufzeichnen — **vollständig**, inklusive Strecke, Kadenz und allen Metriken, die das Gerät liefert | Was unterwegs nicht geschrieben wird, ist für jede spätere Auswertung dauerhaft verloren |
+| Den Trainingsplan der Woche sehen und eine Einheit daraus starten | Sonst ist der Plan genau dann unsichtbar, wenn er gebraucht wird |
+| Einer geplanten Strecke folgen — Karte, Abbiegehinweise, Haptik | Navigation mit dem Handy in der Tasche ist kein Ersatz |
+| Das beendete Training **sofort** sehen und die Belastung angeben | Direkt nach dem Lauf ist der einzige Moment, in dem die Antwort ehrlich ist |
+| Die eigenen letzten Einheiten einsehen | Ohne Gedächtnis ist die Uhr ein Schreibgerät, kein Begleiter |
+
+#### Auswertung auf der Uhr — bewusst ausgewählt
+
+Nicht alles, was das iPhone rechnet, gehört auf ein 1,9-Zoll-Display mit
+kleinerem Energie-Budget. Die Leitfrage ist nicht „geht das technisch?",
+sondern „hilft das **hier**, in diesem Moment?".
+
+**Auf die Uhr gehört,** was unmittelbar nach dem Lauf oder währenddessen
+zählt: Eckdaten der Einheit, Soll-Ist-Vergleich zur geplanten Vorgabe,
+Kilometer-Splits, Herzfrequenz-Zonen der Einheit, Wochenbilanz gegen das
+Wochen-Soll.
+
+**Auf der Uhr hat nichts verloren:** Langzeit-Trends über Monate,
+Form-Verlauf (CTL/ATL/TSB), Goal-Readiness mit ihren vier Säulen,
+Wettkampf-Analysen, alles Chat-basierte. Diese Dinge brauchen Überblick,
+Vergleich und Ruhe — sie gehören auf ein großes Display.
+
+#### Architektur-Konsequenz
+
+Die Uhr darf für ihre eigenen Aufzeichnungen **nicht** auf den
+iPhone-Import warten. Der Import-Master bleibt das iPhone (er löst das
+Dubletten-Problem gerätespezifischer HealthKit-UUIDs), aber die Uhr muss
+ihre eigene Einheit sofort lokal führen und der Abgleich muss sie später
+zusammenführen statt doppelt anzulegen.
 
 ---
 


### PR DESCRIPTION
Closes #828

Das PRD beschrieb die Apple Watch durchgehend als „Companion", ohne Aussage darüber, was sie **ohne iPhone** können muss. Die Lücke hat sich direkt in der Implementierung niedergeschlagen: ein auf der Uhr aufgezeichneter Lauf erschien dort erst, nachdem das iPhone ihn importiert und über CloudKit zurückgespiegelt hatte.

Von Nils: „Das ist unsauber und lückenhaft formuliert. Man muss wichtige Funktionen auch mit der Uhr nutzen können, wenn das Handy zuhause liegt."

## Neu: §5.9 Watch-Standalone

- **Grundsatz:** Handy zu Hause ist ein normaler Fall, kein Ausnahmezustand
- **Was ohne iPhone funktionieren MUSS** — vollständige Aufzeichnung inklusive Strecke, Wochenplan, Navigation, sofortiges Ergebnis mit Belastungsabfrage, eigene Historie. Je mit Begründung, warum das nicht verschiebbar ist.
- **Welche Auswertung auf die Uhr gehört und welche bewusst nicht.** Leitfrage ist nicht „geht das technisch?", sondern „hilft das hier, in diesem Moment?". Langzeit-Trends, Form-Verlauf, Goal-Readiness und Chat bleiben auf dem großen Display.
- **Architektur-Konsequenz:** die Uhr darf für eigene Aufzeichnungen nicht auf den iPhone-Import warten. Der Import-Master bleibt das iPhone (er löst das Dubletten-Problem gerätespezifischer HealthKit-UUIDs), aber der Abgleich muss zusammenführen statt doppelt anzulegen.

Journey 5 bekommt einen Querverweis, damit „Companion" dort nicht weiterhin als „aufs iPhone angewiesen" gelesen wird.

Ist-Analyse und die sechs Journeys stehen in https://github.com/NCS23/minsaga/issues/295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)